### PR TITLE
Add dry-run validator audit test

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Run pre-API freeze audit self-test
         run: python scripts/test_pre_api_freeze_audit.py
 
+      - name: Run validator audit test
+        run: python scripts/test_dry_run_validator_audit.py
+
       - name: Run weekly no-eligible selector test
         run: python scripts/test_weekly_auto_no_eligible.py
 

--- a/scripts/test_dry_run_validator_audit.py
+++ b/scripts/test_dry_run_validator_audit.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = Path(tmp) / "repo"
+        shutil.copytree(
+            ROOT,
+            repo,
+            ignore=shutil.ignore_patterns(".git", "tmp", ".DS_Store"),
+        )
+        workflow = repo / ".github" / "workflows" / "evidence-pipeline-dry-run.yml"
+        text = workflow.read_text(encoding="utf-8")
+        changed = "\n".join(
+            line for line in text.splitlines()
+            if "validate-evidence-artifact.mjs" not in line
+        ) + "\n"
+        workflow.write_text(changed, encoding="utf-8")
+
+        result = subprocess.run(
+            ["python", "scripts/pre_api_freeze_audit.py"],
+            cwd=repo,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        output = f"{result.stdout}\n{result.stderr}"
+        print(output)
+        if result.returncode == 0:
+            raise SystemExit("expected audit to reject missing dry-run validator call")
+        if "validate-evidence-artifact.mjs" not in output:
+            raise SystemExit("expected audit output to mention validate-evidence-artifact.mjs")
+
+    print("dry-run validator audit self-test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a Script Check test for the dry-run artifact validator audit condition.

## Changed files

- `scripts/test_dry_run_validator_audit.py`
- `.github/workflows/script-check.yml`

## Scope

- Test only.
- No `/lab/` changes.
- No generated files committed.