### PR TITLE
Add prompt proposal issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Read the participant tutorial
+    url: https://github.com/Unjuno/prompt-vote-lab/blob/main/docs/participant-tutorial.md
+    about: Learn how prompt proposals, voting, snapshots, and lab runs work.

--- a/.github/ISSUE_TEMPLATE/prompt_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/prompt_proposal.yml
@@ -1,0 +1,61 @@
+name: Prompt proposal
+description: Propose one prompt for a future Prompt Vote Lab run.
+title: "[Prompt]: "
+labels:
+  - prompt-proposal
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Submit one prompt proposal per issue.
+
+        Voting uses public +1 reactions on issues with the `prompt-proposal` label.
+        Comments can explain or challenge an idea, but comments are not counted as votes.
+
+  - type: textarea
+    id: prompt
+    attributes:
+      label: Prompt request
+      description: What should the AI coding agent change if this prompt wins?
+      placeholder: "Add a compact run-history section to /lab/ that shows the latest accepted runs."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_result
+    attributes:
+      label: Expected visible result
+      description: What should a visitor see after the implementation?
+      placeholder: "A visitor can see the latest three accepted runs, their result labels, and links to run logs."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reason
+    attributes:
+      label: Why this matters
+      description: Explain why this is worth spending a weekly run on.
+      placeholder: "It helps visitors understand that the lab is an observable public experiment, not just a generated page."
+    validations:
+      required: true
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints and non-goals
+      description: What should the agent avoid changing?
+      placeholder: "Do not add external network calls. Do not edit files outside lab/. Do not change voting or snapshot logic."
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: scope_check
+    attributes:
+      label: Scope check
+      options:
+        - label: This proposal can be attempted inside the constrained lab surface.
+          required: true
+        - label: This proposal does not require secrets, login, payment, backend storage, or external services.
+          required: true
+        - label: I understand that winning the vote does not guarantee merge.
+          required: true


### PR DESCRIPTION
## Summary

Adds a GitHub Issue Form for prompt proposals.

## Added files

- `.github/ISSUE_TEMPLATE/prompt_proposal.yml`
- `.github/ISSUE_TEMPLATE/config.yml`

## User-facing problem fixed

The landing page sends users to the issue template chooser, but no prompt proposal template existed. A new participant could create an issue without the `prompt-proposal` label or without the fields needed for a useful weekly run.

## What the template enforces

- one prompt proposal per issue
- automatic `prompt-proposal` label
- prompt request
- expected visible result
- reason the change matters
- constraints and non-goals
- scope checkboxes

## Scope

- No workflow changes.
- No selection logic changes.
- No `/lab/` changes.
- No generated evidence files.
- No external API calls.

## Review focus

Check that the issue form helps a first-time participant create a proposal that the weekly snapshot workflow can count and the maintainer can review.