### PR TITLE
Guard lab implementation PR scope

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,20 @@
-# Codex Lab Run PR
+# Prompt Vote Lab PR
+
+## Summary
+
+<!-- What changed? Keep this specific. -->
+
+## Change type
+
+- [ ] Codex / AI agent lab implementation
+- [ ] Documentation or policy change
+- [ ] Workflow or script change
+- [ ] Evidence, log, snapshot, run, or report change
+- [ ] Other
 
 ## Voted prompt
+
+For Codex / AI agent lab implementation PRs only.
 
 Issue: #
 
@@ -8,29 +22,65 @@ Issue: #
 
 ## Rule profile
 
+For Codex / AI agent lab implementation PRs:
+
 - `rules/static-ui-v1.0.md`
 
 ## Expected result
 
+<!-- What should a user see or be able to do after this PR? -->
 
 ## Changed files
+
+For Codex / AI agent lab implementation PRs, only these files may change:
 
 - [ ] `lab/index.html`
 - [ ] `lab/style.css`
 - [ ] `lab/app.js`
 
+For non-lab PRs:
+
+- [ ] This PR does not mix lab implementation changes with policy, workflow, evidence, or documentation changes.
+
+## Scope checklist
+
+- [ ] I checked the changed-file list before review.
+- [ ] This PR does not hide unrelated changes.
+- [ ] If `lab/` changed, no non-lab files changed in the same PR.
+- [ ] If non-lab files changed, `lab/` did not change in the same PR.
+- [ ] Generated evidence files are not manually edited unless this PR is an explicit correction.
+
 ## Safety checklist
 
-- [ ] Only `lab/` files were changed.
+For lab implementation PRs:
+
+- [ ] Only approved `lab/` files were changed.
 - [ ] No external network calls were added.
 - [ ] No cookie access was added.
-- [ ] No `eval` or `new Function` was added.
+- [ ] No `eval` or unsafe `new Function` was added.
 - [ ] No external scripts were added.
+- [ ] No login, payment, tracker, or backend behavior was added.
 - [ ] Browser display check completed.
+
+## User-facing review
+
+- [ ] A first-time participant can still understand how to submit a prompt.
+- [ ] A first-time participant can still understand that voting means a 👍 / +1 reaction.
+- [ ] The 20-vote no-change baseline remains consistent.
+- [ ] `/lab/` remains the constrained implementation surface, not the landing page or evidence store.
+
+## Snapshot / logging review
+
+For snapshot, run-log, report, or workflow PRs:
+
+- [ ] Schema changes include matching tests or documentation updates.
+- [ ] The no-change baseline remains visible in generated evidence when relevant.
+- [ ] Dry-run behavior is safe by default, or this PR explains why not.
+- [ ] No OpenAI/model call or Hacker News posting is introduced without an explicit gate.
 
 ## Result review
 
-React to this PR:
+React to Codex / AI agent lab implementation PRs:
 
 - 👍 = matches expectation
 - 👀 = interesting but off
@@ -50,3 +100,9 @@ Maintainer classification:
 ## Merge policy
 
 Result votes are advisory. The maintainer decides whether to merge.
+
+Do not merge a Codex / AI agent lab implementation PR that mixes `lab/` changes with `.github/`, `docs/`, `rules/`, `data/`, `logs/`, `runs/`, `reports/`, or script changes.
+
+## Notes for reviewer
+
+<!-- Mention anything surprising, risky, or intentionally out of scope. -->

--- a/.github/workflows/lab-pr-scope-check.yml
+++ b/.github/workflows/lab-pr-scope-check.yml
@@ -1,0 +1,23 @@
+name: Lab PR Scope Check
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  lab-pr-scope-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check lab PR scope
+        env:
+          BASE_REF: origin/${{ github.base_ref }}
+          HEAD_REF: HEAD
+        run: bash scripts/check-lab-pr-scope.sh

--- a/scripts/check-lab-pr-scope.sh
+++ b/scripts/check-lab-pr-scope.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref="${BASE_REF:-origin/main}"
+head_ref="${HEAD_REF:-HEAD}"
+
+if ! git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+  echo "ERROR: base ref not found: $base_ref"
+  exit 1
+fi
+
+mapfile -t changed_files < <(git diff --name-only "$base_ref"..."$head_ref" | sort)
+
+if [ "${#changed_files[@]}" -eq 0 ]; then
+  echo "No changed files."
+  exit 0
+fi
+
+echo "Changed files:"
+printf '  - %s\n' "${changed_files[@]}"
+
+lab_changed=false
+non_lab_changes=()
+invalid_lab_changes=()
+
+for file in "${changed_files[@]}"; do
+  case "$file" in
+    lab/index.html|lab/style.css|lab/app.js)
+      lab_changed=true
+      ;;
+    lab/*)
+      lab_changed=true
+      invalid_lab_changes+=("$file")
+      ;;
+    *)
+      non_lab_changes+=("$file")
+      ;;
+  esac
+done
+
+if [ "$lab_changed" != "true" ]; then
+  echo "No lab files changed. Lab PR scope guard passes."
+  exit 0
+fi
+
+if [ "${#invalid_lab_changes[@]}" -gt 0 ]; then
+  echo "ERROR: lab implementation PRs may only change these files:"
+  echo "  - lab/index.html"
+  echo "  - lab/style.css"
+  echo "  - lab/app.js"
+  echo "Invalid lab path changes:"
+  printf '  - %s\n' "${invalid_lab_changes[@]}"
+  exit 1
+fi
+
+if [ "${#non_lab_changes[@]}" -gt 0 ]; then
+  echo "ERROR: PR changes lab files and non-lab files together."
+  echo "Codex/agent implementation PRs must keep evidence, workflow, docs, and policy files untouched."
+  echo "Move non-lab changes to a separate human-reviewed PR."
+  echo "Non-lab changes detected:"
+  printf '  - %s\n' "${non_lab_changes[@]}"
+  exit 1
+fi
+
+echo "Lab PR scope guard passes: only approved lab files changed."


### PR DESCRIPTION
## Summary

Adds a guard for Codex / AI agent lab implementation PRs.

## Changed files

- `scripts/check-lab-pr-scope.sh`
- `.github/workflows/lab-pr-scope-check.yml`
- `.github/pull_request_template.md`

## Reason

The current checks catch some unsafe runtime patterns in `lab/`, but they do not stop a lab implementation PR from also changing docs, workflows, logs, snapshots, or reports.

That is risky because Codex / AI agent implementation PRs should be constrained to the lab surface.

## What the new guard does

If a PR changes any of these files:

- `lab/index.html`
- `lab/style.css`
- `lab/app.js`

then it must not change non-lab files in the same PR.

If a PR changes another path under `lab/`, the check fails.

If a PR does not change `lab/`, the check passes.

## User-facing risk reduced

This reduces the chance that a voted prompt implementation silently modifies evidence, policies, automation, or documentation together with the visible lab result.

## Scope

- Adds one scope-check script.
- Adds one PR workflow.
- Strengthens the PR template.
- No `/lab/` changes.
- No selection logic changes.
- No generated evidence files.
- No model/API calls.

## Review focus

Check that documentation/workflow-only PRs remain possible, while Codex / AI agent lab implementation PRs are restricted to the approved lab files.