### PR TITLE
Require dry-run validator in freeze audit

### DIFF
--- a/scripts/pre_api_freeze_audit.py
+++ b/scripts/pre_api_freeze_audit.py
@@ -130,6 +130,7 @@ REQUIRED_SUBSTRINGS: dict[str, list[str]] = {
         "weekly-metrics.json",
         "week-${WEEK_ID}.md",
         "Do-not-post checklist",
+        "validate-evidence-artifact.mjs",
         "Upload evidence pipeline dry-run artifact",
     ],
 }


### PR DESCRIPTION
## Summary

Makes the freeze audit require the dry-run workflow to call the artifact validator.

## Changed files

- `scripts/pre_api_freeze_audit.py`

## Scope

- Audit check only.
- No `/lab/` changes.
- No workflow changes.
- No generated files committed.