### PR TITLE
Update Codex canary runner

### DIFF
--- a/scripts/run_codex_first_canary.sh
+++ b/scripts/run_codex_first_canary.sh
@@ -16,8 +16,16 @@ prompt="$(cat .tmp/codex-first-canary-prompt.md)"
 codex exec \
   --cd "$PWD" \
   --model "${CODEX_MODEL:-gpt-5.1-codex}" \
-  --full-auto \
+  --sandbox workspace-write \
   --json \
   --output-last-message .tmp/codex-last-message.txt \
   "$prompt" \
   > .tmp/codex-events.jsonl
+
+# `codex exec` can leave the generated diff as the latest Codex output rather
+# than directly modifying the working tree. Try to apply it, then let the
+# workflow's changed-file guard decide whether the run actually produced a
+# valid lab-only diff.
+if ! codex apply > .tmp/codex-apply.log 2>&1; then
+  cat .tmp/codex-apply.log
+fi


### PR DESCRIPTION
## Summary

Updates the first canary runner after the latest manual run authenticated but still produced no file changes.

## Changed file

- `scripts/run_codex_first_canary.sh`

## What changed

- Restores the supported workspace-write mode.
- Adds a follow-up local apply step after the Codex run.
- Keeps the workflow-side file whitelist, safety check, and static-site check as acceptance gates.

## Scope

- No `/lab/` changes in this PR.
- No canary execution in this PR.
- No auto-merge.

## Next step

After merge, run `Codex First Canary Run` again.