### PR TITLE
Add reusable evidence artifact validator

### DIFF
--- a/docs/evidence-artifact-review.md
+++ b/docs/evidence-artifact-review.md
@@ -8,8 +8,8 @@ Use it after running:
 Actions
 → Evidence Pipeline Dry Run
 → Run workflow
-→ source: fixture
-→ week_id: dry-run-001
+→ source: fixture or live
+→ week_id: <week_id>
 ```
 
 Do not treat a successful workflow run as sufficient evidence. The artifact must be inspected.
@@ -35,6 +35,22 @@ tmp/evidence/reports/hn/week-<week_id>.md
 ```
 
 If any file is missing, the dry run is not acceptable.
+
+## Fast CLI check
+
+After downloading and extracting the artifact so that `tmp/evidence/` exists locally, run:
+
+```bash
+node scripts/validate-evidence-artifact.mjs tmp/evidence <week_id>
+```
+
+Example:
+
+```bash
+node scripts/validate-evidence-artifact.mjs tmp/evidence dry-run-001
+```
+
+The CLI check does not replace human review. It catches missing files, schema mismatches, missing sections, missing baseline data, and identity-like voter fields.
 
 ## Review order
 

--- a/scripts/pre_api_freeze_audit.py
+++ b/scripts/pre_api_freeze_audit.py
@@ -21,6 +21,7 @@ REQUIRED_FILES = [
     "scripts/create-snapshot-summary.mjs",
     "scripts/create-public-briefing.mjs",
     "scripts/run-evidence-artifact-smoke.mjs",
+    "scripts/validate-evidence-artifact.mjs",
     ".github/workflows/weekly-auto-run.yml",
     ".github/workflows/evidence-pipeline-dry-run.yml",
 ]
