### PR TITLE
Align implementation runner output cap

### DIFF
--- a/scripts/openai_lab_run.py
+++ b/scripts/openai_lab_run.py
@@ -37,6 +37,7 @@ LAB_FILES = {
 }
 
 MAX_PROMPT_CHARS = int(os.getenv("MAX_IMPLEMENTATION_PROMPT_CHARS", "120000"))
+MAX_OUTPUT_TOKENS_LIMIT = 5000
 
 
 SCHEMA = {
@@ -146,7 +147,7 @@ def main() -> int:
     parser.add_argument("--vote-count", default="unrecorded")
     parser.add_argument("--run-reason", default="normal-weekly-run")
     parser.add_argument("--model", default=os.getenv("IMPLEMENTATION_MODEL", "gpt-5-nano"))
-    parser.add_argument("--max-output-tokens", type=int, default=int(os.getenv("MAX_OUTPUT_TOKENS", "12000")))
+    parser.add_argument("--max-output-tokens", type=int, default=int(os.getenv("MAX_OUTPUT_TOKENS", "5000")))
     parser.add_argument("--temperature-policy", default=os.getenv("TEMPERATURE_POLICY", "model-default"))
     parser.add_argument("--top-p-policy", default=os.getenv("TOP_P_POLICY", "model-default"))
     parser.add_argument("--summary-out", default=".tmp/implementation-summary.md")
@@ -154,8 +155,11 @@ def main() -> int:
 
     api_key = resolve_openai_api_key()
 
-    if args.max_output_tokens > 12000:
-        print("max_output_tokens above 12000 is not allowed for implementation-agent attempts", file=sys.stderr)
+    if args.max_output_tokens > MAX_OUTPUT_TOKENS_LIMIT:
+        print(
+            f"max_output_tokens above {MAX_OUTPUT_TOKENS_LIMIT} is not allowed for implementation-agent attempts",
+            file=sys.stderr,
+        )
         return 2
 
     prompt = build_prompt(args)

--- a/scripts/pre_api_freeze_audit.py
+++ b/scripts/pre_api_freeze_audit.py
@@ -21,6 +21,7 @@ REQUIRED_FILES = [
     "lean-toolchain",
     "scripts/select_eligible.py",
     "scripts/preflight_implementation_agent.py",
+    "scripts/openai_lab_run.py",
     "scripts/create-weekly-snapshot.mjs",
     "scripts/create-snapshot-summary.mjs",
     "scripts/create-public-briefing.mjs",
@@ -142,6 +143,14 @@ REQUIRED_SUBSTRINGS: dict[str, list[str]] = {
         "api_call_performed",
         "False",
     ],
+    "scripts/openai_lab_run.py": [
+        "OpenAI(api_key=api_key, max_retries=0, timeout=120.0)",
+        "MAX_OUTPUT_TOKENS_LIMIT = 5000",
+        "MAX_OUTPUT_TOKENS", "5000",
+        "if args.max_output_tokens > MAX_OUTPUT_TOKENS_LIMIT",
+        "This is one bounded implementation-agent attempt.",
+        "Do not create additional files.",
+    ],
     "scripts/create-weekly-snapshot.mjs": [
         "snapshot-v1.2",
         "no_change_baseline_candidate",
@@ -212,6 +221,14 @@ FORBIDDEN_SUBSTRINGS: dict[str, list[str]] = {
         "MAX_OUTPUT_TOKENS_LIMIT = 12000",
         "api_call_performed\": True",
         "sdk_max_retries != 1",
+    ],
+    "scripts/openai_lab_run.py": [
+        "MAX_OUTPUT_TOKENS_LIMIT = 12000",
+        "MAX_OUTPUT_TOKENS", "12000",
+        "args.max_output_tokens > 12000",
+        "max_output_tokens above 12000",
+        "max_retries=1",
+        "max_retries=2",
     ],
 }
 

--- a/scripts/pre_api_freeze_audit.py
+++ b/scripts/pre_api_freeze_audit.py
@@ -146,7 +146,8 @@ REQUIRED_SUBSTRINGS: dict[str, list[str]] = {
     "scripts/openai_lab_run.py": [
         "OpenAI(api_key=api_key, max_retries=0, timeout=120.0)",
         "MAX_OUTPUT_TOKENS_LIMIT = 5000",
-        "MAX_OUTPUT_TOKENS", "5000",
+        "MAX_OUTPUT_TOKENS",
+        "5000",
         "if args.max_output_tokens > MAX_OUTPUT_TOKENS_LIMIT",
         "This is one bounded implementation-agent attempt.",
         "Do not create additional files.",
@@ -224,7 +225,7 @@ FORBIDDEN_SUBSTRINGS: dict[str, list[str]] = {
     ],
     "scripts/openai_lab_run.py": [
         "MAX_OUTPUT_TOKENS_LIMIT = 12000",
-        "MAX_OUTPUT_TOKENS", "12000",
+        "os.getenv(\"MAX_OUTPUT_TOKENS\", \"12000\")",
         "args.max_output_tokens > 12000",
         "max_output_tokens above 12000",
         "max_retries=1",

--- a/scripts/test_canary_policy_alignment.py
+++ b/scripts/test_canary_policy_alignment.py
@@ -51,6 +51,12 @@ REQUIRED = {
         "api_call_limit != 1",
         "MAX_OUTPUT_TOKENS_LIMIT = 5000",
     ],
+    "scripts/openai_lab_run.py": [
+        "OpenAI(api_key=api_key, max_retries=0, timeout=120.0)",
+        "MAX_OUTPUT_TOKENS_LIMIT = 5000",
+        "os.getenv(\"MAX_OUTPUT_TOKENS\", \"5000\")",
+        "if args.max_output_tokens > MAX_OUTPUT_TOKENS_LIMIT",
+    ],
     ".github/workflows/weekly-auto-run.yml": [
         "AUTO_IMPLEMENTATION_MODEL: \"gpt-5-nano\"",
         "MAX_OUTPUT_TOKENS: \"5000\"",
@@ -81,6 +87,14 @@ FORBIDDEN = {
         "sdk_max_retries != 1",
         "api_call_limit != 2",
         "MAX_OUTPUT_TOKENS_LIMIT = 12000",
+    ],
+    "scripts/openai_lab_run.py": [
+        "MAX_OUTPUT_TOKENS_LIMIT = 12000",
+        "os.getenv(\"MAX_OUTPUT_TOKENS\", \"12000\")",
+        "args.max_output_tokens > 12000",
+        "max_output_tokens above 12000",
+        "max_retries=1",
+        "max_retries=2",
     ],
     ".github/workflows/weekly-auto-run.yml": [
         "AUTO_IMPLEMENTATION_MODEL: \"gpt-5\"",


### PR DESCRIPTION
## Summary

Aligns `scripts/openai_lab_run.py` with the 5000-token first-canary limit and adds audit coverage so the runner cannot silently drift back to 12000.

## Changed files

- `scripts/openai_lab_run.py`
- `scripts/pre_api_freeze_audit.py`
- `scripts/test_canary_policy_alignment.py`

## Scope

- Guardrail alignment only.
- No `/lab/` changes.
- No workflow dispatch.
- No API canary.

## Blocker resolved

Before this change, workflow/preflight/docs said 5000, while the implementation runner still allowed/defaulted to 12000.