### PR TITLE
Verify Lean selection proof after proof fix

### DIFF
--- a/formal/Selection.lean
+++ b/formal/Selection.lean
@@ -2,6 +2,8 @@ import Std
 
 namespace PromptVoteLab
 
+-- Verification trigger: proof simplification fixed.
+
 inductive CandidateType where
   | baseline
   | prompt


### PR DESCRIPTION
Verification-only PR for the Lean selection proof after simplifying the proof.

Expected:
- Lean Proof Test passes
- baseline rank 1 implies selectEligible returns []
- baseline and other candidates are not individually eligible
- No implementation agent is run
- No model API is called

This PR is not meant to be merged.