### PR TITLE
Test terminal report metadata gate

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Run canary policy alignment test
         run: python scripts/test_canary_policy_alignment.py
 
+      - name: Run terminal metadata extraction test
+        run: python scripts/test_extract_pr_metadata.py
+
       - name: Run weekly no-eligible selector test
         run: python scripts/test_weekly_auto_no_eligible.py
 

--- a/scripts/test_extract_pr_metadata.py
+++ b/scripts/test_extract_pr_metadata.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "extract_pr_metadata.py"
+
+
+def run_extract(body: str, labels: list[str]) -> dict[str, object]:
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        body_file = tmp_path / "body.md"
+        out_file = tmp_path / "out.json"
+        body_file.write_text(body, encoding="utf-8")
+        labels_json = json.dumps([{"name": label} for label in labels])
+        subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--body-file",
+                str(body_file),
+                "--labels-json",
+                labels_json,
+                "--out",
+                str(out_file),
+            ],
+            check=True,
+            cwd=ROOT,
+        )
+        return json.loads(out_file.read_text(encoding="utf-8"))
+
+
+def test_ordinary_maintenance_pr_remains_unrecorded() -> None:
+    data = run_extract(
+        """## Summary
+
+Tightens release readiness guardrails.
+
+## Changed files
+
+- docs/current-features.md
+""",
+        [],
+    )
+    assert data["week"] == "unrecorded"
+    assert data["candidate_rank"] == "unrecorded"
+    assert data["issue_number"] == "unrecorded"
+    assert data["vote_count"] == "unrecorded"
+    assert data["selected_prompt"] == "unrecorded"
+    assert data["terminal_state"] == "unrecorded"
+
+
+def test_run_pr_metadata_is_extracted() -> None:
+    data = run_extract(
+        """Implements the selected ranked prompt candidate with the fixed implementation agent.
+
+## Candidate
+
+- Week: week-2026-W19
+- Rank: 1
+- Issue: #12
+- Votes: 24
+- Run reason: normal-weekly-run
+
+## Selected prompt
+
+Add a compact run-history section to /lab/.
+
+## Implementation summary
+
+Changed lab/index.html only.
+""",
+        ["pvl:merged"],
+    )
+    assert data["week"] == "week-2026-W19"
+    assert data["candidate_rank"] == "1"
+    assert data["issue_number"] == "12"
+    assert data["vote_count"] == "24"
+    assert data["run_reason"] == "normal-weekly-run"
+    assert data["selected_prompt"] == "Add a compact run-history section to /lab/."
+    assert data["terminal_state"] == "merged"
+
+
+def main() -> int:
+    test_ordinary_maintenance_pr_remains_unrecorded()
+    test_run_pr_metadata_is_extracted()
+    print("extract PR metadata tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a regression test for terminal report metadata extraction.

## Problem

A normal maintenance PR can have no run metadata. Terminal reports must not treat that as valid run evidence.

## Changed files

- `scripts/test_extract_pr_metadata.py`
- `.github/workflows/script-check.yml`

## What this tests

- Ordinary maintenance PR body remains `unrecorded`.
- Real run PR body extracts:
  - week
  - rank
  - issue
  - votes
  - run reason
  - selected prompt
  - terminal state from `pvl:merged`

## What this deliberately does not change

- Does not modify `/lab/`.
- Does not call the OpenAI API.
- Does not change `weekly-auto-run.yml`.
- Does not change `first-canary-run.yml`.

## Release relevance

This makes the terminal report gate testable before the first real API canary.