### PR TITLE
Add participant tutorial drafts

### DIFF
--- a/docs/participant-tutorial.md
+++ b/docs/participant-tutorial.md
@@ -1,0 +1,256 @@
+# Participant Tutorial
+
+## Purpose
+
+This document is a participant-facing tutorial draft.
+
+It may later be copied into GitHub Wiki if the project uses Wiki as a static tutorial area.
+
+It is not the official experiment record.
+
+Official records live in:
+
+```text
+data/snapshots/
+runs/
+logs/
+reports/
+```
+
+## What is Prompt Vote Lab?
+
+Prompt Vote Lab is a public experiment where participants propose prompts, vote on prompts, and observe constrained AI coding runs.
+
+The experiment is designed to separate four layers:
+
+| Layer | Purpose | Official? |
+|---|---|---:|
+| Root landing page | Explain the project and participation path | No |
+| GitHub Issues | Collect prompt proposals and votes | Source input |
+| Snapshot/run logs | Record official weekly evidence | Yes |
+| `/lab/` | Constrained AI-editable experiment surface | Output target |
+
+Do not confuse the landing page with `/lab/`.
+
+`/lab/` is intentionally minimal until an accepted experiment run changes it.
+
+## Quick start
+
+1. Open the repository issues.
+2. Read existing prompt proposals.
+3. Add a `+1` reaction to prompts you support.
+4. Create a new prompt issue if your idea is missing.
+5. Wait for the weekly snapshot.
+6. Read the weekly run log.
+7. Compare expected result vs actual result.
+
+## How to propose a prompt
+
+Create a GitHub issue for one proposed prompt.
+
+A good prompt proposal should include:
+
+- the requested change
+- the expected user-visible result
+- why the change is useful
+- what should not be changed
+- any constraints that matter
+
+Good example:
+
+```text
+Title: Show weekly run history on the lab page
+
+Request:
+Add a compact run-history section to /lab/.
+
+Expected result:
+A visitor can see the latest three accepted runs and their result labels.
+
+Do not change:
+Do not add external network calls. Do not edit files outside lab/.
+```
+
+Bad example:
+
+```text
+Make it better.
+```
+
+Reason: the expected result is not testable.
+
+## How to vote
+
+Voting uses public GitHub reactions.
+
+Use:
+
+```text
++1 reaction
+```
+
+Do not assume comments count as votes.
+
+Comments may help explain an idea, but the selection workflow counts `+1` reactions.
+
+## How weekly selection works
+
+At the weekly cutoff, the snapshot workflow counts open prompt issues with the prompt label and their public `+1` reactions.
+
+The official weekly decision comes from:
+
+```text
+data/snapshots/week-XXX.json
+```
+
+The human-readable run record comes from:
+
+```text
+runs/week-XXX.md
+```
+
+A prompt is selected only if:
+
+```text
+top prompt votes >= no-change baseline + required margin
+and
+total weekly votes >= minimum total votes
+```
+
+Initial values:
+
+| Parameter | Value |
+|---|---:|
+| no-change baseline | 5 |
+| required margin | 2 |
+| minimum total votes | 5 |
+
+So the top prompt initially needs at least 7 votes.
+
+## What `/lab/` means
+
+`/lab/` is the constrained AI-editable experiment surface.
+
+It is not the public landing page.
+
+It is not the official record.
+
+It is the place where accepted experiment runs may change visible output.
+
+The agent should normally be limited to:
+
+```text
+lab/index.html
+lab/style.css
+lab/app.js
+```
+
+Evidence files should not be edited by the agent.
+
+## How to read results
+
+Start with the weekly run log:
+
+```text
+runs/week-XXX.md
+```
+
+Look for:
+
+- selected issue
+- top prompts
+- selected prompt votes
+- implementation PR
+- changed files
+- safety-check result
+- result status
+- expectation-gap classification
+- reviewer note
+
+Then check the snapshot:
+
+```text
+data/snapshots/week-XXX.json
+```
+
+Use the snapshot to verify why the prompt was selected.
+
+## What is an expectation gap?
+
+The expectation gap is the difference between what participants expected and what the AI coding run actually produced.
+
+Allowed result labels include:
+
+- Hit
+- Partial
+- Misread
+- Overbuild
+- Underbuild
+- Rule conflict
+- Unsafe
+- Rejected
+
+A failed run is still useful if it is recorded clearly.
+
+## What Hacker News drafts mean
+
+HN drafts are generated for maintainer review.
+
+They are not automatically posted.
+
+Drafts live in:
+
+```text
+reports/hn/week-XXX.md
+```
+
+A draft should not be posted if it hides failures, exaggerates results, or if the run log still contains unfinished evidence.
+
+## What not to put in prompts or comments
+
+Do not include:
+
+- private keys
+- passwords
+- private personal information
+- requests to modify evidence files
+- requests to bypass safety checks
+- requests to post automatically to external sites
+
+## FAQ
+
+### Is `/lab/` the home page?
+
+No.
+
+The root page explains the project. `/lab/` is the experiment surface.
+
+### Can I vote by commenting?
+
+No.
+
+Voting is based on public `+1` reactions.
+
+### Can a losing prompt still matter?
+
+Yes.
+
+A losing prompt may influence future proposals, comments, and later experiments.
+
+### Can the AI edit logs?
+
+No.
+
+Logs and snapshots are evidence. They should stay outside the AI-editable surface.
+
+### Does a selected prompt guarantee merge?
+
+No.
+
+A selected prompt starts an implementation attempt. The maintainer can still reject the result.
+
+## Tutorial boundary
+
+This tutorial may be copied to Wiki later.
+
+If copied to Wiki, keep it mostly static. Do not use Wiki as the official evidence store.

