### PR TITLE
Fix Codex exec options

### DIFF
--- a/.github/workflows/codex-first-canary-run.yml
+++ b/.github/workflows/codex-first-canary-run.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Install Codex CLI
         run: |
+          mkdir -p "$CODEX_HOME"
           npm install -g @openai/codex
           codex --version
 
@@ -60,11 +61,11 @@ jobs:
             echo "OPENAI_API_KEY_ secret is not configured."
             exit 1
           fi
+          mkdir -p "$CODEX_HOME"
           codex exec \
             --cd "$PWD" \
             --model "$CODEX_MODEL" \
             --sandbox workspace-write \
-            --ask-for-approval never \
             --json \
             --output-last-message .tmp/codex-last-message.txt \
             - < .tmp/codex-first-canary-prompt.md \


### PR DESCRIPTION
## Summary

Fixes the manual `Codex First Canary Run` workflow after the first run failed at `codex exec` option parsing.

## Observed failure

```text
WARNING: proceeding, even though we could not update PATH: CODEX_HOME points to .../.codex-home, but that path does not exist
error: unexpected argument '--ask-for-approval' found
```

## Changed file

- `.github/workflows/codex-first-canary-run.yml`

## What changed

- Creates `CODEX_HOME` before invoking Codex.
- Removes unsupported `--ask-for-approval never` from `codex exec`.
- Leaves `--sandbox workspace-write`, `--json`, and `--output-last-message` intact.

## What this deliberately does not change

- Does not run Codex in this PR.
- Does not modify `/lab/`.
- Does not change the model label.
- Does not alter the public log contract.
- Does not auto-merge anything.

## Next step after merge

Run `Codex First Canary Run` manually again.