### PR TITLE
Add snapshot participation metrics

### DIFF
--- a/docs/snapshot-spec.md
+++ b/docs/snapshot-spec.md
@@ -53,6 +53,14 @@ The snapshot generator reads:
 
 The generator also inserts a virtual no-change baseline candidate.
 
+## Public-data boundary
+
+Snapshots record aggregate participation metrics.
+
+Snapshots may include issue authors because issue authorship is part of the proposal record.
+
+Snapshots must not include voter login lists. The generator may use reaction users internally to compute aggregate unique-voter counts, but the output stores counts only.
+
 ## Top prompt selection
 
 Sort real prompt candidates by:
@@ -103,11 +111,28 @@ The baseline candidate is not a GitHub issue.
 
 It exists to make `no_run` decisions explainable in the snapshot and run log.
 
+## Participation metrics
+
+The snapshot records aggregate metrics needed to evaluate participation.
+
+Metrics:
+
+- `candidate_count`: number of real prompt candidates
+- `unique_author_count`: number of distinct prompt authors among real candidates
+- `total_votes`: total `+1` reactions across real candidates
+- `top_prompt_votes`: `+1` reaction count for the top real prompt
+- `unique_voter_count`: number of distinct voters across all real candidates, or `null` when unavailable
+- `unique_voter_count_available`: whether `unique_voter_count` was computed from live reaction users
+- `average_votes_per_candidate`: total votes divided by candidate count
+- `top_prompt_vote_share`: top prompt votes divided by total votes
+
+Fixture snapshots normally set `unique_voter_count` to `null`.
+
 ## Snapshot schema
 
 ```json
 {
-  "schema_version": "snapshot-v1.1",
+  "schema_version": "snapshot-v1.2",
   "week": "001",
   "snapshot_at": "2026-05-11T00:00:00+09:00",
   "cutoff_timezone": "Asia/Tokyo",
@@ -124,10 +149,21 @@ It exists to make `no_run` decisions explainable in the snapshot and run log.
     "title": "[Baseline]: No change this week",
     "author": "system",
     "votes": 20,
+    "voter_count": 0,
     "url": null,
     "virtual": true,
     "created_at": null,
     "updated_at": null
+  },
+  "metrics": {
+    "candidate_count": 4,
+    "unique_author_count": 4,
+    "total_votes": 52,
+    "top_prompt_votes": 24,
+    "unique_voter_count": 46,
+    "unique_voter_count_available": true,
+    "average_votes_per_candidate": 13,
+    "top_prompt_vote_share": 0.4615
   },
   "total_votes": 52,
   "top_prompt_votes": 24,
@@ -141,6 +177,7 @@ It exists to make `no_run` decisions explainable in the snapshot and run log.
       "title": "Show weekly runs as a timeline",
       "author": "Unjuno",
       "votes": 24,
+      "voter_count": 24,
       "url": "https://github.com/Unjuno/prompt-vote-lab/issues/3",
       "created_at": "2026-05-02T00:55:32Z",
       "updated_at": "2026-05-02T01:32:25Z",
@@ -152,6 +189,7 @@ It exists to make `no_run` decisions explainable in the snapshot and run log.
       "title": "[Baseline]: No change this week",
       "author": "system",
       "votes": 20,
+      "voter_count": 0,
       "url": null,
       "created_at": null,
       "updated_at": null,
@@ -165,6 +203,7 @@ It exists to make `no_run` decisions explainable in the snapshot and run log.
       "title": "Show weekly runs as a timeline",
       "author": "Unjuno",
       "votes": 24,
+      "voter_count": 24,
       "url": "https://github.com/Unjuno/prompt-vote-lab/issues/3",
       "created_at": "2026-05-02T00:55:32Z",
       "updated_at": "2026-05-02T01:32:25Z"
@@ -176,6 +215,7 @@ It exists to make `no_run` decisions explainable in the snapshot and run log.
       "title": "Show weekly runs as a timeline",
       "author": "Unjuno",
       "votes": 24,
+      "voter_count": 24,
       "url": "https://github.com/Unjuno/prompt-vote-lab/issues/3"
     }
   ]
@@ -188,6 +228,13 @@ It exists to make `no_run` decisions explainable in the snapshot and run log.
 - `top_prompts` contains only real prompt issues
 - `top_prompts` is sorted by descending votes
 - real prompt ties are resolved by ascending issue number
+- each real candidate has `votes` and `voter_count`
+- snapshots do not contain voter login lists
+- `metrics.candidate_count` equals `all_candidates.length`
+- `metrics.unique_author_count` is the number of distinct real candidate authors
+- `metrics.total_votes` equals top-level `total_votes`
+- `metrics.top_prompt_votes` equals top-level `top_prompt_votes`
+- `metrics.unique_voter_count` is either a number or `null`
 - `ranked_candidates_with_baseline` includes the virtual baseline candidate
 - `ranked_candidates_with_baseline` is sorted by descending votes
 - when the baseline and a real prompt tie at 20 votes, the baseline wins unless the prompt reaches the required margin

--- a/scripts/create-weekly-snapshot.mjs
+++ b/scripts/create-weekly-snapshot.mjs
@@ -65,9 +65,18 @@ async function paginate(path) {
   return results;
 }
 
-async function plusOneVotes(issueNumber) {
+async function plusOneReactionSummary(issueNumber) {
   const reactions = await paginate(`/repos/${repository}/issues/${issueNumber}/reactions?content=%2B1`);
-  return reactions.filter((reaction) => reaction.content === '+1').length;
+  const plusOnes = reactions.filter((reaction) => reaction.content === '+1');
+  const voterLogins = plusOnes
+    .map((reaction) => reaction.user?.login)
+    .filter((login) => typeof login === 'string' && login.length > 0);
+
+  return {
+    votes: plusOnes.length,
+    voter_count: new Set(voterLogins).size,
+    voter_logins: voterLogins
+  };
 }
 
 function decisionFor(totalVotes, topPromptVotes) {
@@ -88,24 +97,28 @@ function decisionReasonFor(decision, totalVotes, topPromptVotes) {
   return 'no_run';
 }
 
-function candidateRecord(issue, votes) {
+function candidateRecord(issue, reactionSummary) {
   return {
     issue: issue.number,
     title: issue.title.replace(/^\[Prompt\]:\s*/i, '').trim(),
     author: issue.user?.login || 'unknown',
-    votes,
+    votes: reactionSummary.votes,
+    voter_count: reactionSummary.voter_count,
     url: issue.html_url,
     created_at: issue.created_at,
-    updated_at: issue.updated_at
+    updated_at: issue.updated_at,
+    _voter_logins: reactionSummary.voter_logins
   };
 }
 
 function fixtureCandidateRecord(candidate) {
+  const votes = Number(candidate.votes || 0);
   return {
     issue: Number(candidate.issue),
     title: String(candidate.title || '').replace(/^\[Prompt\]:\s*/i, '').trim(),
     author: candidate.author || 'unknown',
-    votes: Number(candidate.votes || 0),
+    votes,
+    voter_count: Number(candidate.voter_count ?? votes),
     url: candidate.url || `https://github.com/${repository}/issues/${candidate.issue}`,
     created_at: candidate.created_at || null,
     updated_at: candidate.updated_at || null
