### PR TITLE
Make manual workflows dry-run by default

### DIFF
--- a/.github/workflows/hn-draft.yml
+++ b/.github/workflows/hn-draft.yml
@@ -11,6 +11,14 @@ on:
         description: "Submission URL candidate."
         required: false
         type: string
+      commit_changes:
+        description: "Commit generated HN draft. Default is false for manual dry-run safety."
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
 
 permissions:
   contents: write
@@ -34,7 +42,13 @@ jobs:
           REPO_URL: https://github.com/Unjuno/prompt-vote-lab
         run: node scripts/create-hn-draft.mjs
 
+      - name: Show generated diff
+        run: |
+          git status --short
+          git diff -- reports/hn || true
+
       - name: Commit HN draft
+        if: github.event.inputs.commit_changes == 'true'
         run: |
           if git diff --quiet -- reports/hn; then
             echo "No HN draft changes."

--- a/.github/workflows/weekly-snapshot.yml
+++ b/.github/workflows/weekly-snapshot.yml
@@ -11,6 +11,14 @@ on:
         description: "Optional explicit snapshot timestamp. Leave empty to use current time."
         required: false
         type: string
+      commit_changes:
+        description: "Commit generated snapshot files. Default is false for manual dry-run safety."
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
   schedule:
     - cron: "0 15 * * 0"
 
@@ -49,7 +57,13 @@ jobs:
           MINIMUM_TOTAL_VOTES: 5
         run: node scripts/create-weekly-snapshot.mjs
 
+      - name: Show generated diff
+        run: |
+          git status --short
+          git diff -- data/snapshots logs/aggregation runs || true
+
       - name: Commit snapshot files
+        if: github.event_name == 'schedule' || github.event.inputs.commit_changes == 'true'
         run: |
           if git diff --quiet -- data/snapshots logs/aggregation runs; then
             echo "No snapshot changes."


### PR DESCRIPTION
## Summary

Makes manually-triggered generation workflows safer by default.

Manual `workflow_dispatch` runs now show generated diffs without committing unless `commit_changes=true` is explicitly selected.

## Changed files

- `.github/workflows/weekly-snapshot.yml`
- `.github/workflows/hn-draft.yml`

## What changed

### Weekly Vote Snapshot

- Adds `commit_changes` input.
- Default is `false`.
- Manual runs now generate and show the snapshot/run-log diff without committing by default.
- Scheduled weekly runs still commit generated snapshot files.
- Manual runs commit only when `commit_changes=true`.

### Generate HN Draft

- Adds `commit_changes` input.
- Default is `false`.
- Manual runs now generate and show the draft diff without committing by default.
- HN drafts commit only when `commit_changes=true`.

## Safety reason

Before this change, a manual test run could accidentally commit generated evidence/draft files to `main`. This is risky during validation.

The new behavior makes the default manual path a dry run while preserving explicit commit behavior when the maintainer chooses it.

## Scope

- No script logic changed.
- No `lab/` changes.
- No OpenAI/model calls.
- No Hacker News posting.
- Workflow-only guardrail change.