### PR TITLE
Document experiment logging and verification boundaries

### DIFF
--- a/docs/api-control.md
+++ b/docs/api-control.md
@@ -1,0 +1,159 @@
+# API Control Policy
+
+## Purpose
+
+This document defines when Prompt Vote Lab may use a paid implementation-model call and what must be recorded.
+
+The goal is to prevent uncontrolled spending, hidden retries, model drift, and irreproducible experiment runs.
+
+## API gate
+
+Do not run a real implementation-model call unless all gates are satisfied:
+
+1. weekly snapshot exists
+2. selected prompt is recorded in `runs/week-XXX.md`
+3. implementation model policy is recorded
+4. editable file scope is recorded
+5. dry-run path has succeeded
+6. API usage log path exists
+7. safety-check workflow exists
+8. maintainer explicitly approves the run
+
+If any gate fails, stop before calling the model.
+
+## Required model configuration
+
+Each run must record:
+
+- provider
+- model
+- model policy version
+- temperature
+- top_p
+- max output tokens
+- retry count
+- timeout policy
+- editable file scope
+- prompt package hash
+- snapshot reference
+
+## Retry policy
+
+Default retry count:
+
+```text
+0
+```
+
+Reason: hidden retries make prompt comparison unfair.
+
+If a retry is allowed in a later policy, it must be recorded as a separate attempt with:
+
+- attempt number
+- same model settings unless a policy explicitly allows otherwise
+- error reason
+- output hash, if output exists
+
+## Usage log
+
+Canonical path:
+
+```text
+logs/api/week-XXX.jsonl
+```
+
+Each line should be one JSON object.
+
+Example:
+
+```json
+{
+  "event": "implementation_model_call",
+  "week": "001",
+  "attempt": 1,
+  "provider": "openai",
+  "model": "gpt-5-nano",
+  "model_policy": "model-policy-v1.0",
+  "temperature": 0.2,
+  "top_p": 1.0,
+  "max_output_tokens": 12000,
+  "retry_count": 0,
+  "snapshot": "data/snapshots/week-001.json",
+  "prompt_package_hash": "sha256:unrecorded",
+  "status": "success",
+  "input_tokens": null,
+  "output_tokens": null,
+  "estimated_cost_usd": null,
+  "started_at": "2026-05-11T00:05:00+09:00",
+  "finished_at": "2026-05-11T00:05:30+09:00"
+}
+```
+
+## Error log
+
+Canonical path:
+
+```text
+logs/errors/week-XXX.jsonl
+```
+
+Record:
+
+- error type
+- status code, if any
+- retryable boolean
+- selected issue
+- workflow run id
+- commit SHA
+- timestamp
+
+Do not record credentials or private runtime configuration.
+
+## Cost guardrails
+
+Before enabling real calls, define:
+
+- max implementation calls per week
+- max attempts per selected prompt
+- max estimated weekly budget
+- allowed model list
+- who may trigger the workflow
+
+Initial recommendation:
+
+```text
+max_implementation_calls_per_week = 1
+max_retry_count = 0
+manual_approval_required = true
+```
+
+## Prompt package
+
+The implementation prompt should be stored as a generated artifact or committed package before the model call.
+
+Recommended path:
+
+```text
+run-packages/week-XXX/rank-1/prompt.md
+run-packages/week-XXX/rank-1/metadata.json
+```
+
+The usage log should reference the prompt package hash instead of relying only on temporary workflow output.
+
+## Separation from evaluation model
+
+Implementation model calls may modify `lab/` through PR generation.
+
+Evaluation model calls may draft analysis, blog posts, or HN posts, but must not modify `lab/` and must not decide merge automatically.
+
+## Human approval
+
+Until the experiment has at least three successful dry-runs, real implementation-model calls should require explicit maintainer approval.
+
+Approved forms:
+
+- manual workflow dispatch
+- approving a PR that triggers the run
+- explicit repository issue comment command, if a permission-checked command parser is later added
+
+Do not trigger paid model calls from public comments without a permission check.

