### PR TITLE
Add isolated three-file relaxed Codex canary

### DIFF
--- a/.github/workflows/codex-isolated-3file-relaxed-canary-run.yml
+++ b/.github/workflows/codex-isolated-3file-relaxed-canary-run.yml
@@ -1,0 +1,210 @@
+name: Codex Isolated Three File Relaxed Canary Run
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: codex-isolated-3file-relaxed-canary-run
+  cancel-in-progress: false
+
+jobs:
+  codex-isolated-3file-relaxed-canary-run:
+    runs-on: ubuntu-latest
+    env:
+      CODEX_MODEL: gpt-5.4-nano
+      RUN_WEEK: first-canary-003
+      CODEX_HOME: ${{ github.workspace }}/.codex-home
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Codex CLI
+        run: |
+          mkdir -p "$CODEX_HOME"
+          npm install -g @openai/codex
+          codex --version
+
+      - name: Capture diagnostics baseline
+        run: |
+          mkdir -p .tmp/canary-diagnostics
+          git status --porcelain > .tmp/canary-diagnostics/git-status-before.txt
+          python - <<'PY' > .tmp/canary-diagnostics/file-hashes-before.json
+          import hashlib
+          import json
+          from pathlib import Path
+
+          files = ["lab/index.html", "lab/style.css", "lab/app.js"]
+          out = {}
+          for name in files:
+              path = Path(name)
+              if path.exists() and path.is_file():
+                  digest = hashlib.sha256(path.read_bytes()).hexdigest()
+                  out[name] = {"exists": True, "sha256": digest, "size_bytes": path.stat().st_size}
+              else:
+                  out[name] = {"exists": False, "sha256": None, "size_bytes": None}
+          print(json.dumps(out, indent=2, sort_keys=True))
+          PY
+
+      - name: Run Codex isolated three-file relaxed canary once
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY_ }}
+        run: |
+          set +e
+          bash scripts/run_codex_isolated_3file_relaxed_canary.sh > .tmp/codex-stdout.txt 2> .tmp/codex-stderr.txt
+          rc=$?
+          echo "$rc" > .tmp/codex-exit-code.txt
+          cat .tmp/codex-stdout.txt
+          cat .tmp/codex-stderr.txt >&2
+          exit "$rc"
+
+      - name: Validate changed files and checks
+        run: |
+          changed_files="$(git diff --name-only --)"
+          if [ -z "$changed_files" ]; then
+            echo "Codex produced no changes."
+            exit 1
+          fi
+          echo "$changed_files" | while read -r file; do
+            case "$file" in
+              lab/index.html|lab/style.css|lab/app.js) ;;
+              *) echo "Forbidden changed file: $file"; exit 1 ;;
+            esac
+          done
+          bash scripts/safety-check.sh origin/main HEAD
+          bash scripts/static-site-check.sh
+
+      - name: Collect diagnostics artifact
+        if: ${{ always() }}
+        run: |
+          python scripts/collect_canary_diagnostics.py \
+            --out-dir .tmp/canary-diagnostics \
+            --canary-id first-canary-003 \
+            --model "$CODEX_MODEL" \
+            --runner-mode codex-cli-isolated-3file-relaxed-direct-edit \
+            --sandbox-mode danger-full-access \
+            --status "${{ job.status }}" \
+            --failure-step codex_or_validation \
+            --allowed-file lab/index.html \
+            --allowed-file lab/style.css \
+            --allowed-file lab/app.js
+
+      - name: Upload diagnostics artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-isolated-3file-relaxed-canary-diagnostics-${{ github.run_number }}
+          path: .tmp/canary-diagnostics
+          if-no-files-found: warn
+
+      - name: Write public run log
+        if: ${{ always() }}
+        run: |
+          mkdir -p .tmp
+          base_sha="$(git rev-parse origin/main 2>/dev/null || echo unrecorded)"
+          changed_csv="$(git diff --name-only -- 2>/dev/null | paste -sd, -)"
+          status="passed"
+          if [ "${{ job.status }}" != "success" ]; then status="failed"; fi
+          python scripts/write_public_run_log.py \
+            --out .tmp/public-run-log.json \
+            --provider openai-codex \
+            --runner codex-cli-isolated-3file-relaxed-direct-edit \
+            --model "$CODEX_MODEL" \
+            --workflow "Codex Isolated Three File Relaxed Canary Run" \
+            --run-number "${{ github.run_number }}" \
+            --week "$RUN_WEEK" \
+            --candidate-rank 1 \
+            --issue-number 0 \
+            --vote-count 0 \
+            --base-sha "$base_sha" \
+            --branch "codex-isolated-3file-relaxed-canary-003-${{ github.run_number }}" \
+            --attempt-count 1 \
+            --retry-policy none \
+            --fallback-policy none \
+            --auto-merge-policy disabled \
+            --status "$status" \
+            --changed-files "$changed_csv"
+
+      - name: Upload public run log
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-isolated-3file-relaxed-canary-public-log-${{ github.run_number }}
+          path: .tmp/public-run-log.json
+          if-no-files-found: warn
+
+      - name: Commit and create PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branch="codex-isolated-3file-relaxed-canary-003-${{ github.run_number }}"
+          base_sha="$(git rev-parse origin/main)"
+          changed_files="$(git diff --name-only -- | paste -sd ', ' -)"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add lab/index.html lab/style.css lab/app.js
+          git commit -m "Run Codex isolated three-file relaxed canary"
+          git push --set-upstream origin "$branch"
+
+          cat > .tmp/codex-isolated-3file-relaxed-canary-pr-body.md <<EOF
+          Implements the third Codex implementation-agent canary.
+
+          ## Purpose
+
+          This verifies isolated three-file direct editing with relaxed sandbox mode on GitHub-hosted runners. Codex sees and edits only copied lab files inside a temporary worktree, then the workflow copies allowed files back.
+
+          ## Configuration
+
+          - Week: $RUN_WEEK
+          - Rank: 1
+          - Issue: #0
+          - Votes: 0
+          - Inherited lab base: \`$base_sha\`
+          - Provider: \`openai-codex\`
+          - Runner: \`codex-cli-isolated-3file-relaxed-direct-edit\`
+          - Sandbox mode: \`danger-full-access\`
+          - Codex model: \`$CODEX_MODEL\`
+          - Attempts: \`1\`
+          - Retry policy: \`none\`
+          - Fallback: \`none\`
+          - Auto-merge: disabled
+          - Visible files: \`lab/index.html\`, \`lab/style.css\`, \`lab/app.js\`
+          - Final writable files: \`lab/index.html\`, \`lab/style.css\`, \`lab/app.js\`
+
+          ## Changed files
+
+          $changed_files
+
+          ## Internal checks
+
+          - isolated three-file relaxed runner completed before PR creation
+          - changed-file guard passed before PR creation
+          - safety-check passed before PR creation
+          - static-site-check passed before PR creation
+
+          ## Diagnostics
+
+          Internal diagnostics artifact is uploaded for prompt-design analysis.
+
+          ## Merge policy
+
+          Manual review is required. Do not auto-merge.
+          EOF
+
+          gh pr create \
+            --title "Run Codex isolated three-file relaxed canary" \
+            --body-file .tmp/codex-isolated-3file-relaxed-canary-pr-body.md \
+            --base main \
+            --head "$branch"

--- a/scripts/run_codex_isolated_3file_relaxed_canary.sh
+++ b/scripts/run_codex_isolated_3file_relaxed_canary.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+key_env_name="OPENAI_API_KEY"
+if [ -z "${!key_env_name:-}" ]; then
+  echo "Required API key environment variable is not configured."
+  exit 1
+fi
+
+mkdir -p "${CODEX_HOME:-.codex-home}"
+mkdir -p .tmp
+
+worktree=".tmp/codex-3file-relaxed-worktree"
+rm -rf "$worktree"
+mkdir -p "$worktree/lab"
+cp lab/index.html "$worktree/lab/index.html"
+cp lab/style.css "$worktree/lab/style.css"
+cp lab/app.js "$worktree/lab/app.js"
+
+printf '%s' "${!key_env_name}" | codex login --with-api-key
+
+cat > .tmp/codex-isolated-3file-relaxed-prompt.md <<'EOF'
+You are Codex running an isolated three-file Prompt Vote Lab canary.
+
+Goal: add a small static canary panel explaining that this is the third bounded Codex implementation-agent canary.
+
+Visible files:
+- lab/index.html
+- lab/style.css
+- lab/app.js
+
+Hard constraints:
+- Edit only the three visible files.
+- Keep the visible change small and reviewable.
+- Do not add external network calls, external scripts, cookies, analytics, login, payment behavior, dependencies, eval, fetch, XMLHttpRequest, localStorage, or sessionStorage.
+- Do not change voting, selection, evidence, report, or canary policy logic.
+- Do not commit, branch, or open a PR. The workflow will do that.
+
+At the end, provide a short rationale summary with:
+- files changed
+- why each change was necessary
+- files deliberately not changed
+- constraints considered
+Do not include private chain-of-thought.
+EOF
+
+prompt="$(cat .tmp/codex-isolated-3file-relaxed-prompt.md)"
+
+codex exec \
+  --cd "$PWD/$worktree" \
+  --model "${CODEX_MODEL:-gpt-5.4-nano}" \
+  --sandbox danger-full-access \
+  --json \
+  --output-last-message "$PWD/.tmp/codex-last-message.txt" \
+  "$prompt" \
+  > "$PWD/.tmp/codex-events.jsonl"
+
+if ! diff -q lab/index.html "$worktree/lab/index.html" >/dev/null; then
+  cp "$worktree/lab/index.html" lab/index.html
+fi
+if ! diff -q lab/style.css "$worktree/lab/style.css" >/dev/null; then
+  cp "$worktree/lab/style.css" lab/style.css
+fi
+if ! diff -q lab/app.js "$worktree/lab/app.js" >/dev/null; then
+  cp "$worktree/lab/app.js" lab/app.js
+fi


### PR DESCRIPTION
## Summary

Adds `first-canary-003` as a separate isolated three-file direct-edit Codex canary with relaxed sandbox mode.

## Changed files

- `.github/workflows/codex-isolated-3file-relaxed-canary-run.yml`
- `scripts/run_codex_isolated_3file_relaxed_canary.sh`

## Experiment definition

This is a separate canary from `first-canary-001` and `first-canary-002`.

- `first-canary-001`: full repository direct edit with `workspace-write`; failed on GitHub-hosted runner sandbox helper.
- `first-canary-002`: isolated three-file direct edit with `workspace-write`; failed on the same sandbox helper.
- `first-canary-003`: isolated three-file direct edit with relaxed sandbox mode.

## Fixed conditions preserved

- model: `gpt-5.4-nano`
- attempts: `1`
- retry policy: `none`
- fallback policy: `none`
- auto-merge: disabled
- visible files: `lab/index.html`, `lab/style.css`, `lab/app.js`
- final writable files: `lab/index.html`, `lab/style.css`, `lab/app.js`

## Changed condition

- sandbox mode: `workspace-write` → `danger-full-access`

This is why the canary ID changes to `first-canary-003`.

## Diagnostics

The workflow uses the shared diagnostics collector and uploads internal diagnostics artifacts for prompt-design analysis.

## Scope

- No canary execution in this PR.
- No `/lab/` changes.
- No model, parameter, retry, fallback, or final file-scope changes.