### PR TITLE
Add offline workflow smoke tests

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "scripts/**/*.mjs"
+      - "tests/fixtures/**"
       - ".github/workflows/script-check.yml"
   workflow_dispatch:
 
@@ -35,3 +36,6 @@ jobs:
             echo "Checking $file"
             node --check "$file"
           done
+
+      - name: Run offline workflow smoke test
+        run: node scripts/smoke-test-workflows.mjs

--- a/scripts/create-weekly-snapshot.mjs
+++ b/scripts/create-weekly-snapshot.mjs
@@ -11,6 +11,7 @@ const week = process.env.WEEK_ID || inferWeekId();
 const cutoffTimezone = process.env.CUTOFF_TIMEZONE || 'Asia/Tokyo';
 const snapshotAt = process.env.SNAPSHOT_AT || new Date().toISOString();
 const allowSnapshotOverwrite = process.env.ALLOW_SNAPSHOT_OVERWRITE === 'true';
+const snapshotFixture = process.env.SNAPSHOT_FIXTURE || '';
 
 const noChangeBaseline = Number(process.env.NO_CHANGE_BASELINE || 5);
 const requiredMargin = Number(process.env.REQUIRED_MARGIN || 2);
@@ -20,20 +21,20 @@ const snapshotPath = process.env.SNAPSHOT_OUTPUT || `data/snapshots/week-${week}
 const aggregationLogPath = process.env.AGGREGATION_LOG_OUTPUT || `logs/aggregation/week-${week}.jsonl`;
 const runLogPath = process.env.RUN_LOG_OUTPUT || `runs/week-${week}.md`;
 
-if (!token) {
-  throw new Error('GITHUB_TOKEN is required.');
+if (!token && !snapshotFixture) {
+  throw new Error('GITHUB_TOKEN is required unless SNAPSHOT_FIXTURE is provided.');
 }
 
 if (existsSync(snapshotPath) && !allowSnapshotOverwrite) {
   throw new Error(`${snapshotPath} already exists. Refusing to overwrite an existing weekly snapshot.`);
 }
 
-const headers = {
+const headers = token ? {
   Accept: 'application/vnd.github+json',
   Authorization: `Bearer ${token}`,
   'X-GitHub-Api-Version': '2022-11-28',
   'User-Agent': 'prompt-vote-lab-weekly-snapshot'
-};
+} : null;
 
 function inferWeekId() {
   const now = new Date();
@@ -83,6 +84,18 @@ function candidateRecord(issue, votes) {
     url: issue.html_url,
     created_at: issue.created_at,
     updated_at: issue.updated_at
+  };
+}
+
+function fixtureCandidateRecord(candidate) {
+  return {
+    issue: Number(candidate.issue),
+    title: String(candidate.title || '').replace(/^\[Prompt\]:\s*/i, '').trim(),
+    author: candidate.author || 'unknown',
+    votes: Number(candidate.votes || 0),
+    url: candidate.url || `https://github.com/${repository}/issues/${candidate.issue}`,
+    created_at: candidate.created_at || null,
+    updated_at: candidate.updated_at || null
   };
 }
 
@@ -157,24 +170,36 @@ function escapePipes(value) {
   return String(value).replace(/\|/g, '\\|');
 }
 
+async function loadCandidates() {
+  if (snapshotFixture) {
+    const fixture = JSON.parse(await readFile(snapshotFixture, 'utf8'));
+    if (!Array.isArray(fixture.candidates)) {
+      throw new Error('SNAPSHOT_FIXTURE must contain a candidates array.');
+    }
+    return fixture.candidates.map(fixtureCandidateRecord);
+  }
+
+  const issues = await paginate(`/repos/${repository}/issues?state=open&labels=${encodeURIComponent(promptLabel)}`);
+  const promptIssues = issues.filter((issue) => !issue.pull_request);
+  const rawCandidates = [];
+  for (const issue of promptIssues) {
+    const votes = await plusOneVotes(issue.number);
+    rawCandidates.push(candidateRecord(issue, votes));
+  }
+  return rawCandidates;
+}
+
 const startedAt = new Date().toISOString();
 await appendJsonl(aggregationLogPath, {
   event: 'weekly_snapshot_started',
   week,
   repository,
   prompt_label: promptLabel,
+  fixture: Boolean(snapshotFixture),
   started_at: startedAt
 });
 
