### PR TITLE
Add Codex first canary workflow

### DIFF
--- a/.github/workflows/codex-first-canary-run.yml
+++ b/.github/workflows/codex-first-canary-run.yml
@@ -52,6 +52,20 @@ jobs:
           - Do not commit, branch, or open a PR. The workflow will do that.
           EOF
 
-      - name: Placeholder
+      - name: Run Codex once
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY_ }}
         run: |
-          echo "Codex execution step is added in a follow-up patch."
+          if [ -z "$OPENAI_API_KEY" ]; then
+            echo "OPENAI_API_KEY_ secret is not configured."
+            exit 1
+          fi
+          codex exec \
+            --cd "$PWD" \
+            --model "$CODEX_MODEL" \
+            --sandbox workspace-write \
+            --ask-for-approval never \
+            --json \
+            --output-last-message .tmp/codex-last-message.txt \
+            - < .tmp/codex-first-canary-prompt.md \
+            > .tmp/codex-events.jsonl

--- a/.github/workflows/codex-first-canary-run.yml
+++ b/.github/workflows/codex-first-canary-run.yml
@@ -85,3 +85,106 @@ jobs:
           done
           bash scripts/safety-check.sh origin/main HEAD
           bash scripts/static-site-check.sh
+
+      - name: Write public run log
+        if: ${{ always() }}
+        run: |
+          mkdir -p .tmp
+          base_sha="$(git rev-parse origin/main 2>/dev/null || echo unrecorded)"
+          changed_csv="$(git diff --name-only -- 2>/dev/null | paste -sd, -)"
+          status="passed"
+          if [ "${{ job.status }}" != "success" ]; then status="failed"; fi
+          python scripts/write_public_run_log.py \
+            --out .tmp/public-run-log.json \
+            --provider openai-codex \
+            --runner codex-cli \
+            --model "$CODEX_MODEL" \
+            --workflow "Codex First Canary Run" \
+            --run-number "${{ github.run_number }}" \
+            --week "$RUN_WEEK" \
+            --candidate-rank 1 \
+            --issue-number 0 \
+            --vote-count 0 \
+            --base-sha "$base_sha" \
+            --branch "codex-first-canary-001-${{ github.run_number }}" \
+            --attempt-count 1 \
+            --retry-policy none \
+            --fallback-policy none \
+            --auto-merge-policy disabled \
+            --status "$status" \
+            --changed-files "$changed_csv"
+
+      - name: Upload public run log
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-first-canary-public-log-${{ github.run_number }}
+          path: .tmp/public-run-log.json
+          if-no-files-found: warn
+
+      - name: Commit and create PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branch="codex-first-canary-001-${{ github.run_number }}"
+          base_sha="$(git rev-parse origin/main)"
+          prompt="$(cat .tmp/first-canary-prompt.txt)"
+          changed_files="$(git diff --name-only -- | paste -sd ', ' -)"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add lab/index.html lab/style.css lab/app.js
+          git commit -m "Run Codex first canary"
+          git push --set-upstream origin "$branch"
+
+          cat > .tmp/codex-first-canary-pr-body.md <<EOF
+          Implements the fixed first Codex implementation-agent canary.
+
+          ## Purpose
+
+          This is execution-path verification for the Codex runner, not product expansion.
+
+          ## Configuration
+
+          - Week: $RUN_WEEK
+          - Rank: 1
+          - Issue: #0
+          - Votes: 0
+          - Inherited lab base: \`$base_sha\`
+          - Provider: \`openai-codex\`
+          - Runner: \`codex-cli\`
+          - Codex model: \`$CODEX_MODEL\`
+          - Attempts: \`1\`
+          - Retry policy: \`none\`
+          - Fallback: \`none\`
+          - Auto-merge: disabled
+
+          ## Selected prompt
+
+          $prompt
+
+          ## Changed files
+
+          $changed_files
+
+          ## Internal checks
+
+          - safety-check passed before PR creation
+          - static-site-check passed before PR creation
+          - changed-file guard passed before PR creation
+
+          ## Public run log
+
+          Redacted public run log is uploaded as a workflow artifact. Raw stderr, raw Codex JSONL, raw model output, and secrets are not published.
+
+          ## Merge policy
+
+          Manual review is required. Do not auto-merge.
+          EOF
+
+          gh pr create \
+            --title "Run Codex first canary" \
+            --body-file .tmp/codex-first-canary-pr-body.md \
+            --base main \
+            --head "$branch"

--- a/.github/workflows/codex-first-canary-run.yml
+++ b/.github/workflows/codex-first-canary-run.yml
@@ -69,3 +69,19 @@ jobs:
             --output-last-message .tmp/codex-last-message.txt \
             - < .tmp/codex-first-canary-prompt.md \
             > .tmp/codex-events.jsonl
+
+      - name: Validate changed files and checks
+        run: |
+          changed_files="$(git diff --name-only --)"
+          if [ -z "$changed_files" ]; then
+            echo "Codex produced no changes."
+            exit 1
+          fi
+          echo "$changed_files" | while read -r file; do
+            case "$file" in
+              lab/index.html|lab/style.css|lab/app.js) ;;
+              *) echo "Forbidden changed file: $file"; exit 1 ;;
+            esac
+          done
+          bash scripts/safety-check.sh origin/main HEAD
+          bash scripts/static-site-check.sh

--- a/.github/workflows/codex-first-canary-run.yml
+++ b/.github/workflows/codex-first-canary-run.yml
@@ -1,0 +1,57 @@
+name: Codex First Canary Run
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: codex-first-canary-run
+  cancel-in-progress: false
+
+jobs:
+  codex-first-canary-run:
+    runs-on: ubuntu-latest
+    env:
+      CODEX_MODEL: gpt-5.1-codex
+      RUN_WEEK: first-canary-001
+      CODEX_HOME: ${{ github.workspace }}/.codex-home
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Codex CLI
+        run: |
+          npm install -g @openai/codex
+          codex --version
+
+      - name: Build fixed Codex prompt
+        run: |
+          python scripts/create_first_canary_candidate.py
+          mkdir -p .tmp
+          cat > .tmp/codex-first-canary-prompt.md <<'EOF'
+          You are Codex running inside the Prompt Vote Lab repository.
+
+          Goal: add a small static canary panel inside lab/ explaining that this is the first bounded Codex implementation-agent canary.
+
+          Constraints:
+          - Edit only lab/index.html, lab/style.css, and/or lab/app.js.
+          - Keep the visible change small and reviewable.
+          - Do not edit workflows, scripts, docs, rules, formal proofs, run records, package files, or configuration files.
+          - Do not add external network calls, external scripts, cookies, analytics, login, payment behavior, dependencies, or eval.
+          - Do not change voting, selection, evidence, report, or canary policy logic.
+          - Do not commit, branch, or open a PR. The workflow will do that.
+          EOF
+
+      - name: Placeholder
+        run: |
+          echo "Codex execution step is added in a follow-up patch."

--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Run terminal metadata extraction test
         run: python scripts/test_extract_pr_metadata.py
 
+      - name: Run public run log writer test
+        run: python scripts/test_write_public_run_log.py
+
       - name: Run weekly no-eligible selector test
         run: python scripts/test_weekly_auto_no_eligible.py
 

--- a/scripts/test_write_public_run_log.py
+++ b/scripts/test_write_public_run_log.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "write_public_run_log.py"
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="pvl-public-log-") as tmp_name:
+        out = Path(tmp_name) / "public-run-log.json"
+        subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--out",
+                str(out),
+                "--provider",
+                "openai-codex",
+                "--runner",
+                "codex-cli",
+                "--model",
+                "gpt-5.1-codex",
+                "--workflow",
+                "Codex First Canary Run",
+                "--run-number",
+                "1",
+                "--week",
+                "first-canary-001",
+                "--candidate-rank",
+                "1",
+                "--issue-number",
+                "0",
+                "--vote-count",
+                "0",
+                "--base-sha",
+                "abc123",
+                "--branch",
+                "codex-first-canary-001-1",
+                "--attempt-count",
+                "1",
+                "--retry-policy",
+                "none",
+                "--fallback-policy",
+                "none",
+                "--auto-merge-policy",
+                "disabled",
+                "--status",
+                "failed",
+                "--failure-step",
+                "Run Codex once",
+                "--failure-type",
+                "workflow_failure",
+                "--error-summary",
+                "redacted error summary",
+                "--changed-files",
+                "lab/index.html,lab/style.css",
+                "--checks",
+                '{"safety-check":"not-run"}',
+            ],
+            check=True,
+            cwd=ROOT,
+        )
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert data["schema"] == "prompt-vote-lab-public-run-log-v1"
+        assert data["provider"] == "openai-codex"
+        assert data["runner"] == "codex-cli"
+        assert data["status"] == "failed"
+        assert data["changed_files"] == ["lab/index.html", "lab/style.css"]
+        assert data["checks"]["safety-check"] == "not-run"
+        assert data["redaction"]["raw_stderr"] == "not published"
+        assert data["redaction"]["raw_model_output"] == "not published"
+        assert data["redaction"]["raw_codex_jsonl"] == "not published"
+
+    print("public run log writer test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/write_public_run_log.py
+++ b/scripts/write_public_run_log.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Write redacted public run logs for Prompt Vote Lab.
+
+This script is API-free and deterministic. It intentionally records public
+experiment evidence without storing raw model output, raw stderr, or secrets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+ALLOWED_STATUSES = {"started", "passed", "failed", "skipped"}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--provider", required=True)
+    parser.add_argument("--runner", required=True)
+    parser.add_argument("--model", default="unrecorded")
+    parser.add_argument("--workflow", required=True)
+    parser.add_argument("--run-number", default="unrecorded")
+    parser.add_argument("--week", default="unrecorded")
+    parser.add_argument("--candidate-rank", default="unrecorded")
+    parser.add_argument("--issue-number", default="unrecorded")
+    parser.add_argument("--vote-count", default="unrecorded")
+    parser.add_argument("--base-sha", default="unrecorded")
+    parser.add_argument("--branch", default="unrecorded")
+    parser.add_argument("--attempt-count", default="1")
+    parser.add_argument("--retry-policy", default="none")
+    parser.add_argument("--fallback-policy", default="none")
+    parser.add_argument("--auto-merge-policy", default="disabled")
+    parser.add_argument("--status", required=True, choices=sorted(ALLOWED_STATUSES))
+    parser.add_argument("--failure-step", default="none")
+    parser.add_argument("--failure-type", default="none")
+    parser.add_argument("--error-summary", default="none")
+    parser.add_argument("--changed-files", default="")
+    parser.add_argument("--checks", default="{}")
+    args = parser.parse_args()
+
+    changed_files = [item for item in args.changed_files.split(",") if item]
+    try:
+        checks: dict[str, Any] = json.loads(args.checks)
+    except json.JSONDecodeError:
+        checks = {"parse_error": "checks was not valid JSON"}
+
+    data = {
+        "schema": "prompt-vote-lab-public-run-log-v1",
+        "provider": args.provider,
+        "runner": args.runner,
+        "model": args.model,
+        "workflow": args.workflow,
+        "run_number": args.run_number,
+        "week": args.week,
+        "candidate_rank": args.candidate_rank,
+        "issue_number": args.issue_number,
+        "vote_count": args.vote_count,
+        "base_sha": args.base_sha,
+        "branch": args.branch,
+        "attempt_count": args.attempt_count,
+        "retry_policy": args.retry_policy,
+        "fallback_policy": args.fallback_policy,
+        "auto_merge_policy": args.auto_merge_policy,
+        "status": args.status,
+        "failure_step": args.failure_step,
+        "failure_type": args.failure_type,
+        "error_summary": args.error_summary[:500],
+        "changed_files": changed_files,
+        "checks": checks,
+        "redaction": {
+            "raw_stderr": "not published",
+            "raw_model_output": "not published",
+            "raw_codex_jsonl": "not published",
+            "secrets": "not published",
+        },
+    }
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the first real Codex-runner canary path.

## Problem

The previous first canary used `scripts/openai_lab_run.py`, which calls the OpenAI Responses API with `gpt-5-nano` and asks for full-file JSON output. That was not a Codex experiment.

## Changed files

- `.github/workflows/codex-first-canary-run.yml`
- `scripts/write_public_run_log.py`
- `scripts/test_write_public_run_log.py`
- `.github/workflows/script-check.yml`

## What this adds

- A manual `Codex First Canary Run` workflow.
- Uses `codex exec` non-interactively.
- Uses `gpt-5.1-codex` as the Codex model label.
- Runs exactly one Codex attempt.
- Restricts accepted changed files to:
  - `lab/index.html`
  - `lab/style.css`
  - `lab/app.js`
- Runs existing internal gates before PR creation:
  - `safety-check.sh`
  - `static-site-check.sh`
  - changed-file guard
- Creates a PR only after those gates pass.
- Uploads a redacted public run log artifact.

## Public log boundary

The public run log records settings, changed files, check summaries, and status. It does not publish raw stderr, raw Codex JSONL, raw model output, or secrets.

## What this deliberately does not change

- Does not remove the legacy Responses API workflow yet.
- Does not modify `/lab/` in this PR.
- Does not run Codex during this PR.
- Does not auto-merge.

## Next step after merge

Run `Codex First Canary Run` manually from Actions. PASS requires one PR, lab-only diff, safety/static checks, and manual review.