### PR TITLE
Add script syntax check workflow

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -1,0 +1,37 @@
+name: Script Check
+
+on:
+  pull_request:
+    paths:
+      - "scripts/**/*.mjs"
+      - ".github/workflows/script-check.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  node-syntax-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Check JavaScript module syntax
+        shell: bash
+        run: |
+          shopt -s nullglob
+          files=(scripts/*.mjs scripts/**/*.mjs)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No .mjs scripts found."
+            exit 0
+          fi
+          for file in "${files[@]}"; do
+            echo "Checking $file"
+            node --check "$file"
+          done


### PR DESCRIPTION
## Summary

Adds a small CI workflow that checks JavaScript module syntax for repository scripts.

## Changed files

- `.github/workflows/script-check.yml`

## Behavior

On pull requests that change `scripts/**/*.mjs`, the workflow runs:

```text
node --check <script>
```

It also supports manual `workflow_dispatch`.

## Safety boundary

- No external API calls
- No model calls
- No repository write permission
- Read-only contents permission
- Syntax check only

## Why now

PR #43 and PR #44 add Node `.mjs` scripts. This workflow provides a minimal syntax gate before those automation PRs are merged.