### PR TITLE
Clarify vote reaction on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,8 @@
 
     .eyebrow { display: inline-flex; align-items: center; margin: 0 0 14px; padding: 7px 10px; border: 1px solid var(--line); border-radius: 999px; background: rgba(255, 253, 247, 0.76); color: var(--accent-dark); font-size: 0.74rem; font-weight: 950; letter-spacing: 0.11em; text-transform: uppercase; }
     .lead { max-width: 760px; color: var(--muted); font-size: clamp(1.08rem, 2vw, 1.26rem); line-height: 1.72; }
+    .vote-note { max-width: 720px; margin: 14px 0 0; color: var(--muted); font-size: 0.96rem; line-height: 1.6; }
+    .vote-note strong { color: var(--ink); }
     .actions, .link-row { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 28px; }
     .button { display: inline-flex; align-items: center; justify-content: center; min-height: 54px; padding: 0 21px; border: 1px solid var(--line); border-radius: 999px; background: var(--panel); color: var(--accent-dark); font-weight: 950; text-decoration: none; box-shadow: var(--soft-shadow); }
     .button.primary { min-width: 156px; border-color: var(--accent); background: var(--accent); color: #fff; }
@@ -125,6 +127,7 @@
           <a class="button" href="https://github.com/Unjuno/prompt-vote-lab/issues?q=is%3Aissue+is%3Aopen+label%3Aprompt-proposal">Vote on prompts</a>
           <a class="button ghost" href="./lab/">Watch the lab</a>
         </div>
+        <p class="vote-note"><strong>Voting means adding a 👍 / +1 reaction</strong> to a prompt issue. Comments can explain an idea, but comments do not count as votes.</p>
       </div>
 
       <aside class="gate-card" aria-labelledby="gate-title">


### PR DESCRIPTION
## Summary

Adds a short voting clarification to the landing page.

## Changed file

- `index.html`

## User-facing problem fixed

The landing page had Vote buttons, but a first-time participant might not know that a vote means adding a 👍 / +1 reaction to a prompt issue.

This PR adds one line near the primary actions:

> Voting means adding a 👍 / +1 reaction to a prompt issue. Comments can explain an idea, but comments do not count as votes.

## Scope

- Landing page copy only.
- No workflow changes.
- No selection logic changes.
- No `/lab/` changes.
- No generated evidence files.

## Review focus

Check that the text reduces first-time voting confusion without changing the game rule.