### PR TITLE
Add offline JSON canary

### DIFF
--- a/.github/workflows/codex-offline-json-canary-run.yml
+++ b/.github/workflows/codex-offline-json-canary-run.yml
@@ -1,0 +1,213 @@
+name: Codex Offline JSON Canary Run
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: codex-offline-json-canary-run
+  cancel-in-progress: false
+
+jobs:
+  codex-offline-json-canary-run:
+    runs-on: ubuntu-latest
+    env:
+      CODEX_MODEL: gpt-5.4-nano
+      RUN_WEEK: first-canary-005
+      CODEX_HOME: ${{ github.workspace }}/.codex-home
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Codex CLI
+        run: |
+          mkdir -p "$CODEX_HOME"
+          npm install -g @openai/codex
+          codex --version
+
+      - name: Capture diagnostics baseline
+        run: |
+          mkdir -p .tmp/canary-diagnostics
+          git status --porcelain > .tmp/canary-diagnostics/git-status-before.txt
+          python - <<'PY' > .tmp/canary-diagnostics/file-hashes-before.json
+          import hashlib
+          import json
+          from pathlib import Path
+
+          files = ["lab/index.html", "lab/style.css", "lab/app.js"]
+          out = {}
+          for name in files:
+              path = Path(name)
+              if path.exists() and path.is_file():
+                  digest = hashlib.sha256(path.read_bytes()).hexdigest()
+                  out[name] = {"exists": True, "sha256": digest, "size_bytes": path.stat().st_size}
+              else:
+                  out[name] = {"exists": False, "sha256": None, "size_bytes": None}
+          print(json.dumps(out, indent=2, sort_keys=True))
+          PY
+
+      - name: Run Codex offline JSON canary once
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY_ }}
+        run: |
+          set +e
+          bash scripts/run_codex_offline_json_canary.sh > .tmp/codex-stdout.txt 2> .tmp/codex-stderr.txt
+          rc=$?
+          echo "$rc" > .tmp/codex-exit-code.txt
+          cat .tmp/codex-stdout.txt
+          cat .tmp/codex-stderr.txt >&2
+          exit "$rc"
+
+      - name: Validate changed files and checks
+        run: |
+          changed_files="$(git diff --name-only --)"
+          if [ -z "$changed_files" ]; then
+            echo "Codex produced no changes."
+            exit 1
+          fi
+          echo "$changed_files" | while read -r file; do
+            case "$file" in
+              lab/index.html|lab/style.css|lab/app.js) ;;
+              *) echo "Forbidden changed file: $file"; exit 1 ;;
+            esac
+          done
+          bash scripts/safety-check.sh origin/main HEAD
+          bash scripts/static-site-check.sh
+
+      - name: Collect diagnostics artifact
+        if: ${{ always() }}
+        run: |
+          python scripts/collect_canary_diagnostics.py \
+            --out-dir .tmp/canary-diagnostics \
+            --canary-id first-canary-005 \
+            --model "$CODEX_MODEL" \
+            --runner-mode codex-cli-offline-json-writeback \
+            --sandbox-mode read-only-empty-context \
+            --status "${{ job.status }}" \
+            --failure-step codex_or_json_or_validation \
+            --allowed-file lab/index.html \
+            --allowed-file lab/style.css \
+            --allowed-file lab/app.js
+          if [ -f .tmp/codex-offline-output.json ]; then
+            cp .tmp/codex-offline-output.json .tmp/canary-diagnostics/codex-offline-output.json
+          fi
+
+      - name: Upload diagnostics artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-offline-json-canary-diagnostics-${{ github.run_number }}
+          path: .tmp/canary-diagnostics
+          if-no-files-found: warn
+
+      - name: Write public run log
+        if: ${{ always() }}
+        run: |
+          mkdir -p .tmp
+          base_sha="$(git rev-parse origin/main 2>/dev/null || echo unrecorded)"
+          changed_csv="$(git diff --name-only -- 2>/dev/null | paste -sd, -)"
+          status="passed"
+          if [ "${{ job.status }}" != "success" ]; then status="failed"; fi
+          python scripts/write_public_run_log.py \
+            --out .tmp/public-run-log.json \
+            --provider openai-codex \
+            --runner codex-cli-offline-json-writeback \
+            --model "$CODEX_MODEL" \
+            --workflow "Codex Offline JSON Canary Run" \
+            --run-number "${{ github.run_number }}" \
+            --week "$RUN_WEEK" \
+            --candidate-rank 1 \
+            --issue-number 0 \
+            --vote-count 0 \
+            --base-sha "$base_sha" \
+            --branch "codex-offline-json-canary-005-${{ github.run_number }}" \
+            --attempt-count 1 \
+            --retry-policy none \
+            --fallback-policy none \
+            --auto-merge-policy disabled \
+            --status "$status" \
+            --changed-files "$changed_csv"
+
+      - name: Upload public run log
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-offline-json-canary-public-log-${{ github.run_number }}
+          path: .tmp/public-run-log.json
+          if-no-files-found: warn
+
+      - name: Commit and create PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branch="codex-offline-json-canary-005-${{ github.run_number }}"
+          base_sha="$(git rev-parse origin/main)"
+          changed_files="$(git diff --name-only -- | paste -sd ', ' -)"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add lab/index.html lab/style.css lab/app.js
+          git commit -m "Run Codex offline JSON canary"
+          git push --set-upstream origin "$branch"
+
+          cat > .tmp/codex-offline-json-canary-pr-body.md <<EOF
+          Implements the fifth Codex implementation-agent canary.
+
+          ## Purpose
+
+          This verifies offline-context JSON writeback. Codex runs in an empty temporary directory and receives only the three allowed file contents as prompt context. The workflow validates and applies only JSON-provided replacements for allowed lab files.
+
+          ## Configuration
+
+          - Week: $RUN_WEEK
+          - Rank: 1
+          - Issue: #0
+          - Votes: 0
+          - Inherited lab base: \`$base_sha\`
+          - Provider: \`openai-codex\`
+          - Runner: \`codex-cli-offline-json-writeback\`
+          - Sandbox mode: \`read-only-empty-context\`
+          - Writeback mode: \`validated JSON full-file replacement\`
+          - Codex model: \`$CODEX_MODEL\`
+          - Attempts: \`1\`
+          - Retry policy: \`none\`
+          - Fallback: \`none\`
+          - Auto-merge: disabled
+          - Final writable files: \`lab/index.html\`, \`lab/style.css\`, \`lab/app.js\`
+
+          ## Changed files
+
+          $changed_files
+
+          ## Internal checks
+
+          - JSON path/content validator passed before application
+          - changed-file guard passed before PR creation
+          - safety-check passed before PR creation
+          - static-site-check passed before PR creation
+
+          ## Diagnostics
+
+          Internal diagnostics artifact is uploaded for prompt-design analysis.
+
+          ## Merge policy
+
+          Manual review is required. Do not auto-merge.
+          EOF
+
+          gh pr create \
+            --title "Run Codex offline JSON canary" \
+            --body-file .tmp/codex-offline-json-canary-pr-body.md \
+            --base main \
+            --head "$branch"

--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -12,6 +12,7 @@ on:
       - ".github/workflows/codex-isolated-3file-canary-run.yml"
       - ".github/workflows/codex-isolated-3file-relaxed-canary-run.yml"
       - ".github/workflows/codex-writeback-canary-run.yml"
+      - ".github/workflows/codex-offline-json-canary-run.yml"
       - "docs/codex-runner-contract.md"
       - "docs/canary-log-policy.md"
   workflow_dispatch:
@@ -96,6 +97,9 @@ jobs:
 
       - name: Run Codex writeback patch applier test
         run: python scripts/test_apply_codex_writeback_patch.py
+
+      - name: Run offline JSON applier test
+        run: python scripts/test_apply_codex_offline_json.py
 
       - name: Run terminal metadata extraction test
         run: python scripts/test_extract_pr_metadata.py

--- a/scripts/apply_codex_offline_json.py
+++ b/scripts/apply_codex_offline_json.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+ALLOWED_FILES = {
+    "lab/index.html",
+    "lab/style.css",
+    "lab/app.js",
+}
+
+MAX_FILE_BYTES = 200_000
+
+
+def extract_json(raw: str) -> dict[str, Any]:
+    text = raw.strip()
+    fenced = re.search(r"```(?:json)?\s*(.*?)\s*```", text, flags=re.IGNORECASE | re.DOTALL)
+    if fenced:
+        text = fenced.group(1).strip()
+    else:
+        start = text.find("{")
+        end = text.rfind("}")
+        if start == -1 or end == -1 or end < start:
+            raise ValueError("No JSON object found in Codex output")
+        text = text[start : end + 1]
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON output: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("JSON root must be an object")
+    return data
+
+
+def validate_payload(data: dict[str, Any]) -> list[tuple[str, str]]:
+    files = data.get("files")
+    if not isinstance(files, list) or not files:
+        raise ValueError("JSON must contain a non-empty files list")
+
+    seen: set[str] = set()
+    updates: list[tuple[str, str]] = []
+    for item in files:
+        if not isinstance(item, dict):
+            raise ValueError("Each files item must be an object")
+        path = item.get("path")
+        content = item.get("content")
+        if not isinstance(path, str) or path not in ALLOWED_FILES:
+            raise ValueError(f"Forbidden or invalid path: {path!r}")
+        if path in seen:
+            raise ValueError(f"Duplicate path: {path}")
+        seen.add(path)
+        if not isinstance(content, str):
+            raise ValueError(f"Content for {path} must be a string")
+        if not content.strip():
+            raise ValueError(f"Content for {path} must not be empty")
+        if len(content.encode("utf-8")) > MAX_FILE_BYTES:
+            raise ValueError(f"Content for {path} exceeds max size")
+        if not Path(path).exists():
+            raise ValueError(f"Target file does not exist: {path}")
+        updates.append((path, content))
+
+    return updates
+
+
+def apply_updates(updates: list[tuple[str, str]]) -> list[str]:
+    changed: list[str] = []
+    for path, content in updates:
+        target = Path(path)
+        old = target.read_text(encoding="utf-8")
+        if old != content:
+            target.write_text(content, encoding="utf-8")
+            changed.append(path)
+    if not changed:
+        raise ValueError("JSON payload produced no file changes")
+    return changed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate and apply Codex offline JSON output.")
+    parser.add_argument("--input", required=True, help="Path to Codex last-message text")
+    parser.add_argument("--json-out", default=".tmp/codex-offline-output.json")
+    args = parser.parse_args()
+
+    raw = Path(args.input).read_text(encoding="utf-8", errors="replace")
+    data = extract_json(raw)
+    updates = validate_payload(data)
+
+    json_out = Path(args.json_out)
+    json_out.parent.mkdir(parents=True, exist_ok=True)
+    json_out.write_text(json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    changed = apply_updates(updates)
+    print("Applied Codex offline JSON output:")
+    for path in changed:
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_codex_offline_json_canary.sh
+++ b/scripts/run_codex_offline_json_canary.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+key_env_name="OPENAI_API_KEY"
+if [ -z "${!key_env_name:-}" ]; then
+  echo "Required API key environment variable is not configured."
+  exit 1
+fi
+
+mkdir -p "${CODEX_HOME:-.codex-home}"
+mkdir -p .tmp
+
+printf '%s' "${!key_env_name}" | codex login --with-api-key
+
+context_dir=".tmp/codex-offline-context"
+rm -rf "$context_dir"
+mkdir -p "$context_dir"
+
+python - <<'PY'
+from __future__ import annotations
+
+from pathlib import Path
+
+files = ["lab/index.html", "lab/style.css", "lab/app.js"]
+parts = [
+    "You are Codex running an offline-context Prompt Vote Lab writeback canary.",
+    "",
+    "Goal: add a small static canary panel explaining that this is the fifth bounded Codex implementation-agent canary.",
+    "",
+    "You do not have repository write access. Use only the file contents below as context.",
+    "Return only a JSON object with this exact shape:",
+    '{"files":[{"path":"lab/index.html","content":"FULL REPLACEMENT CONTENT"}]}',
+    "",
+    "Rules:",
+    "- Return only JSON. No markdown fence and no explanation.",
+    "- Include only files whose full replacement content should change.",
+    "- Allowed paths are lab/index.html, lab/style.css, and lab/app.js.",
+    "- Do not create or delete files.",
+    "- Keep the visible change small and reviewable.",
+    "- Do not change voting, selection, evidence, report, or canary policy logic.",
+    "- Do not include external scripts, network calls, cookies, storage APIs, or dynamic code execution.",
+    "",
+    "Current allowed file contents:",
+]
+for name in files:
+    content = Path(name).read_text(encoding="utf-8")
+    parts.append(f"\n--- BEGIN {name} ---")
+    parts.append(content)
+    parts.append(f"--- END {name} ---")
+Path(".tmp/codex-offline-json-prompt.md").write_text("\n".join(parts) + "\n", encoding="utf-8")
+PY
+
+prompt="$(cat .tmp/codex-offline-json-prompt.md)"
+
+codex exec \
+  --cd "$PWD/$context_dir" \
+  --model "${CODEX_MODEL:-gpt-5.4-nano}" \
+  --sandbox read-only \
+  --json \
+  --output-last-message "$PWD/.tmp/codex-last-message.txt" \
+  "$prompt" \
+  > "$PWD/.tmp/codex-events.jsonl"
+
+python scripts/apply_codex_offline_json.py \
+  --input .tmp/codex-last-message.txt \
+  --json-out .tmp/codex-offline-output.json

--- a/scripts/test_apply_codex_offline_json.py
+++ b/scripts/test_apply_codex_offline_json.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "scripts" / "apply_codex_offline_json.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("apply_codex_offline_json", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load apply_codex_offline_json module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def expect_raises(fn, needle: str) -> None:
+    try:
+        fn()
+    except Exception as exc:
+        assert needle in str(exc), str(exc)
+        return
+    raise AssertionError(f"expected exception containing {needle!r}")
+
+
+def main() -> int:
+    module = load_module()
+
+    raw = 'prefix ```json\n{"files":[{"path":"lab/index.html","content":"<main>ok</main>"}]}\n``` suffix'
+    data = module.extract_json(raw)
+    assert data["files"][0]["path"] == "lab/index.html"
+
+    module.validate_payload({"files": [{"path": "lab/index.html", "content": "ok"}]})
+    module.validate_payload({"files": [{"path": "lab/style.css", "content": "body{}"}]})
+    module.validate_payload({"files": [{"path": "lab/app.js", "content": "console.log('ok')"}]})
+
+    expect_raises(lambda: module.extract_json("not json"), "No JSON object")
+    expect_raises(lambda: module.validate_payload({}), "non-empty files list")
+    expect_raises(lambda: module.validate_payload({"files": [{"path": "README.md", "content": "ok"}]}), "Forbidden")
+    expect_raises(lambda: module.validate_payload({"files": [{"path": "lab/index.html", "content": ""}]}), "must not be empty")
+    expect_raises(lambda: module.validate_payload({"files": [{"path": "lab/index.html", "content": "ok"}, {"path": "lab/index.html", "content": "ok2"}]}), "Duplicate")
+
+    print("offline JSON applier test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds `first-canary-005` as an offline-context JSON writeback Codex canary.

## Changed files

- `.github/workflows/codex-offline-json-canary-run.yml`
- `.github/workflows/script-check.yml`
- `scripts/apply_codex_offline_json.py`
- `scripts/run_codex_offline_json_canary.sh`
- `scripts/test_apply_codex_offline_json.py`

## Experiment definition

This is a separate canary from the direct-edit and repo-context writeback canaries.

- `first-canary-003`: isolated three-file direct edit with relaxed sandbox; succeeded.
- `first-canary-004`: read-only repo-context writeback; failed because Codex still attempted an internal write path and produced a non-applicable patch.
- `first-canary-005`: empty-context Codex execution plus workflow-mediated JSON full-file replacement.

## Fixed conditions preserved

- model: `gpt-5.4-nano`
- attempts: `1`
- retry policy: `none`
- fallback policy: `none`
- auto-merge: disabled
- final writable files: `lab/index.html`, `lab/style.css`, `lab/app.js`

## Changed condition

- Codex no longer runs in the repository working tree.
- Codex receives only the three allowed file contents as prompt context.
- Workflow validates and applies JSON full-file replacements.

This is why the canary ID changes to `first-canary-005`.

## Safety gates

- JSON extraction and parse validation
- allowed-path validation
- duplicate-path rejection
- empty-content rejection
- changed-file guard
- safety-check
- static-site-check
- manual review

## Diagnostics

The workflow uses the shared diagnostics collector and uploads internal diagnostics artifacts for prompt-design analysis.

## Scope

- No canary execution in this PR.
- No `/lab/` changes.
- No model, parameter, retry, fallback, or final file-scope changes.