### PR TITLE
Enable Codex write mode for canary

### DIFF
--- a/scripts/run_codex_first_canary.sh
+++ b/scripts/run_codex_first_canary.sh
@@ -16,7 +16,7 @@ prompt="$(cat .tmp/codex-first-canary-prompt.md)"
 codex exec \
   --cd "$PWD" \
   --model "${CODEX_MODEL:-gpt-5.1-codex}" \
-  --sandbox workspace-write \
+  --full-auto \
   --json \
   --output-last-message .tmp/codex-last-message.txt \
   "$prompt" \


### PR DESCRIPTION
## Summary

Updates the Codex first canary runner after Codex authenticated and ran, but produced no working-tree changes.

## Observed result

```text
Run changed_files="$(git diff --name-only --)"
Codex produced no changes.
```

## Hypothesis

The prompt is now delivered, but the non-interactive Codex invocation is not actually entering an edit/apply mode. Use Codex full-auto mode for the canary runner.

## Changed file

- `scripts/run_codex_first_canary.sh`

## What changed

- Replaces `--sandbox workspace-write` with `--full-auto`.
- Keeps API-key login.
- Keeps JSON event output and last-message capture.
- Keeps workflow-side file whitelist and safety/static checks.

## What this deliberately does not change

- Does not modify `/lab/` in this PR.
- Does not run Codex during this PR.
- Does not change the public log contract.
- Does not auto-merge.

## Next step after merge

Run `Codex First Canary Run` manually again. PASS requires a lab-only diff, checks passing, and a PR created by the workflow.