### PR TITLE
Restore lab as experiment surface

### DIFF
--- a/lab/app.js
+++ b/lab/app.js
@@ -1,3 +1,2 @@
-// Prompt Vote Lab keeps the participation layer on GitHub Issues.
-// This static lab page does not fetch votes, store submissions, or use external APIs.
-// Generated vote data should live outside the AI-editable lab scope.
+// Prompt Vote Lab starts as an intentionally minimal implementation target.
+// Accepted experiment runs may replace this file.

--- a/lab/index.html
+++ b/lab/index.html
@@ -9,101 +9,11 @@
 </head>
 <body>
   <main class="lab-root" aria-labelledby="lab-title">
-    <section class="hero panel" aria-labelledby="lab-title">
-      <p class="status">Public prompt-to-implementation experiment</p>
-      <h1 id="lab-title">Prompt Vote Lab</h1>
-      <p class="note">
-        Participants propose prompts as GitHub issues and vote with reactions. The selected prompt is implemented by an AI coding agent inside this constrained static lab.
-      </p>
-      <div class="actions" aria-label="Participation links">
-        <a class="button primary" href="https://github.com/Unjuno/prompt-vote-lab/issues/new">Propose a prompt</a>
-        <a class="button" href="https://github.com/Unjuno/prompt-vote-lab/issues">Vote on prompts</a>
-      </div>
-    </section>
-
-    <section class="panel" aria-labelledby="current-week-title">
-      <div class="section-head">
-        <p class="kicker">Current week</p>
-        <h2 id="current-week-title">Week 001 status</h2>
-      </div>
-      <dl class="status-grid">
-        <div>
-          <dt>Voting layer</dt>
-          <dd>GitHub Issues and reactions</dd>
-        </div>
-        <div>
-          <dt>Selection rule</dt>
-          <dd>Top prompt needs at least 7 votes and 5 total weekly votes</dd>
-        </div>
-        <div>
-          <dt>Implementation scope</dt>
-          <dd><code>lab/index.html</code>, <code>lab/style.css</code>, <code>lab/app.js</code></dd>
-        </div>
-        <div>
-          <dt>Run result</dt>
-          <dd>Awaiting first recorded accepted prompt run</dd>
-        </div>
-      </dl>
-    </section>
-
-    <section class="panel" aria-labelledby="candidates-title">
-      <div class="section-head">
-        <p class="kicker">Open prompt candidates</p>
-        <h2 id="candidates-title">Vote by reacting on GitHub</h2>
-        <p class="small-note">This static list is a display fallback. Automated vote data should live outside the AI-editable lab scope.</p>
-      </div>
-      <ul class="candidate-list">
-        <li>
-          <a href="https://github.com/Unjuno/prompt-vote-lab/issues/1">#1 Make the lab page explain the experiment clearly</a>
-          <p>A first-time visitor should understand the experiment within 10 seconds.</p>
-        </li>
-        <li>
-          <a href="https://github.com/Unjuno/prompt-vote-lab/issues/2">#2 Add expected-vs-actual comparison cards</a>
-          <p>Make the expectation gap visible instead of only showing a generated UI.</p>
-        </li>
-        <li>
-          <a href="https://github.com/Unjuno/prompt-vote-lab/issues/3">#3 Show weekly runs as a timeline</a>
-          <p>Show proposal, vote, implementation, PR review, merge or reject, and gap classification.</p>
-        </li>
-      </ul>
-    </section>
-
-    <section class="panel" aria-labelledby="timeline-title">
-      <div class="section-head">
-        <p class="kicker">Observable loop</p>
-        <h2 id="timeline-title">Weekly run timeline</h2>
-      </div>
-      <ol class="timeline">
-        <li><span>1</span><strong>Propose</strong><p>Participants submit prompts as GitHub issues.</p></li>
-        <li><span>2</span><strong>Vote</strong><p>Participants vote with GitHub reactions.</p></li>
-        <li><span>3</span><strong>Select</strong><p>The top prompt must beat the no-change threshold.</p></li>
-        <li><span>4</span><strong>Implement</strong><p>The AI coding agent edits only the allowed lab files.</p></li>
-        <li><span>5</span><strong>Review</strong><p>The maintainer checks safety, scope, and result quality.</p></li>
-        <li><span>6</span><strong>Classify</strong><p>The weekly log records the expectation gap.</p></li>
-      </ol>
-    </section>
-
-    <section class="panel comparison" aria-labelledby="comparison-title">
-      <div class="section-head">
-        <p class="kicker">Expectation gap</p>
-        <h2 id="comparison-title">Expected vs actual</h2>
-      </div>
-      <div class="compare-grid">
-        <article>
-          <h3>Expected before implementation</h3>
-          <p>Participants expect the selected prompt to improve the lab while staying inside the static UI constraints.</p>
-        </article>
-        <article>
-          <h3>Actual result after implementation</h3>
-          <p>The PR diff, safety checks, and reviewer notes determine whether the result matched the expectation.</p>
-        </article>
-        <article>
-          <h3>Classification</h3>
-          <p>Allowed labels include Hit, Partial, Misread, Overbuild, Underbuild, Rule conflict, Unsafe, and Rejected.</p>
-        </article>
-      </div>
-    </section>
-
+    <p class="status">Awaiting first accepted prompt run</p>
+    <h1 id="lab-title">Prompt Vote Lab</h1>
+    <p class="note">
+      This area is the constrained implementation target. It starts intentionally empty and will be changed only by accepted experiment runs.
+    </p>
     <noscript>This lab works without network access or external scripts.</noscript>
   </main>
 