@@ -118,11 +131,17 @@ function baselineCandidateRecord() {
     title: '[Baseline]: No change this week',
     author: 'system',
     votes: noChangeBaseline,
+    voter_count: 0,
     url: null,
     virtual: true,
     created_at: null,
     updated_at: null
   };
+}
+
+function publicCandidate(candidate) {
+  const { _voter_logins, ...rest } = candidate;
+  return rest;
 }
 
 function sortCandidates(candidates) {
@@ -144,6 +163,26 @@ function sortCandidatesWithBaseline(candidates) {
   });
 }
 
+function buildMetrics(candidates) {
+  const authors = new Set(candidates.map((candidate) => candidate.author).filter(Boolean));
+  const voterLogins = candidates.flatMap((candidate) => candidate._voter_logins || []);
+  const uniqueVoterCount = voterLogins.length > 0 ? new Set(voterLogins).size : null;
+  const candidateCount = candidates.length;
+  const totalVotes = candidates.reduce((sum, candidate) => sum + candidate.votes, 0);
+  const topPromptVotes = sortCandidates(candidates)[0]?.votes || 0;
+
+  return {
+    candidate_count: candidateCount,
+    unique_author_count: authors.size,
+    total_votes: totalVotes,
+    top_prompt_votes: topPromptVotes,
+    unique_voter_count: uniqueVoterCount,
+    unique_voter_count_available: uniqueVoterCount !== null,
+    average_votes_per_candidate: candidateCount > 0 ? Number((totalVotes / candidateCount).toFixed(2)) : 0,
+    top_prompt_vote_share: totalVotes > 0 ? Number((topPromptVotes / totalVotes).toFixed(4)) : 0
+  };
+}
+
 async function appendJsonl(path, record) {
   await mkdir(path.split('/').slice(0, -1).join('/'), { recursive: true });
   const previous = existsSync(path) ? await readFile(path, 'utf8') : '';
@@ -153,24 +192,32 @@ async function appendJsonl(path, record) {
 function runLogMarkdown(snapshot) {
   const selected = snapshot.decision === 'selected' ? snapshot.selected_issue : 'none';
   const topRows = snapshot.top_prompts.map((prompt) => (
-    `| ${prompt.rank} | #${prompt.issue} | ${escapePipes(prompt.title)} | ${prompt.author} | ${prompt.votes} | ${prompt.url} |`
-  )).join('\n') || '| - | - | - | - | - | - |';
-  const rankedRows = snapshot.ranked_candidates_with_baseline.map((candidate) => (
-    `| ${candidate.rank} | ${candidate.issue === null ? 'baseline' : `#${candidate.issue}`} | ${escapePipes(candidate.title)} | ${candidate.author} | ${candidate.votes} | ${candidate.virtual ? 'yes' : 'no'} | ${candidate.url || '-'} |`
+    `| ${prompt.rank} | #${prompt.issue} | ${escapePipes(prompt.title)} | ${prompt.author} | ${prompt.votes} | ${prompt.voter_count} | ${prompt.url} |`
   )).join('\n') || '| - | - | - | - | - | - | - |';
+  const rankedRows = snapshot.ranked_candidates_with_baseline.map((candidate) => (
+    `| ${candidate.rank} | ${candidate.issue === null ? 'baseline' : `#${candidate.issue}`} | ${escapePipes(candidate.title)} | ${candidate.author} | ${candidate.votes} | ${candidate.voter_count} | ${candidate.virtual ? 'yes' : 'no'} | ${candidate.url || '-'} |`
+  )).join('\n') || '| - | - | - | - | - | - | - | - |';
 
   return `# Week ${snapshot.week}: Prompt Vote Lab Run\n\n` +
 `## Vote Snapshot\n\n` +
 `Snapshot: \`${snapshot.snapshot_path}\`  \n` +
 `Snapshot at: ${snapshot.snapshot_at}  \n` +
 `Cutoff timezone: ${snapshot.cutoff_timezone}\n\n` +
+`## Participation Metrics\n\n` +
+`- Candidate count: ${snapshot.metrics.candidate_count}\n` +
+`- Unique author count: ${snapshot.metrics.unique_author_count}\n` +
+`- Total real prompt votes: ${snapshot.metrics.total_votes}\n` +
+`- Top prompt votes: ${snapshot.metrics.top_prompt_votes}\n` +
+`- Unique voter count: ${snapshot.metrics.unique_voter_count_available ? snapshot.metrics.unique_voter_count : 'unavailable'}\n` +
+`- Average votes per candidate: ${snapshot.metrics.average_votes_per_candidate}\n` +
+`- Top prompt vote share: ${snapshot.metrics.top_prompt_vote_share}\n\n` +
 `## Ranked Candidates With Baseline\n\n` +
-`| Rank | Issue | Prompt | Author | Votes | Virtual | URL |\n` +
-`|---:|---|---|---|---:|---|---|\n` +
+`| Rank | Issue | Prompt | Author | Votes | Voters | Virtual | URL |\n` +
+`|---:|---|---|---|---:|---:|---|---|\n` +
 `${rankedRows}\n\n` +
 `## Top Prompts\n\n` +
-`| Rank | Issue | Prompt | Author | Votes | URL |\n` +
-`|---:|---:|---|---|---:|---|\n` +
+`| Rank | Issue | Prompt | Author | Votes | Voters | URL |\n` +
+`|---:|---:|---|---|---:|---:|---|\n` +
 `${topRows}\n\n` +
 `## Selection Rule\n\n` +
 `- Rule: \`${snapshot.selection_rule.rule}\`\n` +
@@ -230,8 +277,8 @@ async function loadCandidates() {
   const promptIssues = issues.filter((issue) => !issue.pull_request);
   const rawCandidates = [];
   for (const issue of promptIssues) {
-    const votes = await plusOneVotes(issue.number);
-    rawCandidates.push(candidateRecord(issue, votes));
+    const reactionSummary = await plusOneReactionSummary(issue.number);
+    rawCandidates.push(candidateRecord(issue, reactionSummary));
   }
   return rawCandidates;
 }
@@ -247,7 +294,8 @@ await appendJsonl(aggregationLogPath, {
 });
 
 const rawCandidates = await loadCandidates();
-const allCandidates = sortCandidates(rawCandidates);
+const allCandidatesInternal = sortCandidates(rawCandidates);
+const allCandidates = allCandidatesInternal.map(publicCandidate);
 const noChangeBaselineCandidate = baselineCandidateRecord();
 const rankedCandidatesWithBaseline = sortCandidatesWithBaseline([
   noChangeBaselineCandidate,
@@ -260,14 +308,15 @@ const topPrompts = allCandidates.slice(0, 3).map((candidate, index) => ({
   rank: index + 1,
   ...candidate
 }));
-const totalVotes = allCandidates.reduce((sum, candidate) => sum + candidate.votes, 0);
-const topPromptVotes = topPrompts[0]?.votes || 0;
+const metrics = buildMetrics(allCandidatesInternal);
+const totalVotes = metrics.total_votes;
+const topPromptVotes = metrics.top_prompt_votes;
 const decision = decisionFor(totalVotes, topPromptVotes);
 const selectedIssue = decision === 'selected' ? topPrompts[0]?.issue ?? null : null;
 const decisionReason = decisionReasonFor(decision, totalVotes, topPromptVotes);
 
 const snapshot = {
-  schema_version: 'snapshot-v1.1',
+  schema_version: 'snapshot-v1.2',
   week,
   snapshot_at: snapshotAt,
   cutoff_timezone: cutoffTimezone,
@@ -281,6 +330,7 @@ const snapshot = {
     minimum_total_votes: minimumTotalVotes
   },
   no_change_baseline_candidate: noChangeBaselineCandidate,
+  metrics,
   total_votes: totalVotes,
   top_prompt_votes: topPromptVotes,
   decision,
@@ -305,9 +355,12 @@ await appendJsonl(aggregationLogPath, {
   repository,
   snapshot_path: snapshotPath,
   run_log_path: runLogPath,
-  candidate_count: allCandidates.length,
+  candidate_count: metrics.candidate_count,
+  unique_author_count: metrics.unique_author_count,
   total_votes: totalVotes,
   top_prompt_votes: topPromptVotes,
+  unique_voter_count: metrics.unique_voter_count,
+  unique_voter_count_available: metrics.unique_voter_count_available,
   decision,
   decision_reason: decisionReason,
   selected_issue: selectedIssue,

--- a/scripts/smoke-test-workflows.mjs
+++ b/scripts/smoke-test-workflows.mjs
@@ -44,7 +44,7 @@ assertExists(aggregationLogPath);
 assertExists(runLogPath);
 
 const snapshot = JSON.parse(await readFile(snapshotPath, 'utf8'));
-assertEqual(snapshot.schema_version, 'snapshot-v1.1', 'snapshot schema version');
+assertEqual(snapshot.schema_version, 'snapshot-v1.2', 'snapshot schema version');
 assertEqual(snapshot.source, 'fixture', 'snapshot source');
 assertEqual(snapshot.decision, 'selected', 'snapshot decision');
 assertEqual(snapshot.decision_reason, 'top_prompt_beat_no_change_baseline', 'snapshot decision reason');
@@ -55,16 +55,29 @@ assertEqual(snapshot.selection_rule.no_change_baseline, 20, 'no-change baseline'
 assertEqual(snapshot.selection_rule.required_margin, 1, 'required margin');
 assertEqual(snapshot.no_change_baseline_candidate.title, '[Baseline]: No change this week', 'baseline title');
 assertEqual(snapshot.no_change_baseline_candidate.votes, 20, 'baseline votes');
+assertEqual(snapshot.no_change_baseline_candidate.voter_count, 0, 'baseline voter count');
 assertEqual(snapshot.no_change_baseline_candidate.virtual, true, 'baseline virtual flag');
+assertEqual(snapshot.metrics.candidate_count, 4, 'metrics candidate count');
+assertEqual(snapshot.metrics.unique_author_count, 4, 'metrics unique author count');
+assertEqual(snapshot.metrics.total_votes, 52, 'metrics total votes');
+assertEqual(snapshot.metrics.top_prompt_votes, 24, 'metrics top prompt votes');
+assertEqual(snapshot.metrics.unique_voter_count, null, 'metrics unique voter count unavailable for fixture');
+assertEqual(snapshot.metrics.unique_voter_count_available, false, 'metrics unique voter availability');
+assertEqual(snapshot.metrics.average_votes_per_candidate, 13, 'metrics average votes per candidate');
+assertEqual(snapshot.metrics.top_prompt_vote_share, 0.4615, 'metrics top prompt vote share');
 assertEqual(snapshot.ranked_candidates_with_baseline.length, 5, 'ranked candidates with baseline count');
 assertEqual(snapshot.ranked_candidates_with_baseline[0].issue, 3, 'ranked baseline table rank 1 issue');
 assertEqual(snapshot.ranked_candidates_with_baseline[1].virtual, true, 'ranked baseline table rank 2 baseline');
 assertEqual(snapshot.top_prompts.length, 3, 'top prompt count');
 assertEqual(snapshot.top_prompts[0].issue, 3, 'rank 1 issue');
+assertEqual(snapshot.top_prompts[0].voter_count, 24, 'rank 1 voter count');
 assertEqual(snapshot.top_prompts[1].issue, 2, 'rank 2 tie-break issue');
 assertEqual(snapshot.top_prompts[2].issue, 4, 'rank 3 tie-break issue');
+assertEqual(snapshot.all_candidates.some((candidate) => Object.hasOwn(candidate, '_voter_logins')), false, 'snapshot must not expose voter logins');
 
 const runLog = await readFile(runLogPath, 'utf8');
+assertIncludes(runLog, 'Participation Metrics', 'run log metrics section');
+assertIncludes(runLog, 'Unique voter count: unavailable', 'run log unique voter unavailable note');
 assertIncludes(runLog, 'Ranked Candidates With Baseline', 'run log baseline table heading');
 assertIncludes(runLog, '[Baseline]: No change this week', 'run log baseline row');
 assertIncludes(runLog, 'Decision reason: `top_prompt_beat_no_change_baseline`', 'run log decision reason');

--- a/tests/fixtures/prompt-candidates.json
+++ b/tests/fixtures/prompt-candidates.json
@@ -5,6 +5,7 @@
       "title": "Show weekly runs as a timeline",
       "author": "example-alpha",
       "votes": 24,
+      "voter_count": 24,
       "url": "https://github.com/Unjuno/prompt-vote-lab/issues/3",
       "created_at": "2026-05-01T00:00:00Z",
       "updated_at": "2026-05-01T00:00:00Z"
@@ -14,6 +15,7 @@
       "title": "Add expected-vs-actual comparison cards",
       "author": "example-beta",
       "votes": 12,
+      "voter_count": 12,
       "url": "https://github.com/Unjuno/prompt-vote-lab/issues/2",
       "created_at": "2026-05-01T00:00:00Z",
       "updated_at": "2026-05-01T00:00:00Z"
@@ -23,6 +25,7 @@
       "title": "Make the lab page explain the experiment clearly",
       "author": "example-gamma",
       "votes": 4,
+      "voter_count": 4,
       "url": "https://github.com/Unjuno/prompt-vote-lab/issues/1",
       "created_at": "2026-05-01T00:00:00Z",
       "updated_at": "2026-05-01T00:00:00Z"
@@ -32,6 +35,7 @@
       "title": "Tie breaker should prefer lower issue number",
       "author": "example-delta",
       "votes": 12,
+      "voter_count": 12,
       "url": "https://github.com/Unjuno/prompt-vote-lab/issues/4",
       "created_at": "2026-05-01T00:00:00Z",
       "updated_at": "2026-05-01T00:00:00Z"


### PR DESCRIPTION
## Summary

Adds aggregate participation metrics to weekly snapshots and run logs.

## Changed files

- `scripts/create-weekly-snapshot.mjs`
- `scripts/smoke-test-workflows.mjs`
- `tests/fixtures/prompt-candidates.json`
- `docs/snapshot-spec.md`

## Why

Vote totals alone are not enough for this experiment. We also need to know whether participation is growing and whether the vote is concentrated or distributed.

## Added data

Snapshots now include:

- `schema_version: snapshot-v1.2`
- `metrics.candidate_count`
- `metrics.unique_author_count`
- `metrics.total_votes`
- `metrics.top_prompt_votes`
- `metrics.unique_voter_count`
- `metrics.unique_voter_count_available`
- `metrics.average_votes_per_candidate`
- `metrics.top_prompt_vote_share`
- per-candidate `voter_count`

## Privacy boundary

The generator may use public reaction users internally to compute aggregate unique voter counts, but snapshots do not store voter login lists.

## Scope

- Snapshot data shape and run-log output only.
- No `/lab/` changes.
- No selection threshold change.
- No workflow change.
- No model/API call.
- No generated evidence files committed.

## Review focus

Check that participation metrics are useful for growth and experiment analysis without storing voter identity lists.