-const issues = await paginate(`/repos/${repository}/issues?state=open&labels=${encodeURIComponent(promptLabel)}`);
-const promptIssues = issues.filter((issue) => !issue.pull_request);
-
-const rawCandidates = [];
-for (const issue of promptIssues) {
-  const votes = await plusOneVotes(issue.number);
-  rawCandidates.push(candidateRecord(issue, votes));
-}
-
+const rawCandidates = await loadCandidates();
 const allCandidates = sortCandidates(rawCandidates);
 const topPrompts = allCandidates.slice(0, 3).map((candidate, index) => ({
   rank: index + 1,
@@ -190,7 +215,7 @@ const snapshot = {
   week,
   snapshot_at: snapshotAt,
   cutoff_timezone: cutoffTimezone,
-  source: 'github-issues-reactions',
+  source: snapshotFixture ? 'fixture' : 'github-issues-reactions',
   repository,
   snapshot_path: snapshotPath,
   selection_rule: {
@@ -226,6 +251,7 @@ await appendJsonl(aggregationLogPath, {
   top_prompt_votes: topPromptVotes,
   decision,
   selected_issue: selectedIssue,
+  fixture: Boolean(snapshotFixture),
   started_at: startedAt,
   finished_at: new Date().toISOString()
 });

--- a/scripts/smoke-test-workflows.mjs
+++ b/scripts/smoke-test-workflows.mjs
@@ -65,7 +65,7 @@ run('node', ['scripts/create-hn-draft.mjs'], {
 assertExists(hnDraftPath);
 const draft = await readFile(hnDraftPath, 'utf8');
 assertIncludes(draft, 'HN Draft: Week smoke-001', 'HN draft title');
-assertIncludes(draft, 'do-not-post', 'HN do-not-post section');
+assertIncludes(draft, 'Do-not-post checklist', 'HN do-not-post section');
 assertIncludes(draft, 'Run log still contains unrecorded fields.', 'HN blocker for incomplete run log');
 
 console.log('Offline workflow smoke test passed.');

--- a/scripts/smoke-test-workflows.mjs
+++ b/scripts/smoke-test-workflows.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+import { readFile, rm } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+const testRoot = 'tmp/smoke';
+const week = 'smoke-001';
+const snapshotPath = `${testRoot}/data/snapshots/week-${week}.json`;
+const aggregationLogPath = `${testRoot}/logs/aggregation/week-${week}.jsonl`;
+const runLogPath = `${testRoot}/runs/week-${week}.md`;
+const hnDraftPath = `${testRoot}/reports/hn/week-${week}.md`;
+
+await rm(testRoot, { recursive: true, force: true });
+
+function run(command, args, env) {
+  const result = spawnSync(command, args, {
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+    stdio: 'pipe'
+  });
+
+  if (result.status !== 0) {
+    console.error(result.stdout);
+    console.error(result.stderr);
+    throw new Error(`${command} ${args.join(' ')} failed with status ${result.status}`);
+  }
+
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+}
+
+run('node', ['scripts/create-weekly-snapshot.mjs'], {
+  SNAPSHOT_FIXTURE: 'tests/fixtures/prompt-candidates.json',
+  WEEK_ID: week,
+  SNAPSHOT_AT: '2026-05-11T00:00:00+09:00',
+  SNAPSHOT_OUTPUT: snapshotPath,
+  AGGREGATION_LOG_OUTPUT: aggregationLogPath,
+  RUN_LOG_OUTPUT: runLogPath,
+  ALLOW_SNAPSHOT_OVERWRITE: 'true'
+});
+
+assertExists(snapshotPath);
+assertExists(aggregationLogPath);
+assertExists(runLogPath);
+
+const snapshot = JSON.parse(await readFile(snapshotPath, 'utf8'));
+assertEqual(snapshot.source, 'fixture', 'snapshot source');
+assertEqual(snapshot.decision, 'selected', 'snapshot decision');
+assertEqual(snapshot.selected_issue, 3, 'selected issue');
+assertEqual(snapshot.total_votes, 20, 'total votes');
+assertEqual(snapshot.top_prompts.length, 3, 'top prompt count');
+assertEqual(snapshot.top_prompts[0].issue, 3, 'rank 1 issue');
+assertEqual(snapshot.top_prompts[1].issue, 2, 'rank 2 tie-break issue');
+assertEqual(snapshot.top_prompts[2].issue, 4, 'rank 3 tie-break issue');
+
+run('node', ['scripts/create-hn-draft.mjs'], {
+  WEEK_ID: week,
+  SNAPSHOT_INPUT: snapshotPath,
+  RUN_LOG_INPUT: runLogPath,
+  HN_DRAFT_OUTPUT: hnDraftPath,
+  SITE_URL: 'https://unjuno.github.io/prompt-vote-lab/',
+  REPO_URL: 'https://github.com/Unjuno/prompt-vote-lab'
+});
+
+assertExists(hnDraftPath);
+const draft = await readFile(hnDraftPath, 'utf8');
+assertIncludes(draft, 'HN Draft: Week smoke-001', 'HN draft title');
+assertIncludes(draft, 'do-not-post', 'HN do-not-post section');
+assertIncludes(draft, 'Run log still contains unrecorded fields.', 'HN blocker for incomplete run log');
+
+console.log('Offline workflow smoke test passed.');
+
+function assertExists(path) {
+  if (!existsSync(path)) {
+    throw new Error(`Expected file to exist: ${path}`);
+  }
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(`${label}: expected ${expected}, got ${actual}`);
+  }
+}
+
+function assertIncludes(text, expected, label) {
+  if (!text.includes(expected)) {
+    throw new Error(`${label}: missing ${expected}`);
+  }
+}

--- a/tests/fixtures/prompt-candidates.json
+++ b/tests/fixtures/prompt-candidates.json
@@ -1,0 +1,40 @@
+{
+  "candidates": [
+    {
+      "issue": 3,
+      "title": "Show weekly runs as a timeline",
+      "author": "example-alpha",
+      "votes": 8,
+      "url": "https://github.com/Unjuno/prompt-vote-lab/issues/3",
+      "created_at": "2026-05-01T00:00:00Z",
+      "updated_at": "2026-05-01T00:00:00Z"
+    },
+    {
+      "issue": 2,
+      "title": "Add expected-vs-actual comparison cards",
+      "author": "example-beta",
+      "votes": 5,
+      "url": "https://github.com/Unjuno/prompt-vote-lab/issues/2",
+      "created_at": "2026-05-01T00:00:00Z",
+      "updated_at": "2026-05-01T00:00:00Z"
+    },
+    {
+      "issue": 1,
+      "title": "Make the lab page explain the experiment clearly",
+      "author": "example-gamma",
+      "votes": 2,
+      "url": "https://github.com/Unjuno/prompt-vote-lab/issues/1",
+      "created_at": "2026-05-01T00:00:00Z",
+      "updated_at": "2026-05-01T00:00:00Z"
+    },
+    {
+      "issue": 4,
+      "title": "Tie breaker should prefer lower issue number",
+      "author": "example-delta",
+      "votes": 5,
+      "url": "https://github.com/Unjuno/prompt-vote-lab/issues/4",
+      "created_at": "2026-05-01T00:00:00Z",
+      "updated_at": "2026-05-01T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds an offline smoke test for the weekly snapshot and Hacker News draft generation path.

This lets us validate the evidence pipeline without calling GitHub APIs, OpenAI APIs, or Hacker News.

## Changed files

- `scripts/create-weekly-snapshot.mjs`
- `scripts/smoke-test-workflows.mjs`
- `tests/fixtures/prompt-candidates.json`
- `.github/workflows/script-check.yml`

## What changed

- `create-weekly-snapshot.mjs` now accepts `SNAPSHOT_FIXTURE`.
- When `SNAPSHOT_FIXTURE` is provided, the script uses local fixture candidates and does not require `GITHUB_TOKEN`.
- Added a fixture with four prompt candidates, including a tie-breaker case.
- Added `scripts/smoke-test-workflows.mjs`.
- The smoke test verifies:
  - snapshot generation
  - rank ordering
  - tie-break by lower issue number
  - selected issue calculation
  - run log generation
  - HN draft generation
  - do-not-post blocker when run log is incomplete
- Script Check now runs the offline smoke test.

## Safety boundary

- No OpenAI/model calls.
- No Hacker News posting.
- No GitHub API call in fixture mode.
- Test output is written under `tmp/smoke`, not committed evidence paths.

## Why now

Before manually running Actions against live repository data, we need a local deterministic smoke path that can fail fast in CI.