### PR TITLE
Automate prompt candidate data updates

### DIFF
--- a/.github/workflows/update-candidates.yml
+++ b/.github/workflows/update-candidates.yml
@@ -38,17 +38,17 @@ jobs:
           NO_CHANGE_BASELINE: 5
           REQUIRED_MARGIN: 2
           MINIMUM_TOTAL_VOTES: 5
-          CANDIDATE_OUTPUT: lab/candidates.js
+          CANDIDATE_OUTPUT: data/prompt-candidates.js
         run: node scripts/update-candidates.mjs
 
       - name: Commit generated candidate data
         run: |
-          if git diff --quiet -- lab/candidates.js; then
+          if git diff --quiet -- data/prompt-candidates.js; then
             echo "No candidate data changes."
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add lab/candidates.js
+          git add data/prompt-candidates.js
           git commit -m "Update prompt candidate data"
           git push

--- a/.github/workflows/update-candidates.yml
+++ b/.github/workflows/update-candidates.yml
@@ -1,0 +1,54 @@
+name: Update Prompt Candidates
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 * * * *"
+  issues:
+    types: [opened, edited, labeled, unlabeled, reopened, closed]
+
+permissions:
+  contents: write
+  issues: read
+
+concurrency:
+  group: update-prompt-candidates-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  update-candidates:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'issues' || contains(github.event.issue.labels.*.name, 'prompt-proposal')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Generate candidate data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROMPT_LABEL: prompt-proposal
+          NO_CHANGE_BASELINE: 5
+          REQUIRED_MARGIN: 2
+          MINIMUM_TOTAL_VOTES: 5
+          CANDIDATE_OUTPUT: lab/candidates.js
+        run: node scripts/update-candidates.mjs
+
+      - name: Commit generated candidate data
+        run: |
+          if git diff --quiet -- lab/candidates.js; then
+            echo "No candidate data changes."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add lab/candidates.js
+          git commit -m "Update prompt candidate data"
+          git push

--- a/scripts/update-candidates.mjs
+++ b/scripts/update-candidates.mjs
@@ -9,7 +9,7 @@ const label = process.env.PROMPT_LABEL || 'prompt-proposal';
 const noChangeBaseline = Number(process.env.NO_CHANGE_BASELINE || 5);
 const requiredMargin = Number(process.env.REQUIRED_MARGIN || 2);
 const minimumTotalVotes = Number(process.env.MINIMUM_TOTAL_VOTES || 5);