--- a/docs/contributor-credit-spec.md
+++ b/docs/contributor-credit-spec.md
@@ -1,0 +1,123 @@
+# Contributor Credit Specification
+
+## Purpose
+
+Prompt Vote Lab may show a public contributor summary for accepted prompt authors.
+
+This is not user tracking. It is a public credit record derived only from public GitHub contribution data and weekly experiment logs.
+
+## Allowed data
+
+The contributor summary may use:
+
+- GitHub login
+- public issue number
+- public issue title
+- public issue URL
+- selected week id
+- accepted/merged status
+- count of accepted prompts
+
+## Disallowed data
+
+Do not collect or display:
+
+- IP address
+- device information
+- location
+- private email
+- browser fingerprint
+- session identifiers
+- vote-by-vote personal behavior timelines
+- private analytics data
+
+## Credit rule
+
+A contributor receives accepted-prompt credit only if all conditions are true:
+
+1. a valid weekly snapshot exists
+2. `decision = "selected"`
+3. the contributor authored the selected issue
+4. the weekly run log records an accepted result
+
+Initial accepted result statuses:
+
+- `merged`
+
+Future policies may add more accepted statuses, but they must be documented before use.
+
+## No credit cases
+
+A contributor does not receive accepted-prompt credit if:
+
+- no prompt passed the selection rule
+- the selected implementation PR was rejected
+- the run was invalidated
+- the issue was selected only in a corrected snapshot that was not used for implementation
+- the author information is unavailable
+
+## Canonical files
+
+Machine-readable summary:
+
+```text
+data/contributors.json
+```
+
+Human-readable summary:
+
+```text
+docs/contributors.md
+```
+
+These files are generated or maintained outside `lab/`.
+
+## Contributors JSON schema
+
+```json
+{
+  "schema_version": "contributors-v1.0",
+  "generated_at": "2026-05-11T00:10:00+09:00",
+  "contributors": [
+    {
+      "login": "Unjuno",
+      "accepted_prompts": 2,
+      "selected_issues": [3, 8],
+      "weeks": ["001", "004"],
+      "last_accepted_at": "2026-06-01T00:00:00+09:00"
+    }
+  ]
+}
+```
+
+## Display guidance
+
+Use neutral wording:
+
+- `Accepted prompt contributors`
+- `Accepted prompts`
+- `Selected issues`
+
+Avoid wording that suggests behavioral surveillance:
+
+- `tracked users`
+- `user behavior ranking`
+- `voter profile`
+
+## Anti-gaming note
+
+Contributor credit can encourage spam if over-emphasized.
+
+Initial display should be small and factual:
+
+```text
+Accepted prompt contributors
+1. Unjuno — 2 accepted prompts
+2. example-user — 1 accepted prompt
+```
+
+Do not add prizes, badges, or aggressive ranking mechanics until spam controls exist.
+
+## Privacy note
+
+All displayed contributor information must be derived from public GitHub artifacts already visible in the repository context.

