### PR TITLE
Verify report draft checks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,8 @@ The workflow can draft `runs/<week>-report.md` from explicit inputs and reposito
 
 It does not publish externally and does not compute automated trust ratings.
 
+Verification note: this line exists only to trigger report-draft checks.
+
 ## Rule documents
 
 Operational rules live in [`../rules/`](../rules/).


### PR DESCRIPTION
Verification-only PR for the report draft path.

Expected:
- Static Site Check passes
- Report Draft Test should run if path filters match
- No implementation agent is run
- No report is published externally

This PR is not meant to be merged.