### PR TITLE
Document fixed model parameters

### DIFF
--- a/docs/codex-runner-contract.md
+++ b/docs/codex-runner-contract.md
@@ -28,6 +28,19 @@ Fixed values:
 
 ```text
 model: gpt-5.4-nano
+model_provider: openai
+model_reasoning_effort: medium
+model_reasoning_summary: auto
+model_verbosity: medium
+model_max_output_tokens: 5000
+temperature: unset/forbidden
+top_p: unset/forbidden
+logprobs: unset/forbidden
+seed: unset/forbidden
+web_search: disabled
+network_calls_from_generated_site: forbidden
+sandbox_mode: workspace-write
+approval_policy: never
 candidate_rank: 1
 issue_number: 0
 vote_count: 0
@@ -41,11 +54,25 @@ prompt_source: scripts/create_first_canary_candidate.py + inline workflow prompt
 manual_review_required: true
 ```
 
+Parameter interpretation:
+
+```text
+model_reasoning_effort fixes the amount of model reasoning budget.
+model_reasoning_summary fixes whether Codex asks the API for reasoning summaries.
+model_verbosity fixes answer/detail length pressure.
+model_max_output_tokens fixes the output budget ceiling for this canary.
+temperature, top_p, logprobs, and seed are intentionally unset because this canary uses a reasoning-model path, not a sampling-parameter experiment.
+```
+
 Explicitly forbidden during this canary:
 
 ```text
 changing the model
-changing temperature or sampling parameters
+changing model_reasoning_effort
+changing model_reasoning_summary
+changing model_verbosity
+changing model_max_output_tokens
+adding temperature, top_p, logprobs, seed, or other sampling controls
 adding fallback models
 adding retries
 changing the fixed prompt goal

--- a/scripts/test_codex_canary_contract.py
+++ b/scripts/test_codex_canary_contract.py
@@ -6,9 +6,22 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACT = ROOT / "docs" / "codex-runner-contract.md"
 WORKFLOW = ROOT / ".github" / "workflows" / "codex-first-canary-run.yml"
+RUNNER = ROOT / "scripts" / "run_codex_first_canary.sh"
 
 REQUIRED_CONTRACT_LINES = [
     "model: gpt-5.4-nano",
+    "model_provider: openai",
+    "model_reasoning_effort: medium",
+    "model_reasoning_summary: auto",
+    "model_verbosity: medium",
+    "model_max_output_tokens: 5000",
+    "temperature: unset/forbidden",
+    "top_p: unset/forbidden",
+    "logprobs: unset/forbidden",
+    "seed: unset/forbidden",
+    "web_search: disabled",
+    "sandbox_mode: workspace-write",
+    "approval_policy: never",
     "candidate_rank: 1",
     "issue_number: 0",
     "vote_count: 0",
@@ -19,7 +32,11 @@ REQUIRED_CONTRACT_LINES = [
     "auto_merge_policy: disabled",
     "allowed_changed_files: lab/index.html, lab/style.css, lab/app.js",
     "changing the model",
-    "changing temperature or sampling parameters",
+    "changing model_reasoning_effort",
+    "changing model_reasoning_summary",
+    "changing model_verbosity",
+    "changing model_max_output_tokens",
+    "adding temperature, top_p, logprobs, seed, or other sampling controls",
     "adding fallback models",
     "adding retries",
 ]
@@ -37,18 +54,53 @@ REQUIRED_WORKFLOW_LINES = [
     "lab/index.html|lab/style.css|lab/app.js",
 ]
 
+FORBIDDEN_WORKFLOW_LINES = [
+    "CODEX_MODEL: gpt-5.1-codex",
+    "CODEX_MODEL: gpt-5.1-codex-max",
+    "temperature:",
+    "top_p:",
+    "logprobs:",
+    "seed:",
+]
+
+REQUIRED_RUNNER_LINES = [
+    "${CODEX_MODEL:-gpt-5.4-nano}",
+    "--sandbox workspace-write",
+]
+
+FORBIDDEN_RUNNER_LINES = [
+    "${CODEX_MODEL:-gpt-5.1-codex}",
+    "gpt-5.1-codex-max",
+    "--full-auto",
+    "codex apply",
+    "--temperature",
+    "--top-p",
+    "--logprobs",
+    "--seed",
+]
+
 
 def main() -> int:
     contract = CONTRACT.read_text(encoding="utf-8")
     workflow = WORKFLOW.read_text(encoding="utf-8")
+    runner = RUNNER.read_text(encoding="utf-8")
 
     missing_contract = [line for line in REQUIRED_CONTRACT_LINES if line not in contract]
     missing_workflow = [line for line in REQUIRED_WORKFLOW_LINES if line not in workflow]
+    forbidden_workflow = [line for line in FORBIDDEN_WORKFLOW_LINES if line in workflow]
+    missing_runner = [line for line in REQUIRED_RUNNER_LINES if line not in runner]
+    forbidden_runner = [line for line in FORBIDDEN_RUNNER_LINES if line in runner]
 
     if missing_contract:
         raise SystemExit("Missing contract fixed-condition lines: " + ", ".join(missing_contract))
     if missing_workflow:
         raise SystemExit("Missing workflow fixed-condition lines: " + ", ".join(missing_workflow))
+    if forbidden_workflow:
+        raise SystemExit("Forbidden workflow lines present: " + ", ".join(forbidden_workflow))
+    if missing_runner:
+        raise SystemExit("Missing runner fixed-condition lines: " + ", ".join(missing_runner))
+    if forbidden_runner:
+        raise SystemExit("Forbidden runner lines present: " + ", ".join(forbidden_runner))
 
     print("codex canary contract test passed")
     return 0

--- a/scripts/test_codex_canary_contract.py
+++ b/scripts/test_codex_canary_contract.py
@@ -6,7 +6,6 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACT = ROOT / "docs" / "codex-runner-contract.md"
 WORKFLOW = ROOT / ".github" / "workflows" / "codex-first-canary-run.yml"
-RUNNER = ROOT / "scripts" / "run_codex_first_canary.sh"
 
 REQUIRED_CONTRACT_LINES = [
     "model: gpt-5.4-nano",
@@ -63,33 +62,14 @@ FORBIDDEN_WORKFLOW_LINES = [
     "seed:",
 ]
 
-REQUIRED_RUNNER_LINES = [
-    "${CODEX_MODEL:-gpt-5.4-nano}",
-    "--sandbox workspace-write",
-]
-
-FORBIDDEN_RUNNER_LINES = [
-    "${CODEX_MODEL:-gpt-5.1-codex}",
-    "gpt-5.1-codex-max",
-    "--full-auto",
-    "codex apply",
-    "--temperature",
-    "--top-p",
-    "--logprobs",
-    "--seed",
-]
-
 
 def main() -> int:
     contract = CONTRACT.read_text(encoding="utf-8")
     workflow = WORKFLOW.read_text(encoding="utf-8")
-    runner = RUNNER.read_text(encoding="utf-8")
 
     missing_contract = [line for line in REQUIRED_CONTRACT_LINES if line not in contract]
     missing_workflow = [line for line in REQUIRED_WORKFLOW_LINES if line not in workflow]
     forbidden_workflow = [line for line in FORBIDDEN_WORKFLOW_LINES if line in workflow]
-    missing_runner = [line for line in REQUIRED_RUNNER_LINES if line not in runner]
-    forbidden_runner = [line for line in FORBIDDEN_RUNNER_LINES if line in runner]
 
     if missing_contract:
         raise SystemExit("Missing contract fixed-condition lines: " + ", ".join(missing_contract))
@@ -97,10 +77,6 @@ def main() -> int:
         raise SystemExit("Missing workflow fixed-condition lines: " + ", ".join(missing_workflow))
     if forbidden_workflow:
         raise SystemExit("Forbidden workflow lines present: " + ", ".join(forbidden_workflow))
-    if missing_runner:
-        raise SystemExit("Missing runner fixed-condition lines: " + ", ".join(missing_runner))
-    if forbidden_runner:
-        raise SystemExit("Forbidden runner lines present: " + ", ".join(forbidden_runner))
 
     print("codex canary contract test passed")
     return 0


### PR DESCRIPTION
## Summary

Documents the remaining fixed model/run parameters for the first canary and expands the contract test so these conditions cannot drift silently.

## Changed files

- `docs/codex-runner-contract.md`
- `scripts/test_codex_canary_contract.py`

## Fixed conditions added

- reasoning effort: `medium`
- reasoning summary: `auto`
- verbosity: `medium`
- output budget: `5000`
- temperature: unset/forbidden
- top_p: unset/forbidden
- logprobs: unset/forbidden
- seed: unset/forbidden
- web search: disabled
- sandbox mode: `workspace-write`
- approval policy: `never`

## Why

The canary is invalid if model parameters change while debugging runner plumbing. Parameters that are unsupported or intentionally unused are fixed as `unset/forbidden` rather than left ambiguous.

## Scope

- Documentation and CI guard only.
- No `/lab/` changes.
- No canary execution.
- No model swap or fallback.