### PR TITLE
Guard first canary runner contract

### DIFF
--- a/scripts/test_codex_canary_contract.py
+++ b/scripts/test_codex_canary_contract.py
@@ -6,6 +6,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACT = ROOT / "docs" / "codex-runner-contract.md"
 WORKFLOW = ROOT / ".github" / "workflows" / "codex-first-canary-run.yml"
+RUNNER = ROOT / "scripts" / "run_codex_first_canary.sh"
 
 REQUIRED_CONTRACT_LINES = [
     "model: gpt-5.4-nano",
@@ -62,14 +63,36 @@ FORBIDDEN_WORKFLOW_LINES = [
     "seed:",
 ]
 
+REQUIRED_RUNNER_LINES = [
+    "${CODEX_MODEL:-gpt-5.4-nano}",
+    "--sandbox workspace-write",
+    "--json",
+    "--output-last-message .tmp/codex-last-message.txt",
+    "> .tmp/codex-events.jsonl",
+]
+
+FORBIDDEN_RUNNER_LINES = [
+    "${CODEX_MODEL:-gpt-5.1-codex}",
+    "gpt-5.1-codex-max",
+    "--full-auto",
+    "codex apply",
+    "--temperature",
+    "--top-p",
+    "--logprobs",
+    "--seed",
+]
+
 
 def main() -> int:
     contract = CONTRACT.read_text(encoding="utf-8")
     workflow = WORKFLOW.read_text(encoding="utf-8")
+    runner = RUNNER.read_text(encoding="utf-8")
 
     missing_contract = [line for line in REQUIRED_CONTRACT_LINES if line not in contract]
     missing_workflow = [line for line in REQUIRED_WORKFLOW_LINES if line not in workflow]
     forbidden_workflow = [line for line in FORBIDDEN_WORKFLOW_LINES if line in workflow]
+    missing_runner = [line for line in REQUIRED_RUNNER_LINES if line not in runner]
+    forbidden_runner = [line for line in FORBIDDEN_RUNNER_LINES if line in runner]
 
     if missing_contract:
         raise SystemExit("Missing contract fixed-condition lines: " + ", ".join(missing_contract))
@@ -77,6 +100,10 @@ def main() -> int:
         raise SystemExit("Missing workflow fixed-condition lines: " + ", ".join(missing_workflow))
     if forbidden_workflow:
         raise SystemExit("Forbidden workflow lines present: " + ", ".join(forbidden_workflow))
+    if missing_runner:
+        raise SystemExit("Missing runner fixed-condition lines: " + ", ".join(missing_runner))
+    if forbidden_runner:
+        raise SystemExit("Forbidden runner lines present: " + ", ".join(forbidden_runner))
 
     print("codex canary contract test passed")
     return 0


### PR DESCRIPTION
## Summary

Extends the first-canary contract test to cover the runner script after the runner plumbing was fixed.

## Changed file

- `scripts/test_codex_canary_contract.py`

## What this guards

- runner fallback model remains `gpt-5.4-nano`
- workspace-write sandbox remains enabled
- JSON event output remains enabled
- last-message capture remains enabled
- invalid local apply step stays removed
- sampling controls such as temperature, top_p, logprobs, and seed remain forbidden

## Scope

- CI guard only.
- No `/lab/` changes.
- No canary execution.
- No model or parameter changes.