### PR TITLE
Record no-change baseline in snapshots

### DIFF
--- a/docs/snapshot-spec.md
+++ b/docs/snapshot-spec.md
@@ -51,9 +51,11 @@ The snapshot generator reads:
 - issue created_at and updated_at
 - issue body sections when available
 
+The generator also inserts a virtual no-change baseline candidate.
+
 ## Top prompt selection
 
-Sort candidates by:
+Sort real prompt candidates by:
 
 1. higher vote count
 2. older issue number as deterministic tie-breaker
@@ -67,9 +69,9 @@ Reason: edited issues should not gain or lose rank because they were edited late
 Parameters:
 
 ```text
-no_change_baseline = 5
-required_margin = 2
-minimum_total_votes = 5
+no_change_baseline = 20
+required_margin = 1
+minimum_total_votes = 20
 ```
 
 A prompt is selected only if:
@@ -84,35 +86,85 @@ and:
 total_votes >= minimum_total_votes
 ```
 
-With the initial parameters, the top prompt must have at least 7 votes and the weekly vote must have at least 5 total votes.
+With the initial parameters, the top prompt must have at least 21 votes, and the weekly vote must have at least 20 total real prompt votes.
+
+This is equivalent to saying that a real prompt must beat the 20-vote no-change baseline.
+
+## Baseline candidate
+
+Every snapshot records this virtual candidate:
+
+```text
+[Baseline]: No change this week
+20 virtual votes
+```
+
+The baseline candidate is not a GitHub issue.
+
+It exists to make `no_run` decisions explainable in the snapshot and run log.
 
 ## Snapshot schema
 
 ```json
 {
-  "schema_version": "snapshot-v1.0",
+  "schema_version": "snapshot-v1.1",
   "week": "001",
   "snapshot_at": "2026-05-11T00:00:00+09:00",
   "cutoff_timezone": "Asia/Tokyo",
   "source": "github-issues-reactions",
   "repository": "Unjuno/prompt-vote-lab",
   "selection_rule": {
-    "rule": "selection-v1.0",
-    "no_change_baseline": 5,
-    "required_margin": 2,
-    "minimum_total_votes": 5
+    "rule": "selection-v1.1",
+    "no_change_baseline": 20,
+    "required_margin": 1,
+    "minimum_total_votes": 20
   },
-  "total_votes": 15,
-  "top_prompt_votes": 8,
+  "no_change_baseline_candidate": {
+    "issue": null,
+    "title": "[Baseline]: No change this week",
+    "author": "system",
+    "votes": 20,
+    "url": null,
+    "virtual": true,
+    "created_at": null,
+    "updated_at": null
+  },
+  "total_votes": 52,
+  "top_prompt_votes": 24,
   "decision": "selected",
+  "decision_reason": "top_prompt_beat_no_change_baseline",
   "selected_issue": 3,
+  "ranked_candidates_with_baseline": [
+    {
+      "rank": 1,
+      "issue": 3,
+      "title": "Show weekly runs as a timeline",
+      "author": "Unjuno",
+      "votes": 24,
+      "url": "https://github.com/Unjuno/prompt-vote-lab/issues/3",
+      "created_at": "2026-05-02T00:55:32Z",
+      "updated_at": "2026-05-02T01:32:25Z",
+      "virtual": false
+    },
+    {
+      "rank": 2,
+      "issue": null,
+      "title": "[Baseline]: No change this week",
+      "author": "system",
+      "votes": 20,
+      "url": null,
+      "created_at": null,
+      "updated_at": null,
+      "virtual": true
+    }
+  ],
   "top_prompts": [
     {
       "rank": 1,
       "issue": 3,
       "title": "Show weekly runs as a timeline",
       "author": "Unjuno",
-      "votes": 8,
+      "votes": 24,
       "url": "https://github.com/Unjuno/prompt-vote-lab/issues/3",
       "created_at": "2026-05-02T00:55:32Z",
       "updated_at": "2026-05-02T01:32:25Z"
@@ -123,7 +175,7 @@ With the initial parameters, the top prompt must have at least 7 votes and the w
       "issue": 3,
       "title": "Show weekly runs as a timeline",
       "author": "Unjuno",
-      "votes": 8,
+      "votes": 24,
       "url": "https://github.com/Unjuno/prompt-vote-lab/issues/3"
     }
   ]
@@ -133,11 +185,16 @@ With the initial parameters, the top prompt must have at least 7 votes and the w
 ## Required invariants
 
 - `top_prompts.length <= 3`
+- `top_prompts` contains only real prompt issues
 - `top_prompts` is sorted by descending votes
-- ties are resolved by ascending issue number
+- real prompt ties are resolved by ascending issue number
+- `ranked_candidates_with_baseline` includes the virtual baseline candidate
+- `ranked_candidates_with_baseline` is sorted by descending votes
+- when the baseline and a real prompt tie at 20 votes, the baseline wins unless the prompt reaches the required margin
 - `top_prompt_votes` equals `top_prompts[0].votes` when `top_prompts` is non-empty
 - `selected_issue` equals `top_prompts[0].issue` when `decision = "selected"`
 - `selected_issue` is `null` when `decision = "no_run"`
+- `decision_reason` explains why the decision was selected or no-run
 - no file under `lab/` is modified by the snapshot generator
 
 ## Decision values
@@ -149,6 +206,13 @@ Allowed `decision` values:
 - `invalid`
 
 Use `invalid` only when data retrieval failed or the snapshot could not be trusted.
+
+Allowed `decision_reason` values:
+
+- `top_prompt_beat_no_change_baseline`
+- `minimum_total_votes_not_met`
+- `no_change_baseline_won_or_tied`
+- `no_run`
 
 ## Immutability policy
 

--- a/scripts/create-weekly-snapshot.mjs
+++ b/scripts/create-weekly-snapshot.mjs
@@ -75,6 +75,19 @@ function decisionFor(totalVotes, topPromptVotes) {
   return selected ? 'selected' : 'no_run';
 }
 
+function decisionReasonFor(decision, totalVotes, topPromptVotes) {
+  if (decision === 'selected') {
+    return 'top_prompt_beat_no_change_baseline';
+  }
+  if (totalVotes < minimumTotalVotes) {
+    return 'minimum_total_votes_not_met';
+  }
+  if (topPromptVotes < noChangeBaseline + requiredMargin) {
+    return 'no_change_baseline_won_or_tied';
+  }
+  return 'no_run';
+}
+
 function candidateRecord(issue, votes) {
   return {
     issue: issue.number,
@@ -99,9 +112,34 @@ function fixtureCandidateRecord(candidate) {
   };
 }
 
+function baselineCandidateRecord() {
+  return {
+    issue: null,
+    title: '[Baseline]: No change this week',
+    author: 'system',
+    votes: noChangeBaseline,
+    url: null,
+    virtual: true,
+    created_at: null,
+    updated_at: null
+  };
+}
+
 function sortCandidates(candidates) {
   return [...candidates].sort((a, b) => {
     if (b.votes !== a.votes) return b.votes - a.votes;
+    return a.issue - b.issue;
+  });
+}
+
+function sortCandidatesWithBaseline(candidates) {
+  return [...candidates].sort((a, b) => {
+    if (b.votes !== a.votes) return b.votes - a.votes;
+    if (a.virtual && !b.virtual) return -1;
+    if (!a.virtual && b.virtual) return 1;
+    if (a.issue === null && b.issue === null) return 0;
+    if (a.issue === null) return 1;
+    if (b.issue === null) return -1;
     return a.issue - b.issue;
   });
 }
@@ -117,12 +155,19 @@ function runLogMarkdown(snapshot) {
   const topRows = snapshot.top_prompts.map((prompt) => (
     `| ${prompt.rank} | #${prompt.issue} | ${escapePipes(prompt.title)} | ${prompt.author} | ${prompt.votes} | ${prompt.url} |`
   )).join('\n') || '| - | - | - | - | - | - |';
+  const rankedRows = snapshot.ranked_candidates_with_baseline.map((candidate) => (
+    `| ${candidate.rank} | ${candidate.issue === null ? 'baseline' : `#${candidate.issue}`} | ${escapePipes(candidate.title)} | ${candidate.author} | ${candidate.votes} | ${candidate.virtual ? 'yes' : 'no'} | ${candidate.url || '-'} |`
+  )).join('\n') || '| - | - | - | - | - | - | - |';
 
   return `# Week ${snapshot.week}: Prompt Vote Lab Run\n\n` +
 `## Vote Snapshot\n\n` +
 `Snapshot: \`${snapshot.snapshot_path}\`  \n` +
 `Snapshot at: ${snapshot.snapshot_at}  \n` +
 `Cutoff timezone: ${snapshot.cutoff_timezone}\n\n` +
+`## Ranked Candidates With Baseline\n\n` +
+`| Rank | Issue | Prompt | Author | Votes | Virtual | URL |\n` +
+`|---:|---|---|---|---:|---|---|\n` +
+`${rankedRows}\n\n` +
 `## Top Prompts\n\n` +
 `| Rank | Issue | Prompt | Author | Votes | URL |\n` +
 `|---:|---:|---|---|---:|---|\n` +
@@ -132,9 +177,11 @@ function runLogMarkdown(snapshot) {
 `- No-change baseline: ${snapshot.selection_rule.no_change_baseline}\n` +
 `- Required margin: ${snapshot.selection_rule.required_margin}\n` +
 `- Minimum total votes: ${snapshot.selection_rule.minimum_total_votes}\n` +
-`- Total votes: ${snapshot.total_votes}\n` +
-`- Top prompt votes: ${snapshot.top_prompt_votes}\n\n` +
+`- Total real prompt votes: ${snapshot.total_votes}\n` +
+`- Top prompt votes: ${snapshot.top_prompt_votes}\n` +
+`- Baseline candidate: \`${snapshot.no_change_baseline_candidate.title}\` with ${snapshot.no_change_baseline_candidate.votes} virtual votes\n\n` +
 `Decision: \`${snapshot.decision}\`  \n` +
+`Decision reason: \`${snapshot.decision_reason}\`  \n` +
 `Selected issue: ${selected}\n\n` +
 `## Agent Conditions\n\n` +
 `- Agent: unrecorded\n` +
@@ -201,6 +248,14 @@ await appendJsonl(aggregationLogPath, {
 
 const rawCandidates = await loadCandidates();
 const allCandidates = sortCandidates(rawCandidates);
+const noChangeBaselineCandidate = baselineCandidateRecord();
+const rankedCandidatesWithBaseline = sortCandidatesWithBaseline([
+  noChangeBaselineCandidate,
+  ...allCandidates.map((candidate) => ({ ...candidate, virtual: false }))
+]).map((candidate, index) => ({
+  rank: index + 1,
+  ...candidate
+}));
 const topPrompts = allCandidates.slice(0, 3).map((candidate, index) => ({
   rank: index + 1,
   ...candidate
@@ -209,9 +264,10 @@ const totalVotes = allCandidates.reduce((sum, candidate) => sum + candidate.vote
 const topPromptVotes = topPrompts[0]?.votes || 0;
 const decision = decisionFor(totalVotes, topPromptVotes);
 const selectedIssue = decision === 'selected' ? topPrompts[0]?.issue ?? null : null;
+const decisionReason = decisionReasonFor(decision, totalVotes, topPromptVotes);
 
 const snapshot = {
-  schema_version: 'snapshot-v1.0',
+  schema_version: 'snapshot-v1.1',
   week,
   snapshot_at: snapshotAt,
   cutoff_timezone: cutoffTimezone,
@@ -219,15 +275,18 @@ const snapshot = {
   repository,
   snapshot_path: snapshotPath,
   selection_rule: {
-    rule: 'selection-v1.0',
+    rule: 'selection-v1.1',
     no_change_baseline: noChangeBaseline,
     required_margin: requiredMargin,
     minimum_total_votes: minimumTotalVotes
   },
+  no_change_baseline_candidate: noChangeBaselineCandidate,
   total_votes: totalVotes,
   top_prompt_votes: topPromptVotes,
   decision,
+  decision_reason: decisionReason,
   selected_issue: selectedIssue,
+  ranked_candidates_with_baseline: rankedCandidatesWithBaseline,
   top_prompts: topPrompts,
   all_candidates: allCandidates
 };
@@ -250,6 +309,7 @@ await appendJsonl(aggregationLogPath, {
   total_votes: totalVotes,
   top_prompt_votes: topPromptVotes,
   decision,
+  decision_reason: decisionReason,
   selected_issue: selectedIssue,
   fixture: Boolean(snapshotFixture),
   started_at: startedAt,
@@ -258,4 +318,4 @@ await appendJsonl(aggregationLogPath, {
 
 console.log(`Wrote ${snapshotPath}`);
 console.log(`Ensured ${runLogPath}`);
-console.log(`Decision: ${decision}, selected issue: ${selectedIssue ?? 'none'}`);
+console.log(`Decision: ${decision}, reason: ${decisionReason}, selected issue: ${selectedIssue ?? 'none'}`);

--- a/scripts/smoke-test-workflows.mjs
+++ b/scripts/smoke-test-workflows.mjs
@@ -44,17 +44,30 @@ assertExists(aggregationLogPath);
 assertExists(runLogPath);
 
 const snapshot = JSON.parse(await readFile(snapshotPath, 'utf8'));
+assertEqual(snapshot.schema_version, 'snapshot-v1.1', 'snapshot schema version');
 assertEqual(snapshot.source, 'fixture', 'snapshot source');
 assertEqual(snapshot.decision, 'selected', 'snapshot decision');
+assertEqual(snapshot.decision_reason, 'top_prompt_beat_no_change_baseline', 'snapshot decision reason');
 assertEqual(snapshot.selected_issue, 3, 'selected issue');
 assertEqual(snapshot.total_votes, 52, 'total votes');
 assertEqual(snapshot.top_prompt_votes, 24, 'top prompt votes');
 assertEqual(snapshot.selection_rule.no_change_baseline, 20, 'no-change baseline');
 assertEqual(snapshot.selection_rule.required_margin, 1, 'required margin');
+assertEqual(snapshot.no_change_baseline_candidate.title, '[Baseline]: No change this week', 'baseline title');
+assertEqual(snapshot.no_change_baseline_candidate.votes, 20, 'baseline votes');
+assertEqual(snapshot.no_change_baseline_candidate.virtual, true, 'baseline virtual flag');
+assertEqual(snapshot.ranked_candidates_with_baseline.length, 5, 'ranked candidates with baseline count');
+assertEqual(snapshot.ranked_candidates_with_baseline[0].issue, 3, 'ranked baseline table rank 1 issue');
+assertEqual(snapshot.ranked_candidates_with_baseline[1].virtual, true, 'ranked baseline table rank 2 baseline');
 assertEqual(snapshot.top_prompts.length, 3, 'top prompt count');
 assertEqual(snapshot.top_prompts[0].issue, 3, 'rank 1 issue');
 assertEqual(snapshot.top_prompts[1].issue, 2, 'rank 2 tie-break issue');
 assertEqual(snapshot.top_prompts[2].issue, 4, 'rank 3 tie-break issue');
+
+const runLog = await readFile(runLogPath, 'utf8');
+assertIncludes(runLog, 'Ranked Candidates With Baseline', 'run log baseline table heading');
+assertIncludes(runLog, '[Baseline]: No change this week', 'run log baseline row');
+assertIncludes(runLog, 'Decision reason: `top_prompt_beat_no_change_baseline`', 'run log decision reason');
 
 run('node', ['scripts/create-hn-draft.mjs'], {
   WEEK_ID: week,


### PR DESCRIPTION
## Summary

Makes the 20-vote no-change baseline explicit in weekly snapshots and run logs.

## Changed files

- `scripts/create-weekly-snapshot.mjs`
- `scripts/smoke-test-workflows.mjs`
- `docs/snapshot-spec.md`

## User-facing problem fixed

The project explains the baseline as a virtual candidate, but generated snapshots did not explicitly record that virtual candidate. A reader could see `no_run` or `selected` without seeing the baseline as part of the ranked evidence.

## What changed

The snapshot now includes:

- `schema_version: snapshot-v1.1`
- `selection_rule.rule: selection-v1.1`
- `no_change_baseline_candidate`
- `ranked_candidates_with_baseline`
- `decision_reason`

The run log now includes a `Ranked Candidates With Baseline` table.

## Scope

- Snapshot generation logic only.
- Smoke test assertions updated.
- Snapshot spec updated.
- No `/lab/` changes.
- No workflow changes.
- No landing page changes.
- No generated evidence files committed.

## Review focus

Check that the baseline appears as a virtual candidate, that real prompt `top_prompts` remain real issues only, and that no-run decisions can be explained from the snapshot alone.