### PR TITLE
Add minimum lab participant orientation

### DIFF
--- a/lab/index.html
+++ b/lab/index.html
@@ -9,11 +9,36 @@
 </head>
 <body>
   <main class="lab-root" aria-labelledby="lab-title">
+    <nav class="lab-links" aria-label="Lab navigation">
+      <a href="../">About</a>
+      <a href="https://github.com/Unjuno/prompt-vote-lab/issues/new?template=prompt_proposal.yml">Submit prompt</a>
+      <a href="https://github.com/Unjuno/prompt-vote-lab/issues?q=is%3Aissue+is%3Aopen+label%3Aprompt-proposal">Vote with +1</a>
+      <a href="https://github.com/Unjuno/prompt-vote-lab/tree/main/runs">Run logs</a>
+    </nav>
+
     <p class="status">Awaiting first accepted prompt run</p>
     <h1 id="lab-title">Prompt Vote Lab</h1>
     <p class="note">
-      This area is the constrained implementation target. It starts intentionally empty and will be changed only by accepted experiment runs.
+      This area is the constrained implementation target. It starts intentionally small and will be changed only by accepted experiment runs.
     </p>
+
+    <section class="lab-card" aria-labelledby="participate-title">
+      <h2 id="participate-title">How to participate</h2>
+      <ol>
+        <li>Submit one prompt proposal as a GitHub Issue.</li>
+        <li>Vote by adding a 👍 / +1 reaction to a prompt issue. Comments do not count as votes.</li>
+        <li>A real prompt must beat the 20-vote no-change baseline to receive the normal implementation attempt.</li>
+        <li>Read the official run logs and snapshots after each weekly cutoff.</li>
+      </ol>
+    </section>
+
+    <section class="lab-card" aria-labelledby="evidence-title">
+      <h2 id="evidence-title">Official evidence</h2>
+      <p>
+        This page is not the official record. Evidence lives in <a href="https://github.com/Unjuno/prompt-vote-lab/tree/main/runs">runs/</a> and <a href="https://github.com/Unjuno/prompt-vote-lab/tree/main/data/snapshots">data/snapshots/</a>.
+      </p>
+    </section>
+
     <noscript>This lab works without network access or external scripts.</noscript>
   </main>
 

--- a/lab/style.css
+++ b/lab/style.css
@@ -4,6 +4,7 @@
   --fg: #191919;
   --muted: #6a6a6a;
   --line: #deded8;
+  --panel: #ffffff;
 }
 
 * {
@@ -21,11 +22,36 @@ body {
 }
 
 .lab-root {
-  width: min(640px, calc(100% - 32px));
-  padding: 48px;
+  width: min(760px, calc(100% - 32px));
+  padding: clamp(28px, 6vw, 48px);
   border: 1px dashed var(--line);
   border-radius: 24px;
   background: rgba(255, 255, 255, 0.55);
+}
+
+.lab-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 28px;
+}
+
+.lab-links a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 36px;
+  padding: 0 12px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--panel);
+  color: var(--fg);
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.lab-links a:hover {
+  text-decoration: underline;
 }
 
 .status {
@@ -44,11 +70,37 @@ h1 {
   letter-spacing: -0.07em;
 }
 
+h2 {
+  margin: 0 0 10px;
+  font-size: 1.05rem;
+  letter-spacing: -0.03em;
+}
+
 .note,
-noscript {
+noscript,
+.lab-card p,
+.lab-card li {
   margin: 0;
   color: var(--muted);
   line-height: 1.7;
+}
+
+.lab-card {
+  margin-top: 18px;
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.lab-card ol {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.lab-card a {
+  color: var(--fg);
+  font-weight: 700;
 }
 
 noscript {


### PR DESCRIPTION
## Summary

Adds minimum participant orientation to `/lab/`.

## Changed files

- `lab/index.html`
- `lab/style.css`

## What changed

- Adds navigation links.
- Explains prompt submission.
- Explains that voting uses 👍 / +1 reactions.
- Mentions the 20-vote baseline.
- Points readers to `runs/` and `data/snapshots/` for official evidence.

## Scope

- Lab files only.
- No workflow changes.
- No docs/rules/evidence changes.
- No scripts changed.
- No model/API calls.

## Review focus

Check that `/lab/` remains a constrained experiment surface and does not become the evidence store.