### PR TITLE
Verify Lean selection proof after toolchain fix

### DIFF
--- a/formal/Selection.lean
+++ b/formal/Selection.lean
@@ -2,7 +2,7 @@ import Std
 
 namespace PromptVoteLab
 
--- Verification trigger: Lean toolchain configured.
+-- Verification trigger: Lean workflow no longer requires Lake.
 
 inductive CandidateType where
   | baseline

--- a/formal/Selection.lean
+++ b/formal/Selection.lean
@@ -2,6 +2,8 @@ import Std
 
 namespace PromptVoteLab
 
+-- Verification trigger: Lean toolchain configured.
+
 inductive CandidateType where
   | baseline
   | prompt


### PR DESCRIPTION
Verification-only PR for the Lean model of the closed eligible-selection core after adding lean-toolchain.

Expected:
- Lean Proof Test passes
- baseline rank 1 implies selectEligible returns []
- baseline and other candidates are not individually eligible
- No implementation agent is run
- No model API is called

This PR is not meant to be merged.