--- a/docs/formal-verification-plan.md
+++ b/docs/formal-verification-plan.md
@@ -1,0 +1,138 @@
+# Formal Verification Plan
+
+## Purpose
+
+Prompt Vote Lab can use Lean to verify small decision procedures used by the experiment.
+
+Formal verification is not a substitute for system logs, API logs, or maintainer review. It only verifies defined logic under explicit assumptions.
+
+## What Lean can verify
+
+Lean can verify:
+
+- the selection predicate matches the written rule
+- `selected` implies both threshold conditions
+- `no_run` follows when either threshold condition fails
+- top-three extraction preserves sorted order under a defined comparator
+- tie-breaking is deterministic
+- snapshot decision fields are consistent with candidate votes
+
+## What Lean cannot verify
+
+Lean cannot verify:
+
+- GitHub returned complete reaction data
+- public reactions reflect sincere preferences
+- the AI-generated UI is useful
+- HN readers will respond well
+- a model provider will keep behavior unchanged
+- a workflow runner will never fail
+
+These require operational logs and review, not proof alone.
+
+## Core variables
+
+| Symbol | Meaning | Unit | Definition | Domain | Type |
+|---|---|---:|---|---|---|
+| `v_i` | votes for prompt `i` | votes | public `+1` reaction count | natural number | scalar |
+| `B` | no-change baseline | votes | initial value `5` | natural number | scalar |
+| `M` | required margin | votes | initial value `2` | natural number | scalar |
+| `T` | minimum total votes | votes | initial value `5` | natural number | scalar |
+| `V` | total votes | votes | sum of candidate votes | natural number | scalar |
+| `v_max` | top prompt votes | votes | maximum candidate vote count | natural number | scalar |
+| `S` | selected decision | none | Boolean predicate | true/false | proposition |
+
+## Selection rule
+
+```text
+S iff (v_max >= B + M) and (V >= T)
+```
+
+Unit check:
+
+```text
+v_max: votes
+B + M: votes + votes = votes
+v_max >= B + M compares votes with votes
+
+V: votes
+T: votes
+V >= T compares votes with votes
+```
+
+## Minimal Lean target
+
+```lean
+namespace PromptVoteLab
+
+def selected
+  (topVotes baseline margin totalVotes minTotal : Nat) : Bool :=
+  topVotes >= baseline + margin && totalVotes >= minTotal
+
+theorem selected_true_iff
+  (topVotes baseline margin totalVotes minTotal : Nat) :
+  selected topVotes baseline margin totalVotes minTotal = true ↔
+    topVotes >= baseline + margin ∧ totalVotes >= minTotal := by
+  unfold selected
+  simp
+
+end PromptVoteLab
+```
+
+## Top-three verification target
+
+Define a candidate as:
+
+```lean
+structure Candidate where
+  issue : Nat
+  votes : Nat
+```
+
+Comparator policy:
+
+1. higher votes rank first
+2. lower issue number wins ties
+
+Target properties:
+
+- sorted output is ordered by comparator
+- top-three length is at most three
+- if input is non-empty, first output element is maximal under comparator
+- equal input data produces equal output data
+
+## Snapshot consistency target
+
+Given a generated snapshot:
+
+- `top_prompt_votes` must equal the first top prompt vote count
+- `selected_issue` must equal the first top prompt issue when `decision = selected`
+- `selected_issue` must be absent/null when `decision = no_run`
+- `decision = selected` iff selection rule is true
+
+## Proof boundary
+
+The proof assumes the input candidate list is already parsed correctly.
+
+Parsing JSON, calling GitHub APIs, and writing files are outside the Lean proof boundary.
+
+## Implementation path
+
+Recommended future files:
+
+```text
+formal/PromptVoteLab/Selection.lean
+formal/PromptVoteLab/Ranking.lean
+formal/PromptVoteLab/Snapshot.lean
+formal/lakefile.lean
+```
+
+## Validation path
+
+Run proof checks before real API execution:
+
+```text
+lake build
+```
+
+The repository should not require Lean for ordinary static UI edits, but formal checks should run for changes to selection or snapshot logic.

