### PR TITLE
Align documentation with current selection gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 Prompt Vote Lab is a public prompt game and experiment.
 
-Players compete by writing prompts that other players are willing to trust. If a prompt beats the weekly no-change baseline, a constrained AI coding agent gets one bounded attempt to apply it to the current `lab/` state.
+Players compete by writing prompts that other players are willing to trust. If a prompt passes the weekly selection gate, a constrained AI coding agent gets one bounded attempt to apply it to the current `lab/` state.
 
 A popular prompt can still fail.
 
 The game is not only about getting votes. It is about earning trust by proposing prompts that survive implementation.
 
 ```text
-Prompt → 20-vote gate → agent PR → public outcome → reputation memory
+Prompt → weekly vote gate → agent PR → public outcome → reputation memory
 ```
 
 ## Short explanation
@@ -18,9 +18,10 @@ Prompt Vote Lab is a competitive prompt market plus a constrained, cumulative im
 
 - Players submit prompt candidates as GitHub Issues.
 - Players vote with 👍 reactions.
-- A virtual no-change baseline is inserted every week with 20 virtual votes.
-- If a real prompt beats the baseline, the selected prompt is passed to the implementation agent.
-- The implementation agent attempts the change against the current `main` version of `lab/`.
+- A weekly selection gate decides whether a prompt receives an implementation attempt.
+- The initial gate requires the top prompt to have at least 7 votes and the week to have at least 5 total votes.
+- If no prompt passes the gate, the workflow records the vote summary but does not spend an implementation-agent attempt.
+- The implementation agent attempts the selected change against the current `main` version of `lab/`.
 - If merged, the result becomes the starting point for later weeks.
 - The result is reviewed, classified, and remembered.
 
@@ -92,10 +93,10 @@ Rejected, failed, unsafe, and unmerged comparison PRs do not become the next wee
 
 1. Players submit prompts as GitHub Issues.
 2. Players vote with GitHub reactions.
-3. A virtual no-change baseline is inserted with 20 virtual votes.
-4. Candidates are ranked by vote count.
-5. If the no-change baseline ranks first, no implementation run is created.
-6. If a real prompt ranks first, rank 1 is the normal weekly run candidate.
+3. Candidates are ranked by vote count, then by lower issue number for ties.
+4. The top prompt must pass the weekly selection gate.
+5. If no prompt passes the gate, no implementation run is created.
+6. If a real prompt passes the gate, rank 1 is the normal weekly run candidate.
 7. Rank 2 and rank 3 may be executed as support-unlocked comparison runs.
 8. The selected prompt is given to the implementation agent.
 9. The implementation agent modifies only the current `main` state of `lab/` and opens a PR.
@@ -117,16 +118,27 @@ Rank 2 and rank 3 are comparison candidates. They are not automatically promoted
 
 Only merged PRs affect the inherited lab state.
 
-## No-change baseline
+## Selection gate
 
-Every weekly vote includes a virtual candidate:
+The current weekly selection rule is:
 
 ```text
-[Baseline]: No change this week
-20 virtual votes
+top prompt votes >= no-change baseline + required margin
+and
+total weekly votes >= minimum total votes
 ```
 
-If this baseline ranks first, the workflow records the vote summary but does not create implementation PRs or spend an implementation-agent attempt.
+Initial values:
+
+| Parameter | Value |
+|---|---:|
+| no-change baseline | 5 |
+| required margin | 2 |
+| minimum total votes | 5 |
+
+Therefore, the top prompt initially needs at least 7 votes, and the weekly candidate set needs at least 5 total votes.
+
+If the gate fails, the workflow records the vote state but does not create an implementation-agent attempt.
 
 See [`docs/no-change-baseline.md`](docs/no-change-baseline.md).
 
@@ -181,7 +193,6 @@ See [`docs/support-policy.md`](docs/support-policy.md).
 - inherited lab base commit
 - vote count
 - candidate rank
-- no-change baseline result
 - selection rule
 - implementation agent/model condition
 - AI execution constraints
@@ -206,7 +217,7 @@ Key documents:
 
 - [`docs/experiment-model.md`](docs/experiment-model.md) — project concept and boundaries
 - [`docs/how-to-participate.md`](docs/how-to-participate.md) — how to submit, vote, and review as a player
-- [`docs/no-change-baseline.md`](docs/no-change-baseline.md) — no-change baseline explanation
+- [`docs/no-change-baseline.md`](docs/no-change-baseline.md) — selection gate explanation
 - [`docs/support-policy.md`](docs/support-policy.md) — support tiers and thresholds
 - [`docs/automation-map.md`](docs/automation-map.md) — automation boundary
 

--- a/docs/how-to-participate.md
+++ b/docs/how-to-participate.md
@@ -13,7 +13,7 @@ Winning attention is only the first step. A prompt still has to survive implemen
 ```text
 Submit a prompt
 → persuade other players
-→ beat the 20-vote gate
+→ pass the weekly selection gate
 → receive one bounded agent attempt
 → review the public outcome
 → update trust for the next round
@@ -24,7 +24,7 @@ Submit a prompt
 Open a new prompt proposal issue:
 
 ```text
