### PR TITLE
Link submit buttons to prompt proposal template

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
       <nav class="nav" aria-label="Primary navigation">
         <a href="./lab/">Lab</a>
         <a href="https://github.com/Unjuno/prompt-vote-lab/issues?q=is%3Aissue+is%3Aopen+label%3Aprompt-proposal">Vote</a>
-        <a href="https://github.com/Unjuno/prompt-vote-lab/issues/new/choose">Submit</a>
+        <a href="https://github.com/Unjuno/prompt-vote-lab/issues/new?template=prompt_proposal.yml">Submit</a>
         <a href="https://github.com/Unjuno/prompt-vote-lab/tree/main/docs">Rules</a>
       </nav>
     </header>
@@ -121,7 +121,7 @@
           Players compete by submitting prompts. The crowd votes. If a prompt passes the weekly vote gate, a constrained AI coding agent gets one bounded attempt. A popular prompt can still fail in public.
         </p>
         <div class="actions" aria-label="Primary actions">
-          <a class="button primary" href="https://github.com/Unjuno/prompt-vote-lab/issues/new/choose">Submit a prompt</a>
+          <a class="button primary" href="https://github.com/Unjuno/prompt-vote-lab/issues/new?template=prompt_proposal.yml">Submit a prompt</a>
           <a class="button" href="https://github.com/Unjuno/prompt-vote-lab/issues?q=is%3Aissue+is%3Aopen+label%3Aprompt-proposal">Vote on prompts</a>
           <a class="button ghost" href="./lab/">Watch the lab</a>
         </div>
@@ -219,7 +219,7 @@
         <p>Submit carefully. Popularity opens the gate; implementation decides whether trust was deserved.</p>
       </div>
       <div class="actions" aria-label="Final actions">
-        <a class="button primary" href="https://github.com/Unjuno/prompt-vote-lab/issues/new/choose">Submit a prompt</a>
+        <a class="button primary" href="https://github.com/Unjuno/prompt-vote-lab/issues/new?template=prompt_proposal.yml">Submit a prompt</a>
         <a class="button ghost" href="https://github.com/Unjuno/prompt-vote-lab/issues?q=is%3Aissue+is%3Aopen+label%3Aprompt-proposal">Vote now</a>
       </div>
     </section>


### PR DESCRIPTION
## Summary

Updates landing-page Submit links to open the prompt proposal Issue Form directly.

## Changed file

- `index.html`

## User-facing problem fixed

After adding the prompt proposal template, the landing page still sent users to the issue template chooser. Directly linking to `?template=prompt_proposal.yml` reduces friction and makes it more likely that new proposals receive the `prompt-proposal` label and required fields.

## Scope

- Link-only change.
- No workflow changes.
- No selection logic changes.
- No `/lab/` changes.
- No generated evidence files.

## Review focus

Check that all Submit links now target:

`https://github.com/Unjuno/prompt-vote-lab/issues/new?template=prompt_proposal.yml`