-const outputPath = process.env.CANDIDATE_OUTPUT || 'lab/candidates.js';
+const outputPath = process.env.CANDIDATE_OUTPUT || 'data/prompt-candidates.js';
 
 if (!token) {
   throw new Error('GITHUB_TOKEN is required.');
@@ -123,7 +123,10 @@ const payload = {
   candidates
 };
 
-await mkdir(outputPath.split('/').slice(0, -1).join('/'), { recursive: true });
+const outputDirectory = outputPath.split('/').slice(0, -1).join('/');
+if (outputDirectory) {
+  await mkdir(outputDirectory, { recursive: true });
+}
 await writeFile(
   outputPath,
   `window.PROMPT_VOTE_LAB_CANDIDATES = ${JSON.stringify(payload, null, 2)};\n`,

--- a/scripts/update-candidates.mjs
+++ b/scripts/update-candidates.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+import { writeFile, mkdir } from 'node:fs/promises';
+
+const owner = process.env.GITHUB_REPOSITORY_OWNER || 'Unjuno';
+const repo = process.env.GITHUB_REPOSITORY?.split('/')[1] || 'prompt-vote-lab';
+const token = process.env.GITHUB_TOKEN;
+const label = process.env.PROMPT_LABEL || 'prompt-proposal';
+
+const noChangeBaseline = Number(process.env.NO_CHANGE_BASELINE || 5);
+const requiredMargin = Number(process.env.REQUIRED_MARGIN || 2);
+const minimumTotalVotes = Number(process.env.MINIMUM_TOTAL_VOTES || 5);
+const outputPath = process.env.CANDIDATE_OUTPUT || 'lab/candidates.js';
+
+if (!token) {
+  throw new Error('GITHUB_TOKEN is required.');
+}
+
+const apiBase = 'https://api.github.com';
+const headers = {
+  Accept: 'application/vnd.github+json',
+  Authorization: `Bearer ${token}`,
+  'X-GitHub-Api-Version': '2022-11-28',
+  'User-Agent': 'prompt-vote-lab-candidate-updater'
+};
+
+async function github(path) {
+  const response = await fetch(`${apiBase}${path}`, { headers });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub API ${response.status} for ${path}: ${body}`);
+  }
+  return response.json();
+}
+
+async function paginate(path) {
+  const results = [];
+  let page = 1;
+  while (page <= 10) {
+    const separator = path.includes('?') ? '&' : '?';
+    const data = await github(`${path}${separator}per_page=100&page=${page}`);
+    if (!Array.isArray(data) || data.length === 0) break;
+    results.push(...data);
+    if (data.length < 100) break;
+    page += 1;
+  }
+  return results;
+}
+
+function section(body, heading) {
+  if (!body) return '';
+  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`(?:^|\\n)##\\s+${escaped}\\s*\\n([\\s\\S]*?)(?=\\n##\\s+|$)`, 'i');
+  const match = body.match(pattern);
+  return match ? match[1].trim() : '';
+}
+
+function firstParagraph(markdown) {
+  return markdown
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('- ') && !line.startsWith('* '))[0] || '';
+}
+
+function plainText(value) {
+  return value
+    .replace(/[`*_>#]/g, '')
+    .replace(/\[(.*?)\]\(.*?\)/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+async function plusOneVotes(issueNumber) {
+  const reactions = await paginate(`/repos/${owner}/${repo}/issues/${issueNumber}/reactions?content=%2B1`);
+  return reactions.filter((reaction) => reaction.content === '+1').length;
+}
+
+const issues = await paginate(`/repos/${owner}/${repo}/issues?state=open&labels=${encodeURIComponent(label)}`);
+const promptIssues = issues.filter((issue) => !issue.pull_request);
+
+const candidates = [];
+for (const issue of promptIssues) {
+  const votes = await plusOneVotes(issue.number);
+  const expectedResult = plainText(firstParagraph(section(issue.body || '', 'Expected result')));
+  const votedPrompt = plainText(firstParagraph(section(issue.body || '', 'Voted prompt')));
+  candidates.push({
+    number: issue.number,
+    title: issue.title.replace(/^\[Prompt\]:\s*/i, '').trim(),
+    url: issue.html_url,
+    votes,
+    comments: issue.comments,
+    createdAt: issue.created_at,
+    updatedAt: issue.updated_at,
+    expectedResult,
+    summary: votedPrompt
+  });
+}
+
+candidates.sort((a, b) => {
+  if (b.votes !== a.votes) return b.votes - a.votes;
+  const updatedDelta = Date.parse(b.updatedAt) - Date.parse(a.updatedAt);
+  if (updatedDelta !== 0) return updatedDelta;
+  return a.number - b.number;
+});
+
+const totalVotes = candidates.reduce((sum, candidate) => sum + candidate.votes, 0);
+const topPromptVotes = candidates[0]?.votes || 0;
+const selected = topPromptVotes >= noChangeBaseline + requiredMargin && totalVotes >= minimumTotalVotes;
+
+const payload = {
+  generatedAt: new Date().toISOString(),
+  source: 'github-actions',
+  repository: `${owner}/${repo}`,
+  voteContent: '+1',
+  selection: {
+    noChangeBaseline,
+    requiredMargin,
+    minimumTotalVotes,
+    totalVotes,
+    topPromptVotes,
+    selected,
+    selectedIssueNumber: selected ? candidates[0]?.number ?? null : null
+  },
+  candidates
+};
+
+await mkdir(outputPath.split('/').slice(0, -1).join('/'), { recursive: true });
+await writeFile(
+  outputPath,
+  `window.PROMPT_VOTE_LAB_CANDIDATES = ${JSON.stringify(payload, null, 2)};\n`,
+  'utf8'
+);
+
+console.log(`Wrote ${outputPath}`);
+console.log(`Candidates: ${candidates.length}, total votes: ${totalVotes}, top votes: ${topPromptVotes}, selected: ${selected}`);


### PR DESCRIPTION
## Summary

Closed as superseded.

This PR was originally created to generate current candidate data, but the experiment design has shifted to weekly immutable snapshots as the official vote record.

Use PR #43 instead for the weekly snapshot workflow.

## Superseded by

- #43: Add weekly vote snapshot workflow

## Reason

The old current-candidate updater direction was too ambiguous:

- it was not the official weekly decision record
- it risked confusing live display data with evidence data
- the repository now needs immutable weekly snapshots, aggregation logs, and run-log drafts instead

This PR should stay closed unless the project later decides to add a separate LP-only live ranking feature.