### PR TITLE
Document fixed canary conditions

### DIFF
--- a/.github/workflows/codex-first-canary-run.yml
+++ b/.github/workflows/codex-first-canary-run.yml
@@ -15,7 +15,7 @@ jobs:
   codex-first-canary-run:
     runs-on: ubuntu-latest
     env:
-      CODEX_MODEL: gpt-5.1-codex
+      CODEX_MODEL: gpt-5.4-nano
       RUN_WEEK: first-canary-001
       CODEX_HOME: ${{ github.workspace }}/.codex-home
     steps:

--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -8,6 +8,8 @@ on:
       - "scripts/**/*.sh"
       - "tests/fixtures/**"
       - ".github/workflows/script-check.yml"
+      - ".github/workflows/codex-first-canary-run.yml"
+      - "docs/codex-runner-contract.md"
   workflow_dispatch:
 
 permissions:
@@ -78,6 +80,9 @@ jobs:
 
       - name: Run canary policy alignment test
         run: python scripts/test_canary_policy_alignment.py
+
+      - name: Run Codex canary contract test
+        run: python scripts/test_codex_canary_contract.py
 
       - name: Run terminal metadata extraction test
         run: python scripts/test_extract_pr_metadata.py

--- a/docs/codex-runner-contract.md
+++ b/docs/codex-runner-contract.md
@@ -20,6 +20,54 @@ Rationale:
 - The experiment should test coding-agent behavior under repository constraints.
 - The runner should not force a custom patch DSL unless the experiment explicitly tests DSL-following.
 
+## Fixed canary conditions
+
+The first Codex canary is a controlled experiment. Do not change model or run parameters while debugging execution-path failures.
+
+Fixed values:
+
+```text
+model: gpt-5.4-nano
+candidate_rank: 1
+issue_number: 0
+vote_count: 0
+week: first-canary-001
+attempts_per_candidate: 1
+retry_policy: none
+fallback_policy: none
+auto_merge_policy: disabled
+allowed_changed_files: lab/index.html, lab/style.css, lab/app.js
+prompt_source: scripts/create_first_canary_candidate.py + inline workflow prompt
+manual_review_required: true
+```
+
+Explicitly forbidden during this canary:
+
+```text
+changing the model
+changing temperature or sampling parameters
+adding fallback models
+adding retries
+changing the fixed prompt goal
+expanding writable file scope
+switching to a stronger model to make the run pass
+accepting a run that changes non-lab files
+```
+
+Allowed changes while the runner is failing:
+
+```text
+fix Codex CLI argument syntax
+fix authentication plumbing
+fix stdin/prompt delivery
+fix shell quoting
+fix local diagnostic logging
+fix changed-file detection
+fix public redacted log generation
+```
+
+If a parameter must change, create a new canary ID instead of mutating `first-canary-001`.
+
 ## Required invariants
 
 The Codex runner must preserve these invariants:

--- a/scripts/test_codex_canary_contract.py
+++ b/scripts/test_codex_canary_contract.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "docs" / "codex-runner-contract.md"
+WORKFLOW = ROOT / ".github" / "workflows" / "codex-first-canary-run.yml"
+
+REQUIRED_CONTRACT_LINES = [
+    "model: gpt-5.4-nano",
+    "candidate_rank: 1",
+    "issue_number: 0",
+    "vote_count: 0",
+    "week: first-canary-001",
+    "attempts_per_candidate: 1",
+    "retry_policy: none",
+    "fallback_policy: none",
+    "auto_merge_policy: disabled",
+    "allowed_changed_files: lab/index.html, lab/style.css, lab/app.js",
+    "changing the model",
+    "changing temperature or sampling parameters",
+    "adding fallback models",
+    "adding retries",
+]
+
+REQUIRED_WORKFLOW_LINES = [
+    "CODEX_MODEL: gpt-5.4-nano",
+    "RUN_WEEK: first-canary-001",
+    "--candidate-rank 1",
+    "--issue-number 0",
+    "--vote-count 0",
+    "--attempt-count 1",
+    "--retry-policy none",
+    "--fallback-policy none",
+    "--auto-merge-policy disabled",
+    "lab/index.html|lab/style.css|lab/app.js",
+]
+
+
+def main() -> int:
+    contract = CONTRACT.read_text(encoding="utf-8")
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    missing_contract = [line for line in REQUIRED_CONTRACT_LINES if line not in contract]
+    missing_workflow = [line for line in REQUIRED_WORKFLOW_LINES if line not in workflow]
+
+    if missing_contract:
+        raise SystemExit("Missing contract fixed-condition lines: " + ", ".join(missing_contract))
+    if missing_workflow:
+        raise SystemExit("Missing workflow fixed-condition lines: " + ", ".join(missing_workflow))
+
+    print("codex canary contract test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Documents the fixed first-canary conditions and adds CI coverage so model and run parameters cannot drift silently.

## Changed files

- `docs/codex-runner-contract.md`
- `.github/workflows/codex-first-canary-run.yml`
- `.github/workflows/script-check.yml`
- `scripts/test_codex_canary_contract.py`

## Fixed values now documented

- model: `gpt-5.4-nano`
- week: `first-canary-001`
- candidate rank: `1`
- issue number: `0`
- vote count: `0`
- attempts: `1`
- retry policy: `none`
- fallback policy: `none`
- auto-merge: disabled
- writable files: `lab/index.html`, `lab/style.css`, `lab/app.js`

## Why

Changing the model or run parameters while debugging the runner invalidates the experiment. Runner plumbing may be fixed, but model, sampling policy, retry policy, fallback policy, prompt goal, and file scope must remain fixed for this canary.

## Scope

- Documentation and CI guard only.
- No `/lab/` changes.
- No canary execution.
- No auto-merge.