### PR TITLE
Add Codex writeback canary

### DIFF
--- a/.github/workflows/codex-writeback-canary-run.yml
+++ b/.github/workflows/codex-writeback-canary-run.yml
@@ -1,0 +1,214 @@
+name: Codex Writeback Canary Run
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: codex-writeback-canary-run
+  cancel-in-progress: false
+
+jobs:
+  codex-writeback-canary-run:
+    runs-on: ubuntu-latest
+    env:
+      CODEX_MODEL: gpt-5.4-nano
+      RUN_WEEK: first-canary-004
+      CODEX_HOME: ${{ github.workspace }}/.codex-home
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Codex CLI
+        run: |
+          mkdir -p "$CODEX_HOME"
+          npm install -g @openai/codex
+          codex --version
+
+      - name: Capture diagnostics baseline
+        run: |
+          mkdir -p .tmp/canary-diagnostics
+          git status --porcelain > .tmp/canary-diagnostics/git-status-before.txt
+          python - <<'PY' > .tmp/canary-diagnostics/file-hashes-before.json
+          import hashlib
+          import json
+          from pathlib import Path
+
+          files = ["lab/index.html", "lab/style.css", "lab/app.js"]
+          out = {}
+          for name in files:
+              path = Path(name)
+              if path.exists() and path.is_file():
+                  digest = hashlib.sha256(path.read_bytes()).hexdigest()
+                  out[name] = {"exists": True, "sha256": digest, "size_bytes": path.stat().st_size}
+              else:
+                  out[name] = {"exists": False, "sha256": None, "size_bytes": None}
+          print(json.dumps(out, indent=2, sort_keys=True))
+          PY
+
+      - name: Run Codex writeback canary once
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY_ }}
+        run: |
+          set +e
+          bash scripts/run_codex_writeback_canary.sh > .tmp/codex-stdout.txt 2> .tmp/codex-stderr.txt
+          rc=$?
+          echo "$rc" > .tmp/codex-exit-code.txt
+          cat .tmp/codex-stdout.txt
+          cat .tmp/codex-stderr.txt >&2
+          exit "$rc"
+
+      - name: Validate changed files and checks
+        run: |
+          changed_files="$(git diff --name-only --)"
+          if [ -z "$changed_files" ]; then
+            echo "Codex produced no changes."
+            exit 1
+          fi
+          echo "$changed_files" | while read -r file; do
+            case "$file" in
+              lab/index.html|lab/style.css|lab/app.js) ;;
+              *) echo "Forbidden changed file: $file"; exit 1 ;;
+            esac
+          done
+          bash scripts/safety-check.sh origin/main HEAD
+          bash scripts/static-site-check.sh
+
+      - name: Collect diagnostics artifact
+        if: ${{ always() }}
+        run: |
+          python scripts/collect_canary_diagnostics.py \
+            --out-dir .tmp/canary-diagnostics \
+            --canary-id first-canary-004 \
+            --model "$CODEX_MODEL" \
+            --runner-mode codex-cli-workflow-mediated-writeback \
+            --sandbox-mode read-only \
+            --status "${{ job.status }}" \
+            --failure-step codex_or_patch_or_validation \
+            --allowed-file lab/index.html \
+            --allowed-file lab/style.css \
+            --allowed-file lab/app.js
+          if [ -f .tmp/codex-writeback.patch ]; then
+            cp .tmp/codex-writeback.patch .tmp/canary-diagnostics/codex-writeback.patch
+          fi
+
+      - name: Upload diagnostics artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-writeback-canary-diagnostics-${{ github.run_number }}
+          path: .tmp/canary-diagnostics
+          if-no-files-found: warn
+
+      - name: Write public run log
+        if: ${{ always() }}
+        run: |
+          mkdir -p .tmp
+          base_sha="$(git rev-parse origin/main 2>/dev/null || echo unrecorded)"
+          changed_csv="$(git diff --name-only -- 2>/dev/null | paste -sd, -)"
+          status="passed"
+          if [ "${{ job.status }}" != "success" ]; then status="failed"; fi
+          python scripts/write_public_run_log.py \
+            --out .tmp/public-run-log.json \
+            --provider openai-codex \
+            --runner codex-cli-workflow-mediated-writeback \
+            --model "$CODEX_MODEL" \
+            --workflow "Codex Writeback Canary Run" \
+            --run-number "${{ github.run_number }}" \
+            --week "$RUN_WEEK" \
+            --candidate-rank 1 \
+            --issue-number 0 \
+            --vote-count 0 \
+            --base-sha "$base_sha" \
+            --branch "codex-writeback-canary-004-${{ github.run_number }}" \
+            --attempt-count 1 \
+            --retry-policy none \
+            --fallback-policy none \
+            --auto-merge-policy disabled \
+            --status "$status" \
+            --changed-files "$changed_csv"
+
+      - name: Upload public run log
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-writeback-canary-public-log-${{ github.run_number }}
+          path: .tmp/public-run-log.json
+          if-no-files-found: warn
+
+      - name: Commit and create PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branch="codex-writeback-canary-004-${{ github.run_number }}"
+          base_sha="$(git rev-parse origin/main)"
+          changed_files="$(git diff --name-only -- | paste -sd ', ' -)"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add lab/index.html lab/style.css lab/app.js
+          git commit -m "Run Codex writeback canary"
+          git push --set-upstream origin "$branch"
+
+          cat > .tmp/codex-writeback-canary-pr-body.md <<EOF
+          Implements the fourth Codex implementation-agent canary.
+
+          ## Purpose
+
+          This verifies workflow-mediated writeback on GitHub-hosted runners. Codex runs in read-only mode and returns a unified diff. The workflow validates and applies only allowed lab-file changes.
+
+          ## Configuration
+
+          - Week: $RUN_WEEK
+          - Rank: 1
+          - Issue: #0
+          - Votes: 0
+          - Inherited lab base: \`$base_sha\`
+          - Provider: \`openai-codex\`
+          - Runner: \`codex-cli-workflow-mediated-writeback\`
+          - Sandbox mode: \`read-only\`
+          - Writeback mode: \`validated unified diff patch\`
+          - Codex model: \`$CODEX_MODEL\`
+          - Attempts: \`1\`
+          - Retry policy: \`none\`
+          - Fallback: \`none\`
+          - Auto-merge: disabled
+          - Final writable files: \`lab/index.html\`, \`lab/style.css\`, \`lab/app.js\`
+
+          ## Changed files
+
+          $changed_files
+
+          ## Internal checks
+
+          - patch path/content validator passed before patch application
+          - git apply --check passed before patch application
+          - changed-file guard passed before PR creation
+          - safety-check passed before PR creation
+          - static-site-check passed before PR creation
+
+          ## Diagnostics
+
+          Internal diagnostics artifact is uploaded for prompt-design analysis.
+
+          ## Merge policy
+
+          Manual review is required. Do not auto-merge.
+          EOF
+
+          gh pr create \
+            --title "Run Codex writeback canary" \
+            --body-file .tmp/codex-writeback-canary-pr-body.md \
+            --base main \
+            --head "$branch"

--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -9,6 +9,9 @@ on:
       - "tests/fixtures/**"
       - ".github/workflows/script-check.yml"
       - ".github/workflows/codex-first-canary-run.yml"
+      - ".github/workflows/codex-isolated-3file-canary-run.yml"
+      - ".github/workflows/codex-isolated-3file-relaxed-canary-run.yml"
+      - ".github/workflows/codex-writeback-canary-run.yml"
       - "docs/codex-runner-contract.md"
       - "docs/canary-log-policy.md"
   workflow_dispatch:
@@ -90,6 +93,9 @@ jobs:
 
       - name: Run canary diagnostics collector test
         run: python scripts/test_collect_canary_diagnostics.py
+
+      - name: Run Codex writeback patch applier test
+        run: python scripts/test_apply_codex_writeback_patch.py
 
       - name: Run terminal metadata extraction test
         run: python scripts/test_extract_pr_metadata.py

--- a/scripts/apply_codex_writeback_patch.py
+++ b/scripts/apply_codex_writeback_patch.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from pathlib import Path
+
+ALLOWED_FILES = {
+    "lab/index.html",
+    "lab/style.css",
+    "lab/app.js",
+}
+
+FORBIDDEN_PATCH_PATTERNS = [
+    re.compile(r"^\+.*<script[^>]+src=", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^\+.*\beval\s*\(", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^\+.*\bnew\s+Function\s*\(", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^\+.*\bfetch\s*\(", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^\+.*\bXMLHttpRequest\b", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^\+.*\blocalStorage\b", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^\+.*\bsessionStorage\b", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^\+.*\bdocument\.cookie\b", re.IGNORECASE | re.MULTILINE),
+]
+
+
+def extract_patch(raw: str) -> str:
+    text = raw.strip()
+    fenced = re.search(r"```(?:diff|patch)?\s*(.*?)\s*```", text, flags=re.IGNORECASE | re.DOTALL)
+    if fenced:
+        text = fenced.group(1).strip()
+
+    start = text.find("diff --git ")
+    if start == -1:
+        raise ValueError("No unified diff found in Codex output")
+    patch = text[start:].strip() + "\n"
+    if "@@" not in patch:
+        raise ValueError("Patch has no hunk header")
+    return patch
+
+
+def normalize_patch_path(path: str) -> str:
+    path = path.strip()
+    if path == "/dev/null":
+        return path
+    if path.startswith("a/") or path.startswith("b/"):
+        path = path[2:]
+    return path
+
+
+def validate_patch_paths(patch: str) -> None:
+    touched: set[str] = set()
+    for line in patch.splitlines():
+        if line.startswith("diff --git "):
+            parts = line.split()
+            if len(parts) < 4:
+                raise ValueError(f"Malformed diff header: {line}")
+            paths = [normalize_patch_path(parts[2]), normalize_patch_path(parts[3])]
+        elif line.startswith("--- ") or line.startswith("+++ "):
+            paths = [normalize_patch_path(line.split(maxsplit=1)[1])]
+        else:
+            continue
+
+        for path in paths:
+            if path == "/dev/null":
+                raise ValueError("Creating or deleting files is not allowed")
+            if path not in ALLOWED_FILES:
+                raise ValueError(f"Patch touches forbidden path: {path}")
+            touched.add(path)
+
+    if not touched:
+        raise ValueError("Patch touches no files")
+
+
+def validate_patch_content(patch: str) -> None:
+    for pattern in FORBIDDEN_PATCH_PATTERNS:
+        if pattern.search(patch):
+            raise ValueError(f"Forbidden patch content matched: {pattern.pattern}")
+
+
+def run_git_apply(patch_path: Path) -> None:
+    check = subprocess.run(
+        ["git", "apply", "--check", "--whitespace=nowarn", str(patch_path)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if check.returncode != 0:
+        raise RuntimeError("git apply --check failed:\n" + check.stdout + check.stderr)
+
+    apply = subprocess.run(
+        ["git", "apply", "--whitespace=nowarn", str(patch_path)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if apply.returncode != 0:
+        raise RuntimeError("git apply failed:\n" + apply.stdout + apply.stderr)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate and apply a Codex unified diff writeback patch.")
+    parser.add_argument("--input", required=True, help="Path to Codex last-message text")
+    parser.add_argument("--patch-out", default=".tmp/codex-writeback.patch")
+    args = parser.parse_args()
+
+    raw = Path(args.input).read_text(encoding="utf-8", errors="replace")
+    patch = extract_patch(raw)
+    validate_patch_paths(patch)
+    validate_patch_content(patch)
+
+    patch_out = Path(args.patch_out)
+    patch_out.parent.mkdir(parents=True, exist_ok=True)
+    patch_out.write_text(patch, encoding="utf-8")
+    run_git_apply(patch_out)
+
+    print(f"Applied Codex writeback patch: {patch_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_codex_writeback_canary.sh
+++ b/scripts/run_codex_writeback_canary.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+key_env_name="OPENAI_API_KEY"
+if [ -z "${!key_env_name:-}" ]; then
+  echo "Required API key environment variable is not configured."
+  exit 1
+fi
+
+mkdir -p "${CODEX_HOME:-.codex-home}"
+mkdir -p .tmp
+
+printf '%s' "${!key_env_name}" | codex login --with-api-key
+
+cat > .tmp/codex-writeback-prompt.md <<'EOF'
+You are Codex running a workflow-mediated Prompt Vote Lab writeback canary.
+
+Goal: add a small static canary panel explaining that this is the fourth bounded Codex implementation-agent canary.
+
+Allowed files:
+- lab/index.html
+- lab/style.css
+- lab/app.js
+
+Critical write policy:
+- Do not edit files directly.
+- Return only a unified diff patch in your final answer.
+- The workflow will validate and apply the patch.
+- The patch may touch only the allowed files.
+- Do not create or delete files.
+- Keep the visible change small and reviewable.
+- Do not add external network calls, external scripts, cookies, analytics, login, payment behavior, dependencies, eval, fetch, XMLHttpRequest, localStorage, or sessionStorage.
+- Do not change voting, selection, evidence, report, or canary policy logic.
+- Do not commit, branch, or open a PR. The workflow will do that.
+
+Required final answer:
+- A single unified diff beginning with `diff --git`.
+- No markdown explanation outside the diff.
+EOF
+
+prompt="$(cat .tmp/codex-writeback-prompt.md)"
+
+codex exec \
+  --cd "$PWD" \
+  --model "${CODEX_MODEL:-gpt-5.4-nano}" \
+  --sandbox read-only \
+  --json \
+  --output-last-message "$PWD/.tmp/codex-last-message.txt" \
+  "$prompt" \
+  > "$PWD/.tmp/codex-events.jsonl"
+
+python scripts/apply_codex_writeback_patch.py \
+  --input .tmp/codex-last-message.txt \
+  --patch-out .tmp/codex-writeback.patch

--- a/scripts/test_apply_codex_writeback_patch.py
+++ b/scripts/test_apply_codex_writeback_patch.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "apply_codex_writeback_patch.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("apply_codex_writeback_patch", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load apply_codex_writeback_patch module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def expect_raises(fn, needle: str) -> None:
+    try:
+        fn()
+    except Exception as exc:
+        assert needle in str(exc), str(exc)
+        return
+    raise AssertionError(f"expected exception containing {needle!r}")
+
+
+def main() -> int:
+    module = load_module()
+
+    raw = """Here is the patch:\n```diff\ndiff --git a/lab/index.html b/lab/index.html\n--- a/lab/index.html\n+++ b/lab/index.html\n@@ -1,1 +1,1 @@\n-old\n+new\n```\n"""
+    patch = module.extract_patch(raw)
+    assert patch.startswith("diff --git a/lab/index.html b/lab/index.html")
+    module.validate_patch_paths(patch)
+    module.validate_patch_content(patch)
+
+    forbidden_path_patch = """diff --git a/README.md b/README.md\n--- a/README.md\n+++ b/README.md\n@@ -1,1 +1,1 @@\n-old\n+new\n"""
+    expect_raises(lambda: module.validate_patch_paths(forbidden_path_patch), "forbidden path")
+
+    created_file_patch = """diff --git a/dev/null b/lab/new.html\n--- /dev/null\n+++ b/lab/new.html\n@@ -0,0 +1,1 @@\n+new\n"""
+    expect_raises(lambda: module.validate_patch_paths(created_file_patch), "Creating or deleting")
+
+    forbidden_content_patch = """diff --git a/lab/app.js b/lab/app.js\n--- a/lab/app.js\n+++ b/lab/app.js\n@@ -1,1 +1,1 @@\n-old\n+fetch('/x')\n"""
+    expect_raises(lambda: module.validate_patch_content(forbidden_content_patch), "Forbidden patch content")
+
+    no_diff = "not a patch"
+    expect_raises(lambda: module.extract_patch(no_diff), "No unified diff")
+
+    print("codex writeback patch applier test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_apply_codex_writeback_patch.py
+++ b/scripts/test_apply_codex_writeback_patch.py
@@ -38,8 +38,8 @@ def main() -> int:
     forbidden_path_patch = """diff --git a/README.md b/README.md\n--- a/README.md\n+++ b/README.md\n@@ -1,1 +1,1 @@\n-old\n+new\n"""
     expect_raises(lambda: module.validate_patch_paths(forbidden_path_patch), "forbidden path")
 
-    created_file_patch = """diff --git a/dev/null b/lab/new.html\n--- /dev/null\n+++ b/lab/new.html\n@@ -0,0 +1,1 @@\n+new\n"""
-    expect_raises(lambda: module.validate_patch_paths(created_file_patch), "Creating or deleting")
+    delete_allowed_file_patch = """diff --git a/lab/index.html b/lab/index.html\n--- a/lab/index.html\n+++ /dev/null\n@@ -1,1 +0,0 @@\n-old\n"""
+    expect_raises(lambda: module.validate_patch_paths(delete_allowed_file_patch), "Creating or deleting")
 
     forbidden_content_patch = """diff --git a/lab/app.js b/lab/app.js\n--- a/lab/app.js\n+++ b/lab/app.js\n@@ -1,1 +1,1 @@\n-old\n+fetch('/x')\n"""
     expect_raises(lambda: module.validate_patch_content(forbidden_content_patch), "Forbidden patch content")


### PR DESCRIPTION
## Summary

Adds `first-canary-004` as a workflow-mediated writeback Codex canary.

## Changed files

- `.github/workflows/codex-writeback-canary-run.yml`
- `.github/workflows/script-check.yml`
- `scripts/apply_codex_writeback_patch.py`
- `scripts/run_codex_writeback_canary.sh`
- `scripts/test_apply_codex_writeback_patch.py`

## Experiment definition

This is a separate canary from the direct-edit canaries.

- `first-canary-001`: full repository direct edit with `workspace-write`; failed on GitHub-hosted runner sandbox helper.
- `first-canary-002`: isolated three-file direct edit with `workspace-write`; failed on the same sandbox helper.
- `first-canary-003`: isolated three-file direct edit with `danger-full-access`; succeeded.
- `first-canary-004`: read-only Codex generation plus workflow-mediated validated patch writeback.

## Fixed conditions preserved

- model: `gpt-5.4-nano`
- attempts: `1`
- retry policy: `none`
- fallback policy: `none`
- auto-merge: disabled
- final writable files: `lab/index.html`, `lab/style.css`, `lab/app.js`

## Changed condition

- direct filesystem edit is replaced by validated unified diff writeback
- Codex sandbox mode is `read-only`

This is why the canary ID changes to `first-canary-004`.

## Safety gates

- patch path validator
- forbidden-content validator
- `git apply --check`
- changed-file guard
- safety-check
- static-site-check
- manual review

## Diagnostics

The workflow uses the shared diagnostics collector and uploads internal diagnostics artifacts for prompt-design analysis.

## Scope

- No canary execution in this PR.
- No `/lab/` changes.
- No model, parameter, retry, fallback, or final file-scope changes.