### PR TITLE
Upload dry-run workflow artifacts

### DIFF
--- a/.github/workflows/hn-draft.yml
+++ b/.github/workflows/hn-draft.yml
@@ -47,6 +47,14 @@ jobs:
           git status --short
           git diff -- reports/hn || true
 
+      - name: Upload generated HN draft artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hn-draft-dry-run
+          path: reports/hn/**
+          if-no-files-found: warn
+          retention-days: 7
+
       - name: Commit HN draft
         if: github.event.inputs.commit_changes == 'true'
         run: |

--- a/.github/workflows/weekly-snapshot.yml
+++ b/.github/workflows/weekly-snapshot.yml
@@ -62,6 +62,18 @@ jobs:
           git status --short
           git diff -- data/snapshots logs/aggregation runs || true
 
+      - name: Upload generated snapshot artifacts
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: weekly-snapshot-dry-run
+          path: |
+            data/snapshots/**
+            logs/aggregation/**
+            runs/**
+          if-no-files-found: warn
+          retention-days: 7
+
       - name: Commit snapshot files
         if: github.event_name == 'schedule' || github.event.inputs.commit_changes == 'true'
         run: |


### PR DESCRIPTION
## Summary

Uploads generated dry-run files as GitHub Actions artifacts for easier inspection.

Manual workflow runs already default to `commit_changes=false`, so generated files are not committed unless explicitly requested. This PR makes those dry-run outputs downloadable from the workflow run page.

## Changed files

- `.github/workflows/weekly-snapshot.yml`
- `.github/workflows/hn-draft.yml`

## What changed

### Weekly Vote Snapshot

Manual `workflow_dispatch` runs now upload:

- `data/snapshots/**`
- `logs/aggregation/**`
- `runs/**`

as artifact:

- `weekly-snapshot-dry-run`

### Generate HN Draft

Manual runs now upload:

- `reports/hn/**`

as artifact:

- `hn-draft-dry-run`

## Retention

Artifacts are retained for 7 days.

## Safety boundary

- No model/API calls added.
- No Hacker News posting.
- No behavior change for scheduled weekly snapshots.
- No generated evidence files are committed by default during manual dry-runs.

## Why now

After adding offline smoke tests, the next live validation step is workflow_dispatch dry-run. Artifacts make the generated snapshot, run log, aggregation log, and HN draft inspectable without committing them to main.