--- a/docs/hn-draft-policy.md
+++ b/docs/hn-draft-policy.md
@@ -1,0 +1,139 @@
+# Hacker News Draft Policy
+
+## Purpose
+
+Prompt Vote Lab may generate Hacker News submission drafts, but it must not automatically submit to Hacker News.
+
+The goal is to help the maintainer publish clear public updates while avoiding account automation risk, accidental spam, and unauthorized posting.
+
+## Policy
+
+Allowed:
+
+- generate HN title candidates
+- generate an HN text draft
+- generate a short experiment summary
+- generate a link checklist
+- generate a post-publication follow-up checklist
+
+Disallowed:
+
+- automatically logging in to Hacker News
+- automatically submitting a story
+- automatically commenting
+- browser automation for posting
+- storing HN credentials
+- asking public issue commenters to trigger HN posting
+
+## Human action boundary
+
+The maintainer must manually decide whether to post.
+
+The generated draft is only a draft. It is not an instruction to publish.
+
+## Canonical output path
+
+Generated HN drafts should live outside `lab/`:
+
+```text
+reports/hn/week-XXX.md
+```
+
+The draft should reference evidence files:
+
+- `data/snapshots/week-XXX.json`
+- `runs/week-XXX.md`
+- implementation PR URL, if available
+- final report URL, if available
+
+## Required draft sections
+
+Each generated HN draft should contain:
+
+1. title candidates
+2. recommended title
+3. submission URL candidate
+4. text draft
+5. evidence checklist
+6. do-not-post checklist
+
+## Draft schema in Markdown
+
+```md
+# HN Draft: Week XXX
+
+## Title candidates
+
+1. ...
+2. ...
+3. ...
+
+## Recommended title
+
+...
+
+## Submission URL candidate
+
+...
+
+## Text draft
+
+...
+
+## Evidence checklist
+
+- [ ] Weekly snapshot exists
+- [ ] Run log exists
+- [ ] Implementation PR exists or no-run is explicitly recorded
+- [ ] Safety result is recorded
+- [ ] Expectation gap classification is recorded
+
+## Do-not-post checklist
+
+Do not post if any of these are true:
+
+- [ ] The run log is still mostly `unrecorded`
+- [ ] The snapshot is missing
+- [ ] The implementation PR is missing for a selected run
+- [ ] The safety result is missing
+- [ ] The draft exaggerates results
+- [ ] The draft hides failures
+```
+
+## Writing constraints
+
+HN drafts must be factual and restrained.
+
+Do not claim:
+
+- the experiment proves AI coding quality
+- the system is autonomous end-to-end
+- the result is statistically significant
+- the voting mechanism is Sybil-resistant
+- the AI output is safe without maintainer review
+
+Prefer concrete wording:
+
+- `This is a small public experiment`
+- `The weekly snapshot records vote state`
+- `The implementation is constrained to lab/`
+- `The result was classified as Partial/Misread/etc.`
+
+## Publication timing
+
+A draft can be generated after the weekly run log reaches one of these states:
+
+- `merged`
+- `rejected`
+- `no_run`
+- `invalidated`
+
+Do not generate a public-facing HN draft from a half-filled run log unless it is explicitly labeled as internal draft.
+
+## Privacy and attribution
+
+Use only public repository data.
+
+Contributor mentions should use GitHub login only when already visible in public issues or PRs.
+
+Do not include private analytics, IP-level data, or non-public supporter information.