--- a/docs/wiki-tutorial-home-draft.md
+++ b/docs/wiki-tutorial-home-draft.md
@@ -1,0 +1,95 @@
+# Prompt Vote Lab Tutorial Home
+
+> This is a draft for a static GitHub Wiki home page.
+>
+> Use this only if the project enables Wiki as a tutorial surface.
+>
+> Do not use Wiki as the official experiment record.
+
+## What this Wiki is
+
+This Wiki is a tutorial and orientation area.
+
+It explains:
+
+- how to participate
+- how voting works
+- how weekly snapshots work
+- how to read results
+- what `/lab/` means
+
+## What this Wiki is not
+
+This Wiki is not the official record.
+
+Official records live in the repository:
+
+| Record | Location |
+|---|---|
+| Weekly vote snapshots | `data/snapshots/` |
+| Weekly run logs | `runs/` |
+| System and aggregation logs | `logs/` |
+| HN draft reports | `reports/` |
+| Rules and policies | `docs/`, `rules/` |
+
+If the Wiki conflicts with repository evidence, trust the repository evidence.
+
+## Recommended reading path
+
+1. Start with the root landing page.
+2. Read this tutorial.
+3. Browse prompt proposal issues.
+4. Vote with `+1` reactions.
+5. After the weekly cutoff, read the run log.
+6. Compare the selected prompt with the actual `/lab/` result.
+
+## Pages
+
+Suggested Wiki pages:
+
+- Home
+- Getting Started
+- How to Propose a Prompt
+- How to Vote
+- How Weekly Selection Works
+- How to Read Results
+- What `/lab/` Means
+- FAQ
+
+## Editing policy
+
+Initial recommendation:
+
+```text
+Wiki editing: collaborator only
+```
+
+Reason:
+
+- Tutorial pages should remain stable.
+- Official evidence should not be confused with community notes.
+- The project is still validating its snapshot and run-log pipeline.
+
+## If community notes are needed later
+
+Use GitHub Issues first.
+
+Suggested labels:
+
+- `insight`
+- `improvement`
+- `question`
+- `prompt-proposal`
+
+Do not turn the Wiki into an unreviewed evidence store.
+
+## Key distinction
+
+```text
+Root page = public explanation and participation path
+/lab/ = constrained AI-editable experiment surface
+Repository logs = official evidence
+Wiki = optional tutorial layer
+```
+
+Keep these separate.


### PR DESCRIPTION
## Summary

Adds participant-facing tutorial drafts without enabling or editing GitHub Wiki.

## Added files

- `docs/participant-tutorial.md`
- `docs/wiki-tutorial-home-draft.md`

## Purpose

These files define the tutorial layer before any Wiki use.

They clarify:

- how participants propose prompts
- how participants vote
- how weekly selection works
- what `/lab/` means
- where official records live
- why Wiki, if used later, should be a static tutorial layer rather than an evidence store

## Safety boundary

- No workflow changes.
- No generated evidence files.
- No `/lab/` changes.
- No GitHub Wiki mutation.
- No external posting or API call.

## Rationale

The project can use Wiki later as a tutorial surface, but the content should be reviewed in-repo first so it does not mix with official evidence paths.