### PR TITLE
Verify Lean selection proof

### DIFF
--- a/formal/Selection.lean
+++ b/formal/Selection.lean
@@ -2,6 +2,8 @@ import Std
 
 namespace PromptVoteLab
 
+-- Formal model for the closed selection core used by scripts/select_eligible.py.
+
 inductive CandidateType where
   | baseline
   | prompt


### PR DESCRIPTION
Verification-only PR for the Lean model of the closed eligible-selection core.

Expected:
- Lean Proof Test passes
- baseline rank 1 implies selectEligible returns []
- baseline and other candidates are not individually eligible
- No implementation agent is run
- No model API is called

This PR is not meant to be merged.