### PR TITLE
Add briefing artifact to evidence dry run

### DIFF
--- a/.github/workflows/evidence-pipeline-dry-run.yml
+++ b/.github/workflows/evidence-pipeline-dry-run.yml
@@ -82,6 +82,24 @@ jobs:
 
           node scripts/create-snapshot-summary.mjs
 
+      - name: Generate public briefing
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          WEEK_ID="${{ github.event.inputs.week_id || 'dry-run-001' }}"
+          SITE_URL="${{ github.event.inputs.site_url || 'https://unjuno.github.io/prompt-vote-lab/' }}"
+
+          export WEEK_ID
+          export SNAPSHOT_INPUT="tmp/evidence/data/snapshots/week-${WEEK_ID}.json"
+          export SUMMARY_INPUT="tmp/evidence/reports/summary/weekly-metrics.json"
+          export RUN_LOG_INPUT="tmp/evidence/runs/week-${WEEK_ID}.md"
+          export BRIEFING_OUTPUT="tmp/evidence/reports/briefings/week-${WEEK_ID}.md"
+          export SITE_URL
+          export REPO_URL="https://github.com/Unjuno/prompt-vote-lab"
+
+          node scripts/create-public-briefing.mjs
+
       - name: Generate HN draft from generated snapshot
         shell: bash
         run: |
@@ -111,6 +129,7 @@ jobs:
           test -s "tmp/evidence/runs/week-${WEEK_ID}.md"
           test -s "tmp/evidence/reports/summary/weekly-metrics.json"
           test -s "tmp/evidence/reports/summary/weekly-metrics.md"
+          test -s "tmp/evidence/reports/briefings/week-${WEEK_ID}.md"
           test -s "tmp/evidence/reports/hn/week-${WEEK_ID}.md"
 
           node -e "const fs=require('fs'); const p='tmp/evidence/data/snapshots/week-${WEEK_ID}.json'; const s=JSON.parse(fs.readFileSync(p,'utf8')); if (!Array.isArray(s.top_prompts)) throw new Error('top_prompts missing'); if (s.top_prompts.length > 3) throw new Error('too many top prompts'); if (!s.metrics) throw new Error('metrics missing'); console.log(JSON.stringify({decision:s.decision, selected_issue:s.selected_issue, total_votes:s.total_votes, candidate_count:s.metrics.candidate_count}, null, 2));"
@@ -118,6 +137,9 @@ jobs:
           node -e "const fs=require('fs'); const p='tmp/evidence/reports/summary/weekly-metrics.json'; const s=JSON.parse(fs.readFileSync(p,'utf8')); if (s.schema_version !== 'snapshot-summary-v1.0') throw new Error('unexpected summary schema'); if (s.week_count < 1) throw new Error('summary has no weeks'); console.log(JSON.stringify({week_count:s.week_count, selected_count:s.selected_count, no_run_count:s.no_run_count}, null, 2));"
 
           grep -q "Weekly Metrics Summary" "tmp/evidence/reports/summary/weekly-metrics.md"
+          grep -q "Prompt Vote Lab Briefing" "tmp/evidence/reports/briefings/week-${WEEK_ID}.md"
+          grep -q "## Observe" "tmp/evidence/reports/briefings/week-${WEEK_ID}.md"
+          grep -q "## Act" "tmp/evidence/reports/briefings/week-${WEEK_ID}.md"
           grep -q "Do-not-post checklist" "tmp/evidence/reports/hn/week-${WEEK_ID}.md"
 
       - name: Show generated file tree

--- a/docs/automation-map.md
+++ b/docs/automation-map.md
@@ -38,6 +38,7 @@ The project may automate:
 - vote snapshot artifact creation
 - weekly run-log draft creation
 - weekly metrics summary artifact creation
+- weekly public briefing draft artifact creation
 - event log artifact creation
 - HN/blog/report draft artifact creation
 
@@ -62,7 +63,7 @@ The project must not automate:
 | `static-site-check.yml` | implemented | Check public page structure, support wording, and lab smoke expectations | 0 |
 | `lab-pr-scope-check.yml` | implemented | Prevent lab implementation PRs from mixing lab and non-lab files | 0 |
 | `script-check.yml` | implemented | Check scripts, offline workflow smoke tests, and lab scope guard tests | 0 |
-| `evidence-pipeline-dry-run.yml` | implemented | Manually generate snapshot, run log, weekly summary, and HN draft as artifact | 0 |
+| `evidence-pipeline-dry-run.yml` | implemented | Manually generate snapshot, run log, weekly summary, public briefing, and HN draft as artifact | 0 |
 | `exception-matrix-test.yml` | implemented | Test known pass/fail boundary cases | 0 |
 | `multi-fuzz-test.yml` | implemented | Run weighted random boundary mutations | 0 |
 | `weekly-mock-run.yml` | implemented | Test weekly selection and PR creation without model API calls | 0 |
@@ -107,6 +108,7 @@ tmp/evidence/logs/aggregation/week-<week_id>.jsonl
 tmp/evidence/runs/week-<week_id>.md
 tmp/evidence/reports/summary/weekly-metrics.json
 tmp/evidence/reports/summary/weekly-metrics.md
+tmp/evidence/reports/briefings/week-<week_id>.md
 tmp/evidence/reports/hn/week-<week_id>.md
 ```
 
@@ -122,6 +124,7 @@ GitHub Issues
 → weekly snapshot
 → weekly run-log draft
 → weekly metrics summary
+→ public weekly briefing draft
 → HN/report draft
 → artifact review
 → implementation attempt, if eligible and explicitly run
@@ -131,6 +134,18 @@ GitHub Issues
 → terminal state label
 → run/report record
 ```
+
+## Public briefing data
+
+Weekly public briefing generation may summarize:
+
+- observed vote and candidate metrics
+- interpretation of the current week
+- selected/no-run decision
+- next participant action
+- links for submit and vote actions
+
+The briefing is a draft artifact. It must not auto-post externally. It must not store voter login lists.
 
 ## Metrics summary data
 


### PR DESCRIPTION
## Summary

Adds the public briefing draft to the manual evidence dry-run artifact.

## Changed files

- `.github/workflows/evidence-pipeline-dry-run.yml`
- `docs/automation-map.md`

## Outputs added

- `tmp/evidence/reports/briefings/week-<week_id>.md`

## Scope

- Manual dry-run artifact only.
- Documentation update.
- No `/lab/` changes.
- No threshold changes.
- No generated files committed.
- No external posting.