--- a/lab/style.css
+++ b/lab/style.css
@@ -2,311 +2,56 @@
   color-scheme: light;
   --bg: #f7f7f4;
   --fg: #191919;
-  --muted: #676767;
-  --panel: #ffffff;
+  --muted: #6a6a6a;
   --line: #deded8;
-  --soft: #efefea;
-  --accent: #2738d8;
-  --accent-ink: #ffffff;
-  --shadow: 0 20px 70px rgba(20, 20, 20, 0.08);
 }
 
 * {
   box-sizing: border-box;
 }
 
-html {
-  scroll-behavior: smooth;
-}
-
 body {
   min-height: 100vh;
   margin: 0;
-  background:
-    radial-gradient(circle at top left, rgba(39, 56, 216, 0.10), transparent 30rem),
-    var(--bg);
+  display: grid;
+  place-items: center;
+  background: var(--bg);
   color: var(--fg);
   font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
-a {
-  color: inherit;
-}
-
 .lab-root {
-  width: min(1120px, calc(100% - 32px));
-  margin: 0 auto;
-  padding: 40px 0;
+  width: min(640px, calc(100% - 32px));
+  padding: 48px;
+  border: 1px dashed var(--line);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.55);
 }
 
-.panel {
-  margin: 16px 0;
-  padding: clamp(24px, 4vw, 44px);
-  border: 1px solid var(--line);
-  border-radius: 28px;
-  background: rgba(255, 255, 255, 0.78);
-  box-shadow: var(--shadow);
-}
-
-.hero {
-  padding-top: clamp(40px, 8vw, 76px);
-  padding-bottom: clamp(36px, 7vw, 72px);
-}
-
-.status,
-.kicker {
-  margin: 0 0 14px;
-  color: var(--accent);
-  font-size: 0.78rem;
-  font-weight: 800;
+.status {
+  margin: 0 0 16px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-h1,
-h2,
-h3,
-p {
-  margin-top: 0;
-}
-
 h1 {
-  max-width: 820px;
-  margin-bottom: 18px;
-  font-size: clamp(3rem, 10vw, 7rem);
-  line-height: 0.9;
-  letter-spacing: -0.085em;
-}
-
-h2 {
-  margin-bottom: 0;
-  font-size: clamp(1.6rem, 4vw, 2.6rem);
-  letter-spacing: -0.045em;
-}
-
-h3 {
-  margin-bottom: 10px;
-  font-size: 1rem;
+  margin: 0 0 16px;
+  font-size: clamp(2rem, 8vw, 4.5rem);
+  line-height: 0.95;
+  letter-spacing: -0.07em;
 }
 
 .note,
-.panel p,
-noscript,
-dd {
+noscript {
+  margin: 0;
   color: var(--muted);
   line-height: 1.7;
 }
 
-.note {
-  max-width: 760px;
-  font-size: clamp(1.05rem, 2vw, 1.28rem);
-}
-
-.small-note {
-  margin-bottom: 0;
-  font-size: 0.9rem;
-}
-
-.actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  margin-top: 28px;
-}
-
-.button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 44px;
-  padding: 12px 18px;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  background: var(--panel);
-  color: var(--fg);
-  font-weight: 800;
-  text-decoration: none;
-}
-
-.button.primary {
-  border-color: var(--accent);
-  background: var(--accent);
-  color: var(--accent-ink);
-}
-
-.button:focus-visible,
-.candidate-list a:focus-visible {
-  outline: 3px solid rgba(39, 56, 216, 0.35);
-  outline-offset: 3px;
-}
-
-.section-head {
-  margin-bottom: 22px;
-}
-
-.status-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 14px;
-  margin: 0;
-}
-
-.status-grid div,
-.candidate-list li,
-.timeline li,
-.compare-grid article {
-  border: 1px solid var(--line);
-  border-radius: 20px;
-  background: var(--panel);
-}
-
-.status-grid div {
-  padding: 18px;
-}
-
-dt {
-  margin-bottom: 8px;
-  font-weight: 800;
-}
-
-dd {
-  margin: 0;
-}
-
-code {
-  padding: 0.12em 0.36em;
-  border-radius: 0.45em;
-  background: var(--soft);
-  color: var(--fg);
-  font-size: 0.92em;
-}
-
-.candidate-list,
-.timeline {
-  padding: 0;
-  margin: 0;
-  list-style: none;
-}
-
-.candidate-list {
-  display: grid;
-  gap: 12px;
-}
-
-.candidate-list li {
-  padding: 18px;
-}
-
-.candidate-header {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 8px;
-}
-
-.candidate-list a {
-  display: inline-block;
-  color: var(--accent);
-  font-weight: 850;
-  text-decoration-thickness: 0.12em;
-  text-underline-offset: 0.18em;
-}
-
-.vote-pill {
-  display: inline-flex;
-  align-items: center;
-  min-height: 30px;
-  padding: 6px 10px;
-  border-radius: 999px;
-  background: var(--soft);
-  color: var(--fg);
-  font-size: 0.82rem;
-  font-weight: 850;
-}
-
-.candidate-list p,
-.timeline p,
-.compare-grid p {
-  margin-bottom: 0;
-}
-
-.timeline {
-  display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
-  gap: 12px;
-}
-
-.timeline li {
-  min-height: 180px;
-  padding: 16px;
-}
-
-.timeline span {
-  display: inline-grid;
-  width: 34px;
-  height: 34px;
-  margin-bottom: 14px;
-  place-items: center;
-  border-radius: 50%;
-  background: var(--soft);
-  color: var(--accent);
-  font-weight: 900;
-}
-
-.timeline strong {
-  display: block;
-  margin-bottom: 8px;
-}
-
-.compare-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
-}
-
-.compare-grid article {
-  padding: 18px;
-}
-
 noscript {
   display: block;
-  margin: 18px 0 0;
-  padding: 16px;
-  border: 1px dashed var(--line);
-  border-radius: 18px;
-}
-
-@media (max-width: 900px) {
-  .status-grid,
-  .timeline,
-  .compare-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .timeline li {
-    min-height: auto;
-  }
-}
-
-@media (max-width: 560px) {
-  .lab-root {
-    width: min(100% - 20px, 1120px);
-    padding: 20px 0;
-  }
-
-  .panel {
-    border-radius: 22px;
-  }
-
-  .actions,
-  .button {
-    width: 100%;
-  }
-
-  .candidate-header {
-    align-items: flex-start;
-    flex-direction: column;
-  }
+  margin-top: 16px;
 }


### PR DESCRIPTION
## Summary

Restores `/lab/` to its intended role: the constrained AI-editable experiment surface.

The participation/LP content already exists at the repository root `index.html`. Putting the same participation, voting, candidate, and expectation-gap explanation inside `/lab/` mixed two roles:

- root `index.html`: public landing page and participation guide
- `lab/`: constrained implementation target for accepted experiment runs

## Changed files

- `lab/index.html`
- `lab/style.css`
- `lab/app.js`

## What changed

- Removed participation links, candidate links, voting explanation, and process panels from `/lab/`.
- Restored `/lab/` to a minimal awaiting-run canvas.
- Kept CSP with `connect-src 'none'`.
- Kept `lab/app.js` minimal.

## Trust boundary

`lab/` should be safe for accepted AI coding runs to replace. Evidence, voting, logs, and participation UI should remain outside `lab/`.

## Reason

The live page at `https://unjuno.github.io/prompt-vote-lab/lab/` was mixing the public LP/participation layer with the AI-editable implementation surface. This made the repository model harder to reason about and contradicted the logging/snapshot trust boundary.