--- a/docs/logging-spec.md
+++ b/docs/logging-spec.md
@@ -1,0 +1,177 @@
+# Logging Specification
+
+## Purpose
+
+Prompt Vote Lab must preserve enough evidence to reconstruct why a prompt was selected, what the AI coding agent changed, whether the result passed review, and how the outcome was classified.
+
+This document separates three log classes:
+
+1. experiment logs
+2. aggregation logs
+3. system logs
+
+Do not mix these classes. Mixing them makes later analysis ambiguous.
+
+## Log classes
+
+### 1. Experiment log
+
+Experiment logs describe one weekly experiment run.
+
+Canonical location:
+
+```text
+runs/week-XXX.md
+```
+
+Required fields:
+
+- week id
+- vote snapshot reference
+- selected issue number
+- selected prompt title
+- selected prompt author login
+- selected prompt vote count
+- implementation model policy
+- implementation model settings
+- AI execution constraints
+- implementation PR
+- changed files
+- safety-check result
+- maintainer merge/reject decision
+- expectation-gap classification
+- reviewer note
+- rule change for the next run
+
+Experiment logs are human-readable and should link to machine-readable evidence.
+
+### 2. Aggregation log
+
+Aggregation logs preserve vote-count evidence.
+
+Canonical locations:
+
+```text
+data/snapshots/week-XXX.json
+logs/aggregation/week-XXX.jsonl
+```
+
+`data/snapshots/week-XXX.json` is the weekly fixed vote snapshot.
+
+`logs/aggregation/week-XXX.jsonl` records operational events produced while creating that snapshot.
+
+Aggregation logs must not be stored under `lab/` because `lab/` is the AI-editable implementation target.
+
+### 3. System log
+
+System logs preserve automation behavior.
+
+Canonical locations:
+
+```text
+logs/system/week-XXX.jsonl
+logs/api/week-XXX.jsonl
+logs/errors/week-XXX.jsonl
+```
+
+System logs should record:
+
+- workflow name
+- workflow run id
+- commit SHA
+- started_at
+- finished_at
+- status
+- error type, if any
+- model name, if an API call is made
+- token/cost estimate, if available
+- retry count
+- fallback status
+
+## Trust boundary
+
+The following paths have different trust levels:
+
+| Path | Trust role | Editable by AI agent? |
+|---|---|---:|
+| `lab/` | UI implementation target | Yes |
+| `data/` | generated experiment data | No |
+| `runs/` | weekly experiment record | No |
+| `logs/` | operational evidence | No |
+| `rules/` | experiment policy | No |
+| `.github/workflows/` | automation | No |
+| `scripts/` | maintainer-controlled scripts | No |
+
+The AI coding agent must not edit evidence files.
+
+## Minimum evidence chain
+
+Each week must produce this chain:
+
+```text
+GitHub Issues + reactions
+  -> data/snapshots/week-XXX.json
+  -> runs/week-XXX.md
+  -> implementation PR
+  -> safety-check result
+  -> merge/reject decision
+  -> expectation-gap classification
+```
+
+If any link is missing, the run is incomplete.
+
+## Required weekly status values
+
+Allowed `run_status` values:
+
+- `no_run`
+- `selected_pending_implementation`
+- `implementation_pr_open`
+- `merged`
+- `rejected`
+- `invalidated`
+
+Allowed `gap_classification` values:
+
+- `Hit`
+- `Partial`
+- `Misread`
+- `Overbuild`
+- `Underbuild`
+- `Rule conflict`
+- `Unsafe`
+- `Rejected`
+
+## Redaction and privacy
+
+Only use public GitHub information for public logs:
+
+- issue number
+- issue title
+- issue URL
+- author login
+- public reaction counts
+- public PR URL
+
+Do not log:
+
+- IP address
+- device fingerprint
+- location
+- private email
+- access tokens
+- raw API keys
+- private browser/session data
+
+## API-before-log rule
+
+Do not run a real implementation-model API call until these exist:
+
+- weekly snapshot schema
+- weekly snapshot generation workflow
+- run log template with snapshot reference
+- API usage log schema
+- safety-check workflow
+- dry-run path
+
+If the API is called before these exist, the experiment is not reproducible enough.

