### PR TITLE
Tighten release readiness guardrails

### DIFF
--- a/.github/workflows/lean-proof-test.yml
+++ b/.github/workflows/lean-proof-test.yml
@@ -29,6 +29,17 @@ jobs:
         run: |
           lean --version
 
-      - name: Check selection proof
+      - name: Check all formal proofs
+        shell: bash
         run: |
-          lean formal/Selection.lean
+          set -euo pipefail
+          shopt -s nullglob
+          files=(formal/*.lean formal/**/*.lean)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No Lean files found under formal/."
+            exit 1
+          fi
+          for file in "${files[@]}"; do
+            echo "Checking ${file}"
+            lean "$file"
+          done

--- a/docs/current-features.md
+++ b/docs/current-features.md
@@ -105,7 +105,7 @@ Prepared but not yet executed:
 - one implementation attempt per candidate
 - SDK retry must be 0
 - no fallback model
-- max output tokens capped at 12000
+- max output tokens capped at 5000
 - eligible candidate secret requirement
 - no-eligible path does not require implementation-agent secret
 - preflight script before API dependency install
@@ -167,6 +167,7 @@ Verified:
 Implemented:
 
 - Lean 4 model under `formal/Selection.lean`
+- Lean 4 model under `formal/Canary.lean`
 - `lean-toolchain`
 - CI workflow for Lean proof checking
 
@@ -176,11 +177,13 @@ Currently proven:
 baselineWon candidates = true -> selectEligible candidates support = []
 baseline candidate is not individually eligible
 other candidate is not individually eligible
+first canary policy satisfies the closed canary safety predicate
+safe canary implies lab-only scope, one attempt, no SDK retry, one API call, no fallback, no auto-merge, and no external publishing
 ```
 
 Scope limitation:
 
-The Lean proof models the closed selection core. It does not prove the full GitHub Actions runtime, GitHub API behavior, or model output behavior.
+The Lean proof models the closed selection and canary-policy cores. It does not prove the full GitHub Actions runtime, GitHub API behavior, or model output behavior.
 
 ## Reporting
 

--- a/formal/Canary.lean
+++ b/formal/Canary.lean
@@ -56,7 +56,8 @@ theorem safe_canary_one_attempt
   cases policy with
   | mk scope attempts sdkMaxRetries apiCallsPerCandidate fallbackModel autoMerge externalPublishing =>
       cases scope <;> simp [safeCanary] at h
-      exact h.1
+      rcases h with ⟨⟨⟨⟨⟨h_attempts, _h_retries⟩, _h_api⟩, _h_fallback⟩, _h_auto⟩, _h_external⟩
+      exact h_attempts
 
 theorem safe_canary_no_sdk_retry
     (policy : CanaryPolicy) :
@@ -65,7 +66,8 @@ theorem safe_canary_no_sdk_retry
   cases policy with
   | mk scope attempts sdkMaxRetries apiCallsPerCandidate fallbackModel autoMerge externalPublishing =>
       cases scope <;> simp [safeCanary] at h
-      exact h.2.1
+      rcases h with ⟨⟨⟨⟨⟨_h_attempts, h_retries⟩, _h_api⟩, _h_fallback⟩, _h_auto⟩, _h_external⟩
+      exact h_retries
 
 theorem safe_canary_one_api_call
     (policy : CanaryPolicy) :
@@ -74,7 +76,8 @@ theorem safe_canary_one_api_call
   cases policy with
   | mk scope attempts sdkMaxRetries apiCallsPerCandidate fallbackModel autoMerge externalPublishing =>
       cases scope <;> simp [safeCanary] at h
-      exact h.2.2.1
+      rcases h with ⟨⟨⟨⟨⟨_h_attempts, _h_retries⟩, h_api⟩, _h_fallback⟩, _h_auto⟩, _h_external⟩
+      exact h_api
 
 theorem safe_canary_no_fallback
     (policy : CanaryPolicy) :
@@ -83,7 +86,8 @@ theorem safe_canary_no_fallback
   cases policy with
   | mk scope attempts sdkMaxRetries apiCallsPerCandidate fallbackModel autoMerge externalPublishing =>
       cases scope <;> simp [safeCanary] at h
-      exact h.2.2.2.1
+      rcases h with ⟨⟨⟨⟨⟨_h_attempts, _h_retries⟩, _h_api⟩, h_fallback⟩, _h_auto⟩, _h_external⟩
+      exact h_fallback
 
 theorem safe_canary_no_auto_merge
     (policy : CanaryPolicy) :
@@ -92,7 +96,8 @@ theorem safe_canary_no_auto_merge
   cases policy with
   | mk scope attempts sdkMaxRetries apiCallsPerCandidate fallbackModel autoMerge externalPublishing =>
       cases scope <;> simp [safeCanary] at h
-      exact h.2.2.2.2.1
+      rcases h with ⟨⟨⟨⟨⟨_h_attempts, _h_retries⟩, _h_api⟩, _h_fallback⟩, h_auto⟩, _h_external⟩
+      exact h_auto
 
 theorem safe_canary_no_external_publishing
     (policy : CanaryPolicy) :
@@ -101,6 +106,7 @@ theorem safe_canary_no_external_publishing
   cases policy with
   | mk scope attempts sdkMaxRetries apiCallsPerCandidate fallbackModel autoMerge externalPublishing =>
       cases scope <;> simp [safeCanary] at h
-      exact h.2.2.2.2.2
+      rcases h with ⟨⟨⟨⟨⟨_h_attempts, _h_retries⟩, _h_api⟩, _h_fallback⟩, _h_auto⟩, h_external⟩
+      exact h_external
 
 end PromptVoteLab


### PR DESCRIPTION
## Summary

Keeps the existing `Weekly Auto Run` structure intact and applies only release-readiness guardrail fixes.

## Changed files

- `.github/workflows/lean-proof-test.yml`
- `formal/Canary.lean`
- `docs/current-features.md`

## What changed

- `Lean Proof Test` now checks every Lean file under `formal/`, not only `formal/Selection.lean`.
- `formal/Canary.lean` proof decomposition was fixed after the expanded CI exposed that it had not actually been checked before.
- `docs/current-features.md` now reflects the current implementation-agent guardrail of `max output tokens capped at 5000`.
- The feature inventory now records that `formal/Canary.lean` exists and states the canary-policy proof coverage.

## What this deliberately does not change

- Does not remove `weekly-auto-run.yml`.
- Does not split the weekly workflow.
- Does not run the API canary.
- Does not change `/lab/`.
- Does not change model, retry, fallback, or auto-merge behavior.

## CI result

- Lean Proof Test: PASS
- Static Site Check: PASS
- Lab PR Scope Check: PASS
- Pre-API Freeze Audit: PASS

## Release relevance

This PR reduces release ambiguity before the first API canary by making the formal proof check match the files that exist and making documentation match the 5000-token canary guardrail.