### PR TITLE
Pass Codex prompt as argument

### DIFF
--- a/scripts/run_codex_first_canary.sh
+++ b/scripts/run_codex_first_canary.sh
@@ -11,11 +11,13 @@ mkdir -p .tmp
 
 printf '%s' "$OPENAI_API_KEY" | codex login --with-api-key
 
+prompt="$(cat .tmp/codex-first-canary-prompt.md)"
+
 codex exec \
   --cd "$PWD" \
   --model "${CODEX_MODEL:-gpt-5.1-codex}" \
   --sandbox workspace-write \
   --json \
   --output-last-message .tmp/codex-last-message.txt \
-  - < .tmp/codex-first-canary-prompt.md \
+  "$prompt" \
   > .tmp/codex-events.jsonl


### PR DESCRIPTION
## Summary

Fixes the Codex first canary prompt delivery after the latest run authenticated successfully but produced no file changes.

## Observed result

```text
Reading API key from stdin...
Successfully logged in
Codex produced no changes.
```

## Hypothesis

`codex exec ... - < .tmp/codex-first-canary-prompt.md` did not deliver the editing prompt as intended. The command completed without changing files.

## Changed file

- `scripts/run_codex_first_canary.sh`

## What changed

- Reads `.tmp/codex-first-canary-prompt.md` into a shell variable.
- Passes the prompt as the positional argument to `codex exec`.
- Keeps explicit API-key login.
- Keeps `workspace-write`, JSON event output, and last-message capture.

## What this deliberately does not change

- Does not modify `/lab/`.
- Does not run Codex during this PR.
- Does not change the model label.
- Does not change the public log contract.
- Does not auto-merge.

## Next step after merge

Run `Codex First Canary Run` manually again. PASS requires a lab-only diff, checks passing, and a PR created by the workflow.