### PR TITLE
Delegate Codex canary execution to script

### DIFF
--- a/.github/workflows/codex-first-canary-run.yml
+++ b/.github/workflows/codex-first-canary-run.yml
@@ -56,20 +56,7 @@ jobs:
       - name: Run Codex once
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY_ }}
-        run: |
-          if [ -z "$OPENAI_API_KEY" ]; then
-            echo "OPENAI_API_KEY_ secret is not configured."
-            exit 1
-          fi
-          mkdir -p "$CODEX_HOME"
-          codex exec \
-            --cd "$PWD" \
-            --model "$CODEX_MODEL" \
-            --sandbox workspace-write \
-            --json \
-            --output-last-message .tmp/codex-last-message.txt \
-            - < .tmp/codex-first-canary-prompt.md \
-            > .tmp/codex-events.jsonl
+        run: bash scripts/run_codex_first_canary.sh
 
       - name: Validate changed files and checks
         run: |

--- a/scripts/run_codex_first_canary.sh
+++ b/scripts/run_codex_first_canary.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${OPENAI_API_KEY:-}" ]; then
+  echo "OPENAI_API_KEY is not configured."
+  exit 1
+fi
+
+mkdir -p "${CODEX_HOME:-.codex-home}"
+mkdir -p .tmp
+
+printf '%s' "$OPENAI_API_KEY" | codex login --with-api-key
+
+codex exec \
+  --cd "$PWD" \
+  --model "${CODEX_MODEL:-gpt-5.1-codex}" \
+  --sandbox workspace-write \
+  --json \
+  --output-last-message .tmp/codex-last-message.txt \
+  - < .tmp/codex-first-canary-prompt.md \
+  > .tmp/codex-events.jsonl


### PR DESCRIPTION
## Summary

Moves the `Codex First Canary Run` execution command into a repository script so Codex CLI authentication and invocation can be tested and adjusted without rewriting the workflow body each time.

## Observed issue

The previous Codex canary reached the OpenAI endpoint but failed with `401 Unauthorized`. This suggests the current workflow is reaching the API path, but the Codex CLI authentication path still needs tighter isolation.

## Changed files

- `.github/workflows/codex-first-canary-run.yml`
- `scripts/run_codex_first_canary.sh`

## What changed

- Adds `scripts/run_codex_first_canary.sh`.
- The script checks `OPENAI_API_KEY`, creates `CODEX_HOME`, runs `codex login --with-api-key`, then runs `codex exec`.
- The workflow now delegates the Codex execution step to that script.

## What this deliberately does not change

- Does not change the secret name used by the workflow.
- Does not publish raw stderr, raw Codex JSONL, raw model output, or secrets.
- Does not modify `/lab/`.
- Does not run Codex during this PR.
- Does not auto-merge.

## Next step after merge

Run `Codex First Canary Run` manually again. If it still returns 401, the remaining likely cause is the configured secret value or key permissions, not the workflow option syntax.