### PR TITLE
Add lab smoke test

### DIFF
--- a/.github/workflows/static-site-check.yml
+++ b/.github/workflows/static-site-check.yml
@@ -9,6 +9,7 @@ on:
       - "docs/**"
       - "rules/**"
       - "scripts/static-site-check.sh"
+      - "scripts/lab-smoke-test.mjs"
   workflow_dispatch:
 
 permissions:
@@ -21,5 +22,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Run static site check
         run: bash scripts/static-site-check.sh
+
+      - name: Run lab smoke test
+        run: node scripts/lab-smoke-test.mjs

--- a/scripts/lab-smoke-test.mjs
+++ b/scripts/lab-smoke-test.mjs
@@ -12,6 +12,16 @@ const visibleText = html
   .replace(/\s+/g, ' ')
   .trim();
 
+const externalResourcePatterns = [
+  /<script[^>]+src=["']https?:\/\//i,
+  /<link[^>]+href=["']https?:\/\//i,
+  /<img[^>]+src=["']https?:\/\//i,
+  /<iframe[^>]+src=["']https?:\/\//i,
+  /<object[^>]+data=["']https?:\/\//i,
+  /@import\s+url\(["']?https?:\/\//i,
+  /url\(["']?https?:\/\//i
+];
+
 const checks = [
   {
     label: 'lab title is present',
@@ -58,8 +68,8 @@ const checks = [
     pass: /Content-Security-Policy/i.test(html) && /connect-src 'none'/i.test(html)
   },
   {
-    label: 'lab does not reference external http resources',
-    pass: !/https?:\/\//i.test(combined)
+    label: 'lab does not load external http resources',
+    pass: !externalResourcePatterns.some((pattern) => pattern.test(combined))
   },
   {
     label: 'lab does not contain network APIs',

--- a/scripts/lab-smoke-test.mjs
+++ b/scripts/lab-smoke-test.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+
+const html = await readFile('lab/index.html', 'utf8');
+const css = await readFile('lab/style.css', 'utf8');
+const js = await readFile('lab/app.js', 'utf8');
+const combined = `${html}\n${css}\n${js}`;
+const visibleText = html
+  .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+  .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+  .replace(/<[^>]+>/g, ' ')
+  .replace(/\s+/g, ' ')
+  .trim();
+
+const checks = [
+  {
+    label: 'lab title is present',
+    pass: /Prompt Vote Lab/i.test(visibleText)
+  },
+  {
+    label: 'lab identifies itself as constrained implementation target',
+    pass: /constrained/i.test(visibleText) && /implementation target/i.test(visibleText)
+  },
+  {
+    label: 'lab explains accepted experiment runs change it',
+    pass: /accepted/i.test(visibleText) && /experiment runs/i.test(visibleText)
+  },
+  {
+    label: 'lab keeps a no-network expectation visible',
+    pass: /without network access/i.test(visibleText) || /no network/i.test(visibleText)
+  },
+  {
+    label: 'lab links back to the landing page',
+    pass: /href=["']\.\.\/["']/i.test(html) || /href=["']\/["']/i.test(html)
+  },
+  {
+    label: 'lab links to prompt proposal submission',
+    pass: /issues\/new\?template=prompt_proposal\.yml/i.test(html)
+  },
+  {
+    label: 'lab links to prompt vote list',
+    pass: /issues\?q=.*prompt-proposal/i.test(html)
+  },
+  {
+    label: 'lab explains votes are +1 reactions',
+    pass: /(\+1|👍)/u.test(visibleText) && /reaction/i.test(visibleText)
+  },
+  {
+    label: 'lab mentions 20-vote no-change baseline',
+    pass: /20/.test(visibleText) && /baseline/i.test(visibleText)
+  },
+  {
+    label: 'lab links to official run or snapshot evidence',
+    pass: /runs\//i.test(html) || /data\/snapshots/i.test(html) || /docs\/snapshot-spec\.md/i.test(html)
+  },
+  {
+    label: 'lab has Content-Security-Policy with connect-src none',
+    pass: /Content-Security-Policy/i.test(html) && /connect-src 'none'/i.test(html)
+  },
+  {
+    label: 'lab does not reference external http resources',
+    pass: !/https?:\/\//i.test(combined)
+  },
+  {
+    label: 'lab does not contain network APIs',
+    pass: !/fetch\(|XMLHttpRequest|WebSocket|EventSource|sendBeacon/i.test(combined)
+  }
+];
+
+const failures = checks.filter((check) => !check.pass);
+
+for (const check of checks) {
+  console.log(`${check.pass ? 'PASS' : 'FAIL'}: ${check.label}`);
+}
+
+if (failures.length > 0) {
+  console.error('\nLab smoke test failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure.label}`);
+  }
+  process.exit(1);
+}
+
+console.log('Lab smoke test passed.');


### PR DESCRIPTION
## Summary

Adds a lab smoke test to protect minimum user orientation in `/lab/`.

## Changed files

- `scripts/lab-smoke-test.mjs`
- `.github/workflows/static-site-check.yml`

## What the test checks

- lab title exists
- lab says it is the constrained implementation target
- accepted experiment runs can change it
- no-network expectation remains visible
- links exist for About, Submit, Vote, and official evidence
- voting uses 👍 / +1 reactions
- 20-vote baseline remains visible
- CSP keeps `connect-src 'none'`
- no external HTTP resources or network APIs appear in lab files

## Scope

- Test and workflow coverage only.
- No `/lab/` changes in this PR.
- No selection logic changes.
- No generated evidence files.
- No model/API calls.

## Review focus

Check that this prevents Codex/AI-agent lab changes from deleting the minimum participant orientation while keeping the test simple and dependency-free.