--- a/docs/snapshot-spec.md
+++ b/docs/snapshot-spec.md
@@ -1,0 +1,179 @@
+# Weekly Snapshot Specification
+
+## Purpose
+
+A weekly snapshot freezes the vote state at the official cutoff time.
+
+The snapshot is the evidence used to decide whether a prompt is selected for the weekly implementation run.
+
+Do not use the live GitHub issue state after cutoff as the decision source. Reactions can change after the cutoff.
+
+## Canonical path
+
+```text
+data/snapshots/week-XXX.json
+```
+
+Example:
+
+```text
+data/snapshots/week-001.json
+```
+
+## Time policy
+
+Default cutoff:
+
+```text
+Monday 00:00 Asia/Tokyo
+```
+
+In UTC cron form:
+
+```text
+0 15 * * 0
+```
+
+Reason: Sunday 15:00 UTC equals Monday 00:00 in Japan Standard Time.
+
+If this cutoff changes, update this document and record the policy version in the weekly run log.
+
+## Input source
+
+The snapshot generator reads:
+
+- open GitHub issues labeled `prompt-proposal`
+- public `+1` reactions on those issues
+- issue title
+- issue number
+- issue author login
+- issue URL
+- issue created_at and updated_at
+- issue body sections when available
+
+## Top prompt selection
+
+Sort candidates by:
+
+1. higher vote count
+2. older issue number as deterministic tie-breaker
+
+Do not use updated time as a tie-breaker for official weekly selection.
+
+Reason: edited issues should not gain or lose rank because they were edited later.
+
+## Selection rule
+
+Parameters:
+
+```text
+no_change_baseline = 5
+required_margin = 2
+minimum_total_votes = 5
+```
+
+A prompt is selected only if:
+
+```text
+top_prompt_votes >= no_change_baseline + required_margin
+```
+
+and:
+
+```text
+total_votes >= minimum_total_votes
+```
+
+With the initial parameters, the top prompt must have at least 7 votes and the weekly vote must have at least 5 total votes.
+
+## Snapshot schema
+
+```json
+{
+  "schema_version": "snapshot-v1.0",
+  "week": "001",
+  "snapshot_at": "2026-05-11T00:00:00+09:00",
+  "cutoff_timezone": "Asia/Tokyo",
+  "source": "github-issues-reactions",
+  "repository": "Unjuno/prompt-vote-lab",
+  "selection_rule": {
+    "rule": "selection-v1.0",
+    "no_change_baseline": 5,
+    "required_margin": 2,
+    "minimum_total_votes": 5
+  },
+  "total_votes": 15,
+  "top_prompt_votes": 8,
+  "decision": "selected",
+  "selected_issue": 3,
+  "top_prompts": [
+    {
+      "rank": 1,
+      "issue": 3,
+      "title": "Show weekly runs as a timeline",
+      "author": "Unjuno",
+      "votes": 8,
+      "url": "https://github.com/Unjuno/prompt-vote-lab/issues/3",
+      "created_at": "2026-05-02T00:55:32Z",
+      "updated_at": "2026-05-02T01:32:25Z"
+    }
+  ],
+  "all_candidates": [
+    {
+      "issue": 3,
+      "title": "Show weekly runs as a timeline",
+      "author": "Unjuno",
+      "votes": 8,
+      "url": "https://github.com/Unjuno/prompt-vote-lab/issues/3"
+    }
+  ]
+}
+```
+
+## Required invariants
+
+- `top_prompts.length <= 3`
+- `top_prompts` is sorted by descending votes
+- ties are resolved by ascending issue number
+- `top_prompt_votes` equals `top_prompts[0].votes` when `top_prompts` is non-empty
+- `selected_issue` equals `top_prompts[0].issue` when `decision = "selected"`
+- `selected_issue` is `null` when `decision = "no_run"`
+- no file under `lab/` is modified by the snapshot generator
+
+## Decision values
+
+Allowed `decision` values:
+
+- `selected`
+- `no_run`
+- `invalid`
+
+Use `invalid` only when data retrieval failed or the snapshot could not be trusted.
+
+## Immutability policy
+
+A snapshot file should not be edited after it is used for a weekly run.
+
+If a mistake is discovered, create a correction file:
+
+```text
+data/snapshots/week-001.correction-001.json
+```
+
+The run log must link both the original snapshot and the correction.
+
+## LP display
+
+The landing page may display the current top 3 prompts, but that display is not the official selection record.
+
+The official weekly record is the snapshot file.
+
+## Contributor credit
+
+A contributor receives accepted-prompt credit only when:
+
+- the contributor authored the selected issue
+- the selected issue comes from a valid weekly snapshot
+- the run log marks the weekly result as `merged` or another explicitly accepted status
+
+A contributor should not receive accepted-prompt credit merely for being rank 1 if the run is rejected or invalidated.


### PR DESCRIPTION
## Summary

Adds documentation for the evidence and verification layer that should exist before real implementation-model API calls.

This PR does not change `lab/`, workflows, scripts, or runtime behavior.

## Added docs

- `docs/logging-spec.md`
- `docs/snapshot-spec.md`
- `docs/contributor-credit-spec.md`
- `docs/api-control.md`
- `docs/formal-verification-plan.md`
- `docs/hn-draft-policy.md`

## Key decisions

- Separates experiment logs, aggregation logs, and system logs.
- Keeps generated vote/candidate data outside the AI-editable `lab/` scope.
- Defines weekly snapshots as the official vote decision record.
- Defines contributor credit as public GitHub contribution credit, not user tracking.
- Requires API gates before paid implementation-model calls.
- Limits Lean/formal verification to deterministic decision procedures, not API correctness or AI output quality.
- Allows Hacker News draft generation, but disallows automatic Hacker News posting.

## No merge request

This PR is ready for review, but I am not asking to merge it yet. Review the boundaries first.