-https://github.com/Unjuno/prompt-vote-lab/issues/new/choose
+https://github.com/Unjuno/prompt-vote-lab/issues/new?template=prompt_proposal.yml
 ```
 
 A strong proposal should include:
@@ -71,23 +71,36 @@ Vote with GitHub reactions on prompt proposal issues.
 The default vote signal is:
 
 ```text
-👍
+👍 / +1 reaction
 ```
+
+Comments can explain or challenge an idea, but comments are not counted as votes.
 
 Votes are treated as public trust signals, not as a binding election.
 
 A prompt with many votes receives attention. It does not receive guaranteed merge.
 
-## 4. Beat the no-change baseline
+## 4. Pass the weekly selection gate
 
-Every week includes this virtual competitor:
+The current weekly selection rule is:
 
 ```text
-[Baseline]: No change this week
-20 virtual votes
+top prompt votes >= no-change baseline + required margin
+and
+total weekly votes >= minimum total votes
 ```
 
-If no real prompt beats 20, the lab does not move that week.
+Initial values:
+
+| Parameter | Value |
+|---|---:|
+| no-change baseline | 5 |
+| required margin | 2 |
+| minimum total votes | 5 |
+
+Therefore, the top prompt initially needs at least 7 votes, and the week needs at least 5 total votes.
+
+If the gate fails, the lab does not move that week.
 
 Doing nothing is always in the game.
 

--- a/docs/no-change-baseline.md
+++ b/docs/no-change-baseline.md
@@ -1,19 +1,38 @@
-# No-change baseline
+# Selection gate
 
-Prompt Vote Lab includes a virtual no-change candidate in every weekly vote.
+Prompt Vote Lab includes a no-change baseline in the weekly selection rule.
 
-It is the game's default opponent.
+It is the game's default opponent: a prompt should not receive an implementation-agent attempt merely because it exists.
 
-## Baseline
+## Current rule
 
 ```text
-[Baseline]: No change this week
-20 virtual votes
+top prompt votes >= no-change baseline + required margin
+and
+total weekly votes >= minimum total votes
 ```
 
-## Rule
+Initial values:
 
-If the no-change baseline ranks first, no implementation-agent attempt is created for that week.
+| Parameter | Value |
+|---|---:|
+| no-change baseline | 5 |
+| required margin | 2 |
+| minimum total votes | 5 |
+
+Therefore:
+
+```text
+top prompt votes >= 7
+and
+total weekly votes >= 5
+```
+
+## Result
+
+If the weekly gate passes, the top prompt becomes the normal implementation candidate.
+
+If the weekly gate fails, no implementation-agent attempt is created for that week.
 
 Only real `prompt-proposal` issues can create implementation-agent attempts.
 
@@ -31,13 +50,15 @@ The baseline protects:
 - public trust in the vote
 - the inherited lab state
 
-## Example
+## Example: gate fails
 
 | Candidate | Votes | Result |
 |---|---:|---|
-| No change baseline | 20 | wins |
-| Issue #1 | 7 | not attempted |
-| Issue #2 | 5 | not attempted |
+| Issue #1 | 6 | below top-prompt threshold |
+| Issue #2 | 3 | below top-prompt threshold |
+
+Total weekly votes: 9  
+Top prompt votes: 6
 
 Result:
 
@@ -45,13 +66,15 @@ Result:
 No implementation PR is created.
 ```
 
-## Strong prompt example
+## Example: gate passes
 
 | Candidate | Votes | Result |
 |---|---:|---|
-| Issue #1 | 24 | rank 1 |
-| No change baseline | 20 | loses |
-| Issue #2 | 12 | rank 2 |
+| Issue #1 | 7 | rank 1 |
+| Issue #2 | 5 | rank 2 |
+
+Total weekly votes: 12  
+Top prompt votes: 7
 
 Result:
 
@@ -61,12 +84,12 @@ Issue #1 becomes the normal weekly implementation candidate.
 
 ## Support interaction
 
-Support does not override the no-change baseline.
+Support does not override the selection gate.
 
-Support only opens additional comparison runs among real prompt candidates that remain eligible after the baseline is inserted.
+Support only opens additional comparison runs among real prompt candidates after the weekly candidate set has passed the gate.
 
 ## Reputation interaction
 
 Reputation is not currently computed automatically.
 
-However, players should remember which prompt styles repeatedly beat the baseline and still failed, and which prompts actually improved the lab.
+However, players should remember which prompt styles pass the gate and still fail, and which prompts actually improve the lab.


### PR DESCRIPTION
## Summary

Aligns documentation with the current implemented selection gate.

The landing page already uses the current rule, but README and participation docs still described the old 20-vote no-change baseline. That would mislead participants and developers.

## Changed files

- `README.md`
- `docs/how-to-participate.md`
- `docs/no-change-baseline.md`

## Current rule documented

```text
top prompt votes >= no-change baseline + required margin
and
total weekly votes >= minimum total votes
```

Initial values:

```text
no-change baseline = 5
required margin = 2
minimum total votes = 5
```

So the top prompt initially needs at least 7 votes, and the week needs at least 5 total votes.

## Scope

- Documentation only.
- No workflow changes.
- No selection logic changes.
- No `/lab/` changes.
- No generated evidence files.

## User-facing problem fixed

Participants should not read one threshold on the landing page and another threshold in the README or participation docs.