@@ -66,6 +67,7 @@ REQUIRED_SUBSTRINGS: dict[str, list[str]] = {
     ],
     "docs/evidence-artifact-review.md": [
         "Evidence Pipeline Dry Run",
+        "validate-evidence-artifact.mjs",
         "snapshot-v1.2",
         "snapshot-summary-v1.0",
         "Do-not-post checklist",
@@ -99,10 +101,20 @@ REQUIRED_SUBSTRINGS: dict[str, list[str]] = {
         "Do not treat it as an automated external post",
     ],
     "scripts/run-evidence-artifact-smoke.mjs": [
+        "scripts/validate-evidence-artifact.mjs",
+        "create-weekly-snapshot.mjs",
+        "create-snapshot-summary.mjs",
+        "create-public-briefing.mjs",
+        "create-hn-draft.mjs",
+    ],
+    "scripts/validate-evidence-artifact.mjs": [
         "snapshot-v1.2",
         "snapshot-summary-v1.0",
         "Prompt Vote Lab Briefing",
         "Do-not-post checklist",
+        "weekly_snapshot_started",
+        "weekly_snapshot_finished",
+        "no_change_baseline_candidate",
     ],
     ".github/workflows/weekly-auto-run.yml": [
         "AUTO_IMPLEMENTATION_MODEL: \"gpt-5-nano\"",

--- a/scripts/run-evidence-artifact-smoke.mjs
+++ b/scripts/run-evidence-artifact-smoke.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
-import { mkdir, readFile, rm } from 'node:fs/promises';
+import { mkdir, rm } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
 
 const root = process.env.EVIDENCE_SMOKE_ROOT || 'tmp/evidence-smoke';
 const week = process.env.WEEK_ID || 'artifact-smoke-001';
@@ -51,7 +50,7 @@ run('node', ['scripts/create-hn-draft.mjs'], {
   REPO_URL: 'https://github.com/Unjuno/prompt-vote-lab'
 });
 
-await assertArtifactSet();
+run('node', ['scripts/validate-evidence-artifact.mjs', root, week], {});
 console.log(`Evidence artifact smoke passed: ${root}`);
 
 function run(command, args, env) {
@@ -69,84 +68,4 @@ function run(command, args, env) {
 
   if (result.stdout) process.stdout.write(result.stdout);
   if (result.stderr) process.stderr.write(result.stderr);
-}
-
-async function assertArtifactSet() {
-  const required = [
-    snapshotPath,
-    aggregationLogPath,
-    runLogPath,
-    summaryJsonPath,
-    summaryMarkdownPath,
-    briefingPath,
-    hnDraftPath
-  ];
-
-  for (const file of required) {
-    if (!existsSync(file)) {
-      throw new Error(`Missing artifact: ${file}`);
-    }
-  }
-
-  const snapshot = JSON.parse(await readFile(snapshotPath, 'utf8'));
-  assertEqual(snapshot.schema_version, 'snapshot-v1.2', 'snapshot schema');
-  assertEqual(snapshot.metrics.candidate_count, 4, 'snapshot candidate count');
-  assertEqual(snapshot.no_change_baseline_candidate.votes, 20, 'snapshot baseline votes');
-  assertNoForbiddenIdentityFields(snapshot, snapshotPath);
-
-  const summary = JSON.parse(await readFile(summaryJsonPath, 'utf8'));
-  assertEqual(summary.schema_version, 'snapshot-summary-v1.0', 'summary schema');
-  assertEqual(summary.week_count, 1, 'summary week count');
-  assertNoForbiddenIdentityFields(summary, summaryJsonPath);
-
-  const runLog = await readFile(runLogPath, 'utf8');
-  assertIncludes(runLog, 'Participation Metrics', 'run log metrics');
-  assertIncludes(runLog, 'Ranked Candidates With Baseline', 'run log baseline table');
-
-  const summaryMarkdown = await readFile(summaryMarkdownPath, 'utf8');
-  assertIncludes(summaryMarkdown, 'Weekly Metrics Summary', 'summary markdown title');
-
-  const briefing = await readFile(briefingPath, 'utf8');
-  assertIncludes(briefing, 'Prompt Vote Lab Briefing', 'briefing title');
-  assertIncludes(briefing, '## Observe', 'briefing observe');
-  assertIncludes(briefing, '## Orient', 'briefing orient');
-  assertIncludes(briefing, '## Decide', 'briefing decide');
-  assertIncludes(briefing, '## Act', 'briefing act');
-  assertIncludes(briefing, 'Submit prompt:', 'briefing submit link');
-  assertIncludes(briefing, 'Vote:', 'briefing vote link');
-
-  const hnDraft = await readFile(hnDraftPath, 'utf8');
-  assertIncludes(hnDraft, 'Do-not-post checklist', 'HN draft safety checklist');
-  assertIncludes(hnDraft, 'Run log still contains unrecorded fields.', 'HN draft evidence blocker');
-}
-
-function assertEqual(actual, expected, label) {
-  if (actual !== expected) {
-    throw new Error(`${label}: expected ${expected}, got ${actual}`);
-  }
-}
-
-function assertIncludes(text, expected, label) {
-  if (!text.includes(expected)) {
-    throw new Error(`${label}: missing ${expected}`);
-  }
-}
-
-function assertNoForbiddenIdentityFields(value, location) {
-  const forbidden = new Set(['_voter_logins', 'voter_logins', 'voters', 'reaction_users']);
-  const stack = [{ value, path: '$' }];
-  while (stack.length > 0) {
-    const current = stack.pop();
-    if (!current || current.value === null || typeof current.value !== 'object') continue;
-    if (Array.isArray(current.value)) {
-      current.value.forEach((item, index) => stack.push({ value: item, path: `${current.path}[${index}]` }));
-      continue;
-    }
-    for (const [key, child] of Object.entries(current.value)) {
-      if (forbidden.has(key)) {
-        throw new Error(`${location}: forbidden key ${current.path}.${key}`);
-      }
-      stack.push({ value: child, path: `${current.path}.${key}` });
-    }
-  }
 }

--- a/scripts/validate-evidence-artifact.mjs
+++ b/scripts/validate-evidence-artifact.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+
+const root = process.env.EVIDENCE_ROOT || process.argv[2] || 'tmp/evidence';
+const week = process.env.WEEK_ID || process.argv[3] || inferWeek(root);
+
+const paths = {
+  snapshot: `${root}/data/snapshots/week-${week}.json`,
+  aggregationLog: `${root}/logs/aggregation/week-${week}.jsonl`,
+  runLog: `${root}/runs/week-${week}.md`,
+  summaryJson: `${root}/reports/summary/weekly-metrics.json`,
+  summaryMarkdown: `${root}/reports/summary/weekly-metrics.md`,
+  briefing: `${root}/reports/briefings/week-${week}.md`,
+  hnDraft: `${root}/reports/hn/week-${week}.md`
+};
+
+await validateArtifact();
+console.log(`Evidence artifact validation passed: ${root} week=${week}`);
+
+function inferWeek(base) {
+  const prefix = `${base}/data/snapshots/week-`;
+  const candidates = [];
+  for (const maybe of [
+    'dry-run-001',
+    'artifact-smoke-001',
+    'smoke-001'
+  ]) {
+    if (existsSync(`${prefix}${maybe}.json`)) return maybe;
+  }
+  throw new Error('WEEK_ID is required when the snapshot name is not one of the known smoke defaults');
+}
+
+async function validateArtifact() {
+  for (const [label, file] of Object.entries(paths)) {
+    if (!existsSync(file)) throw new Error(`missing ${label}: ${file}`);
+  }
+
+  const snapshot = JSON.parse(await readFile(paths.snapshot, 'utf8'));
+  assertEqual(snapshot.schema_version, 'snapshot-v1.2', 'snapshot schema');
+  assertEqual(snapshot.selection_rule?.no_change_baseline, 20, 'selection baseline');
+  assertEqual(snapshot.no_change_baseline_candidate?.votes, 20, 'baseline candidate votes');
+  assertArray(snapshot.top_prompts, 'top_prompts');
+  if (snapshot.top_prompts.length > 3) throw new Error('top_prompts must contain at most 3 prompts');
+  assertObject(snapshot.metrics, 'snapshot metrics');
+  assertNoForbiddenIdentityFields(snapshot, paths.snapshot);
+
+  const aggregationLog = await readFile(paths.aggregationLog, 'utf8');
+  assertIncludes(aggregationLog, 'weekly_snapshot_started', 'aggregation start event');
+  assertIncludes(aggregationLog, 'weekly_snapshot_finished', 'aggregation finish event');
+
+  const runLog = await readFile(paths.runLog, 'utf8');
+  assertIncludes(runLog, 'Participation Metrics', 'run log metrics');
+  assertIncludes(runLog, 'Ranked Candidates With Baseline', 'run log baseline table');
+  assertIncludes(runLog, 'Selection Rule', 'run log selection rule');
+
+  const summary = JSON.parse(await readFile(paths.summaryJson, 'utf8'));
+  assertEqual(summary.schema_version, 'snapshot-summary-v1.0', 'summary schema');
+  if (!Number.isInteger(summary.week_count) || summary.week_count < 1) throw new Error('summary week_count must be >= 1');
+  assertObject(summary.latest_week, 'summary latest_week');
+  assertObject(summary.trend, 'summary trend');
+  assertNoForbiddenIdentityFields(summary, paths.summaryJson);
+
+  const summaryMarkdown = await readFile(paths.summaryMarkdown, 'utf8');
+  assertIncludes(summaryMarkdown, 'Weekly Metrics Summary', 'summary markdown title');
+
+  const briefing = await readFile(paths.briefing, 'utf8');
+  assertIncludes(briefing, 'Prompt Vote Lab Briefing', 'briefing title');
+  assertIncludes(briefing, '## Observe', 'briefing observe');
+  assertIncludes(briefing, '## Orient', 'briefing orient');
+  assertIncludes(briefing, '## Decide', 'briefing decide');
+  assertIncludes(briefing, '## Act', 'briefing act');
+  assertIncludes(briefing, 'Submit prompt:', 'briefing submit link');
+  assertIncludes(briefing, 'Vote:', 'briefing vote link');
+  assertNoForbiddenText(briefing, paths.briefing);
+
+  const hnDraft = await readFile(paths.hnDraft, 'utf8');
+  assertIncludes(hnDraft, 'Do-not-post checklist', 'HN draft checklist');
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual !== expected) throw new Error(`${label}: expected ${expected}, got ${actual}`);
+}
+
+function assertIncludes(text, expected, label) {
+  if (!text.includes(expected)) throw new Error(`${label}: missing ${expected}`);
+}
+
+function assertArray(value, label) {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+}
+
+function assertObject(value, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+}
+
+function assertNoForbiddenText(text, location) {
+  for (const needle of ['_voter_logins', 'voter_logins', 'reaction_users']) {
+    if (text.includes(needle)) throw new Error(`${location}: forbidden text ${needle}`);
+  }
+}
+
+function assertNoForbiddenIdentityFields(value, location) {
+  const forbidden = new Set(['_voter_logins', 'voter_logins', 'voters', 'reaction_users']);
+  const stack = [{ value, path: '$' }];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current || current.value === null || typeof current.value !== 'object') continue;
+    if (Array.isArray(current.value)) {
+      current.value.forEach((item, index) => stack.push({ value: item, path: `${current.path}[${index}]` }));
+      continue;
+    }
+    for (const [key, child] of Object.entries(current.value)) {
+      if (forbidden.has(key)) throw new Error(`${location}: forbidden key ${current.path}.${key}`);
+      stack.push({ value: child, path: `${current.path}.${key}` });
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a reusable validator for Evidence Pipeline Dry Run artifacts.

## Changed files

- `scripts/validate-evidence-artifact.mjs`
- `scripts/run-evidence-artifact-smoke.mjs`
- `docs/evidence-artifact-review.md`
- `scripts/pre_api_freeze_audit.py`

## What changed

- Adds a CLI validator for downloaded artifact directories.
- Reuses the validator from the existing artifact smoke runner.
- Documents the validator command in the artifact review guide.
- Adds the validator to the pre-API freeze audit requirements.

## Scope

- Validation and documentation only.
- No `/lab/` changes.
- No workflow behavior changes.
- No threshold changes.
- No generated files committed.
- No API call.