### PR TITLE
Record no eligible workflow verification status

### DIFF
--- a/docs/current-features.md
+++ b/docs/current-features.md
@@ -56,6 +56,7 @@ Implemented:
 - `scripts/test_weekly_auto_no_eligible.py`
 - CI for collect-votes tests
 - CI for eligible-selection tests
+- CI for weekly no-eligible selector test
 
 Current selection rule:
 
@@ -79,6 +80,14 @@ Implemented:
 - model-free weekly report draft PR
 - no-eligible summary PR path
 - implementation-agent preflight before model dependency install
+
+Verified:
+
+- Weekly Auto Run no-eligible production path created only `runs/week-2026-W19-vote-summary.md` in PR #81.
+- The recorded summary had baseline rank 1 with 20 virtual votes.
+- `eligible_count` was 0.
+- `eligible_ranks` was empty.
+- No implementation PR was created during that no-eligible run.
 
 Not implemented:
 
@@ -139,6 +148,8 @@ Implemented:
 - implementation preflight test
 - Lean proof test
 - pre-API freeze audit
+- pre-API freeze audit self-test
+- evidence artifact smoke test
 
 ## Formal proof
 
@@ -196,11 +207,12 @@ Implemented:
 - pre-API freeze checklist
 - pre-API freeze audit script
 - pre-API freeze audit CI
+- Weekly Auto Run no-eligible production path verification
 
 Current policy:
 
 ```text
-No real implementation-agent API call until all offline gates are green and the Weekly Auto Run no-eligible workflow path is confirmed.
+No real implementation-agent API call until all offline gates are green and live evidence artifacts are reviewed.
 ```
 
 ## Current release judgment
@@ -210,10 +222,11 @@ Current state:
 ```text
 MVP structure: mostly complete
 offline verification: strong
+no-eligible production workflow path: verified
 real implementation-agent canary: not yet executed
 production autonomy: not complete
 ```
 
 Operational recommendation:
 
-Run one final no-eligible workflow test before any paid implementation-agent canary.
+Run `Evidence Pipeline Dry Run` with `source=live`, review the generated artifact with `docs/evidence-artifact-review.md`, and only then consider a single low-risk paid implementation-agent canary.

--- a/docs/pre-api-freeze.md
+++ b/docs/pre-api-freeze.md
@@ -24,24 +24,41 @@ Only verification, documentation, and guardrail fixes are allowed.
 
 All of these must pass before the first real canary run.
 
-| Gate | Required result |
-|---|---|
-| Static Site Check | PASS |
-| Safety Check | PASS |
-| Exception Matrix Test | PASS |
-| Multi-Fuzz Test | PASS |
-| Collect Votes Test | PASS |
-| Select Eligible Test | PASS |
-| Weekly Auto no-eligible selector test | PASS |
-| Implementation Preflight Test | PASS |
-| Lean Proof Test | PASS |
-| Weekly Report Draft workflow | PASS, report PR only |
-| Weekly Mock Run workflow | PASS, summary PR + mock implementation PR only |
-| Weekly Auto Run no-eligible workflow | PASS, summary PR only |
+| Gate | Required result | Current evidence |
+|---|---|---|
+| Static Site Check | PASS | CI |
+| Safety Check | PASS | CI |
+| Exception Matrix Test | PASS | CI |
+| Multi-Fuzz Test | PASS | CI |
+| Collect Votes Test | PASS | CI |
+| Select Eligible Test | PASS | CI |
+| Weekly Auto no-eligible selector test | PASS | CI |
+| Implementation Preflight Test | PASS | CI |
+| Lean Proof Test | PASS | CI |
+| Weekly Report Draft workflow | PASS, report PR only | completed before canary |
+| Weekly Mock Run workflow | PASS, summary PR + mock implementation PR only | completed before canary |
+| Weekly Auto Run no-eligible workflow | PASS, summary PR only | PR #81 |
+| Evidence Pipeline Dry Run with `source=live` | PASS, artifact review only | not yet verified |
 
 ## Real API canary entry condition
 
-A real implementation-agent canary is allowed only after the no-eligible production workflow path proves that it does not request secrets, install API dependencies, run preflight, or call the model when no prompt beats the baseline.
+A real implementation-agent canary is allowed only after:
+
+```text
+Weekly Auto Run no-eligible path has produced only a summary PR
+Evidence Pipeline Dry Run source=live has produced reviewable artifacts
+the live artifact review passes docs/evidence-artifact-review.md
+```
+
+The no-eligible production path was verified in PR #81:
+
+```text
+changed file: runs/week-2026-W19-vote-summary.md
+baseline_won: true
+eligible_count: 0
+eligible_ranks: []
+implementation PR created: no
+```
 
 ## Canary constraints
 

--- a/scripts/pre_api_freeze_audit.py
+++ b/scripts/pre_api_freeze_audit.py
@@ -31,6 +31,8 @@ REQUIRED_SUBSTRINGS: dict[str, list[str]] = {
         "no hidden retry",
         "no fallback model",
         "Weekly Auto Run no-eligible workflow",
+        "Evidence Pipeline Dry Run with `source=live`",
+        "PR #81",
         "gpt-5-nano",
         "workflow attempts to auto-merge",
     ],
@@ -50,9 +52,11 @@ REQUIRED_SUBSTRINGS: dict[str, list[str]] = {
         "workflow attempts auto-merge",
     ],
     "docs/current-features.md": [
+        "no-eligible production workflow path: verified",
         "real implementation-agent canary: not yet executed",
         "production autonomy: not complete",
-        "Run one final no-eligible workflow test before any paid implementation-agent canary.",
+        "Evidence Pipeline Dry Run",
+        "source=live",
     ],
     "docs/weekly-ops-doctrine.md": [
         "Observe → Orient → Decide → Act → Record → Improve",


### PR DESCRIPTION
## Summary

Records the verified Weekly Auto Run no-eligible production path in the release state docs.

## Changed files

- `docs/current-features.md`
- `docs/pre-api-freeze.md`

## What changed

- Marks the no-eligible production path as verified by PR #81.
- Records that PR #81 changed only the weekly vote summary file.
- Records that baseline won with `eligible_count = 0`.
- Keeps live evidence dry-run artifact review as the remaining pre-canary gate.

## Scope

- Documentation only.
- No `/lab/` changes.
- No workflow changes.
- No threshold changes.
- No generated files committed.
- No API call.