### PR TITLE
Add agent-observed Codex canary

### DIFF
--- a/.github/workflows/codex-agent-observed-canary-run.yml
+++ b/.github/workflows/codex-agent-observed-canary-run.yml
@@ -1,0 +1,223 @@
+name: Codex Agent Observed Canary Run
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: codex-agent-observed-canary-run
+  cancel-in-progress: false
+
+jobs:
+  codex-agent-observed-canary-run:
+    runs-on: ubuntu-latest
+    env:
+      CODEX_MODEL: gpt-5.4-nano
+      RUN_WEEK: first-canary-006
+      CODEX_HOME: ${{ github.workspace }}/.codex-home
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Codex CLI
+        run: |
+          mkdir -p "$CODEX_HOME"
+          npm install -g @openai/codex
+          codex --version
+
+      - name: Capture diagnostics baseline
+        run: |
+          mkdir -p .tmp/canary-diagnostics
+          git status --porcelain > .tmp/canary-diagnostics/git-status-before.txt
+          python - <<'PY' > .tmp/canary-diagnostics/file-hashes-before.json
+          import hashlib
+          import json
+          from pathlib import Path
+
+          files = ["lab/index.html", "lab/style.css", "lab/app.js"]
+          out = {}
+          for name in files:
+              path = Path(name)
+              if path.exists() and path.is_file():
+                  digest = hashlib.sha256(path.read_bytes()).hexdigest()
+                  out[name] = {"exists": True, "sha256": digest, "size_bytes": path.stat().st_size}
+              else:
+                  out[name] = {"exists": False, "sha256": None, "size_bytes": None}
+          print(json.dumps(out, indent=2, sort_keys=True))
+          PY
+
+      - name: Run Codex agent-observed canary once
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY_ }}
+        run: |
+          set +e
+          bash scripts/run_codex_agent_observed_canary.sh > .tmp/codex-stdout.txt 2> .tmp/workflow-codex-stderr.txt
+          rc=$?
+          echo "$rc" > .tmp/codex-exit-code.txt
+          cat .tmp/codex-stdout.txt
+          cat .tmp/workflow-codex-stderr.txt >&2
+          exit "$rc"
+
+      - name: Validate changed files and checks
+        run: |
+          changed_files="$(git diff --name-only --)"
+          if [ -z "$changed_files" ]; then
+            echo "Codex produced no changes."
+            exit 1
+          fi
+          echo "$changed_files" | while read -r file; do
+            case "$file" in
+              lab/index.html|lab/style.css|lab/app.js) ;;
+              *) echo "Forbidden changed file: $file"; exit 1 ;;
+            esac
+          done
+          bash scripts/safety-check.sh origin/main HEAD
+          bash scripts/static-site-check.sh
+
+      - name: Collect diagnostics artifact
+        if: ${{ always() }}
+        run: |
+          python scripts/collect_canary_diagnostics.py \
+            --out-dir .tmp/canary-diagnostics \
+            --canary-id first-canary-006 \
+            --model "$CODEX_MODEL" \
+            --runner-mode codex-cli-agent-observed-wrapper \
+            --sandbox-mode danger-full-access-isolated-3file \
+            --status "${{ job.status }}" \
+            --failure-step codex_or_wrapper_or_validation \
+            --allowed-file lab/index.html \
+            --allowed-file lab/style.css \
+            --allowed-file lab/app.js
+          for file in \
+            .tmp/agent-wrapper-timeline.jsonl \
+            .tmp/agent-worktree-status.txt \
+            .tmp/agent-worktree-diff-name-only.txt \
+            .tmp/agent-worktree-diff-stat.txt \
+            .tmp/agent-worktree-diff.patch \
+            .tmp/agent-worktree-hashes-before.json \
+            .tmp/agent-worktree-hashes-after.json \
+            .tmp/agent-copied-files.txt \
+            .tmp/codex-exit-code.txt \
+            .tmp/workflow-codex-stderr.txt; do
+            if [ -f "$file" ]; then cp "$file" .tmp/canary-diagnostics/; fi
+          done
+
+      - name: Upload diagnostics artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-agent-observed-canary-diagnostics-${{ github.run_number }}
+          path: .tmp/canary-diagnostics
+          if-no-files-found: warn
+
+      - name: Write public run log
+        if: ${{ always() }}
+        run: |
+          mkdir -p .tmp
+          base_sha="$(git rev-parse origin/main 2>/dev/null || echo unrecorded)"
+          changed_csv="$(git diff --name-only -- 2>/dev/null | paste -sd, -)"
+          status="passed"
+          if [ "${{ job.status }}" != "success" ]; then status="failed"; fi
+          python scripts/write_public_run_log.py \
+            --out .tmp/public-run-log.json \
+            --provider openai-codex \
+            --runner codex-cli-agent-observed-wrapper \
+            --model "$CODEX_MODEL" \
+            --workflow "Codex Agent Observed Canary Run" \
+            --run-number "${{ github.run_number }}" \
+            --week "$RUN_WEEK" \
+            --candidate-rank 1 \
+            --issue-number 0 \
+            --vote-count 0 \
+            --base-sha "$base_sha" \
+            --branch "codex-agent-observed-canary-006-${{ github.run_number }}" \
+            --attempt-count 1 \
+            --retry-policy none \
+            --fallback-policy none \
+            --auto-merge-policy disabled \
+            --status "$status" \
+            --changed-files "$changed_csv"
+
+      - name: Upload public run log
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-agent-observed-canary-public-log-${{ github.run_number }}
+          path: .tmp/public-run-log.json
+          if-no-files-found: warn
+
+      - name: Commit and create PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branch="codex-agent-observed-canary-006-${{ github.run_number }}"
+          base_sha="$(git rev-parse origin/main)"
+          changed_files="$(git diff --name-only -- | paste -sd ', ' -)"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add lab/index.html lab/style.css lab/app.js
+          git commit -m "Run Codex agent-observed canary"
+          git push --set-upstream origin "$branch"
+
+          cat > .tmp/codex-agent-observed-canary-pr-body.md <<EOF
+          Implements the sixth Codex implementation-agent canary.
+
+          ## Purpose
+
+          This verifies Codex as an observed file-operating agent, not as a pure API-style JSON generator. Codex runs in an isolated three-file worktree with relaxed sandbox mode. The wrapper records timeline, worktree before/after hashes, isolated worktree diff, copied-back files, Codex events, last message, stdout, stderr, and final repository diff.
+
+          ## Configuration
+
+          - Week: $RUN_WEEK
+          - Rank: 1
+          - Issue: #0
+          - Votes: 0
+          - Inherited lab base: \`$base_sha\`
+          - Provider: \`openai-codex\`
+          - Runner: \`codex-cli-agent-observed-wrapper\`
+          - Sandbox mode: \`danger-full-access-isolated-3file\`
+          - Codex model: \`$CODEX_MODEL\`
+          - Attempts: \`1\`
+          - Retry policy: \`none\`
+          - Fallback: \`none\`
+          - Auto-merge: disabled
+          - Visible files: \`lab/index.html\`, \`lab/style.css\`, \`lab/app.js\`
+          - Final writable files: \`lab/index.html\`, \`lab/style.css\`, \`lab/app.js\`
+
+          ## Changed files
+
+          $changed_files
+
+          ## Internal checks
+
+          - agent wrapper completed before PR creation
+          - changed-file guard passed before PR creation
+          - safety-check passed before PR creation
+          - static-site-check passed before PR creation
+
+          ## Diagnostics
+
+          Internal diagnostics artifact is uploaded for prompt-design and agent-action analysis.
+
+          ## Merge policy
+
+          Manual review is required. Do not auto-merge.
+          EOF
+
+          gh pr create \
+            --title "Run Codex agent-observed canary" \
+            --body-file .tmp/codex-agent-observed-canary-pr-body.md \
+            --base main \
+            --head "$branch"

--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -13,6 +13,7 @@ on:
       - ".github/workflows/codex-isolated-3file-relaxed-canary-run.yml"
       - ".github/workflows/codex-writeback-canary-run.yml"
       - ".github/workflows/codex-offline-json-canary-run.yml"
+      - ".github/workflows/codex-agent-observed-canary-run.yml"
       - "docs/codex-runner-contract.md"
       - "docs/canary-log-policy.md"
       - "docs/current-codex-implementation-path.md"

--- a/scripts/run_codex_agent_observed_canary.sh
+++ b/scripts/run_codex_agent_observed_canary.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+key_env_name="OPENAI_API_KEY"
+if [ -z "${!key_env_name:-}" ]; then
+  echo "Required API key environment variable is not configured."
+  exit 1
+fi
+
+mkdir -p "${CODEX_HOME:-.codex-home}"
+mkdir -p .tmp .tmp/canary-diagnostics
+
+root="$PWD"
+worktree=".tmp/codex-agent-observed-worktree"
+timeline="$root/.tmp/agent-wrapper-timeline.jsonl"
+
+log_event() {
+  python - "$timeline" "$1" "$2" <<'PY'
+from __future__ import annotations
+import json
+import sys
+from datetime import datetime, timezone
+path, event, detail = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path, "a", encoding="utf-8") as handle:
+    handle.write(json.dumps({
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "event": event,
+        "detail": detail,
+    }, sort_keys=True) + "\n")
+PY
+}
+
+rm -f "$timeline"
+log_event start "agent observed canary wrapper started"
+
+rm -rf "$worktree"
+mkdir -p "$worktree/lab"
+cp lab/index.html "$worktree/lab/index.html"
+cp lab/style.css "$worktree/lab/style.css"
+cp lab/app.js "$worktree/lab/app.js"
+log_event prepare_worktree "copied allowed lab files into isolated worktree"
+
+python - <<'PY' > .tmp/agent-worktree-hashes-before.json
+from __future__ import annotations
+import hashlib
+import json
+from pathlib import Path
+files = [
+    ".tmp/codex-agent-observed-worktree/lab/index.html",
+    ".tmp/codex-agent-observed-worktree/lab/style.css",
+    ".tmp/codex-agent-observed-worktree/lab/app.js",
+]
+out = {}
+for name in files:
+    path = Path(name)
+    out[name] = {
+        "exists": path.exists(),
+        "sha256": hashlib.sha256(path.read_bytes()).hexdigest() if path.exists() else None,
+        "size_bytes": path.stat().st_size if path.exists() else None,
+    }
+print(json.dumps(out, indent=2, sort_keys=True))
+PY
+
+(
+  cd "$worktree"
+  git init -q
+  git config user.name "agent-observer"
+  git config user.email "agent-observer@example.invalid"
+  git add lab/index.html lab/style.css lab/app.js
+  git commit -q -m "baseline"
+)
+log_event baseline_commit "created isolated worktree baseline commit"
+
+printf '%s' "${!key_env_name}" | codex login --with-api-key
+log_event codex_login "codex login completed"
+
+cat > .tmp/codex-agent-observed-prompt.md <<'EOF'
+You are Codex running an agent-observed Prompt Vote Lab canary.
+
+Goal: make a small static lab change that clearly marks this as the sixth bounded Codex implementation-agent canary.
+
+Visible files:
+- lab/index.html
+- lab/style.css
+- lab/app.js
+
+Experiment purpose:
+- This is not a pure API-style JSON generation test.
+- This run is meant to observe Codex as an agent operating on files.
+- Use available file tools normally, but keep the final change small.
+
+Hard constraints:
+- Edit only the three visible files.
+- Keep the visible change small and reviewable.
+- Do not add external network calls, external scripts, cookies, analytics, login, payment behavior, dependencies, eval, fetch, XMLHttpRequest, localStorage, or sessionStorage.
+- Do not change voting, selection, evidence, report, or canary policy logic.
+- Do not commit, branch, or open a PR. The workflow will do that.
+
+At the end, provide a short action summary with:
+- files inspected
+- files changed
+- any tool or write failures encountered
+- why the final change was selected
+- files deliberately not changed
+Do not include private chain-of-thought.
+EOF
+
+prompt="$(cat .tmp/codex-agent-observed-prompt.md)"
+log_event codex_exec_start "starting codex exec in isolated worktree"
+set +e
+codex exec \
+  --cd "$root/$worktree" \
+  --model "${CODEX_MODEL:-gpt-5.4-nano}" \
+  --sandbox danger-full-access \
+  --json \
+  --output-last-message "$root/.tmp/codex-last-message.txt" \
+  "$prompt" \
+  > "$root/.tmp/codex-events.jsonl" \
+  2> "$root/.tmp/codex-stderr.txt"
+rc=$?
+set -e
+printf '%s\n' "$rc" > .tmp/codex-exit-code.txt
+log_event codex_exec_exit "exit_code=$rc"
+
+(
+  cd "$worktree"
+  git status --porcelain > "$root/.tmp/agent-worktree-status.txt"
+  git diff --name-only -- > "$root/.tmp/agent-worktree-diff-name-only.txt"
+  git diff --stat -- > "$root/.tmp/agent-worktree-diff-stat.txt"
+  git diff -- lab/index.html lab/style.css lab/app.js > "$root/.tmp/agent-worktree-diff.patch"
+)
+log_event collect_worktree_diff "captured isolated worktree diff artifacts"
+
+python - <<'PY' > .tmp/agent-worktree-hashes-after.json
+from __future__ import annotations
+import hashlib
+import json
+from pathlib import Path
+files = [
+    ".tmp/codex-agent-observed-worktree/lab/index.html",
+    ".tmp/codex-agent-observed-worktree/lab/style.css",
+    ".tmp/codex-agent-observed-worktree/lab/app.js",
+]
+out = {}
+for name in files:
+    path = Path(name)
+    out[name] = {
+        "exists": path.exists(),
+        "sha256": hashlib.sha256(path.read_bytes()).hexdigest() if path.exists() else None,
+        "size_bytes": path.stat().st_size if path.exists() else None,
+    }
+print(json.dumps(out, indent=2, sort_keys=True))
+PY
+
+if [ "$rc" -ne 0 ]; then
+  log_event stop_before_copyback "codex failed; preserving diagnostics without copyback"
+  exit "$rc"
+fi
+
+: > .tmp/agent-copied-files.txt
+if ! diff -q lab/index.html "$worktree/lab/index.html" >/dev/null; then
+  cp "$worktree/lab/index.html" lab/index.html
+  echo "lab/index.html" >> .tmp/agent-copied-files.txt
+fi
+if ! diff -q lab/style.css "$worktree/lab/style.css" >/dev/null; then
+  cp "$worktree/lab/style.css" lab/style.css
+  echo "lab/style.css" >> .tmp/agent-copied-files.txt
+fi
+if ! diff -q lab/app.js "$worktree/lab/app.js" >/dev/null; then
+  cp "$worktree/lab/app.js" lab/app.js
+  echo "lab/app.js" >> .tmp/agent-copied-files.txt
+fi
+log_event copyback "copied changed allowed files back to repository"
+
+cp .tmp/agent-wrapper-timeline.jsonl .tmp/canary-diagnostics/agent-wrapper-timeline.jsonl
+cp .tmp/agent-worktree-status.txt .tmp/canary-diagnostics/agent-worktree-status.txt
+cp .tmp/agent-worktree-diff-name-only.txt .tmp/canary-diagnostics/agent-worktree-diff-name-only.txt
+cp .tmp/agent-worktree-diff-stat.txt .tmp/canary-diagnostics/agent-worktree-diff-stat.txt
+cp .tmp/agent-worktree-diff.patch .tmp/canary-diagnostics/agent-worktree-diff.patch
+cp .tmp/agent-worktree-hashes-before.json .tmp/canary-diagnostics/agent-worktree-hashes-before.json
+cp .tmp/agent-worktree-hashes-after.json .tmp/canary-diagnostics/agent-worktree-hashes-after.json
+cp .tmp/agent-copied-files.txt .tmp/canary-diagnostics/agent-copied-files.txt
+
+cat .tmp/codex-stderr.txt >&2
+log_event finish "agent observed wrapper finished"


### PR DESCRIPTION
## Summary

Adds `first-canary-006` as an agent-observed Codex canary.

## Changed files

- `.github/workflows/codex-agent-observed-canary-run.yml`
- `.github/workflows/script-check.yml`
- `scripts/run_codex_agent_observed_canary.sh`

## Experiment definition

This is not another API-style JSON writeback path.

`first-canary-006` is for observing Codex as a file-operating agent. It uses an isolated three-file worktree and relaxed direct-edit mode, but wraps the run with additional workflow-level diagnostics.

## What is observed

The runner captures:

- Codex JSON events
- Codex stderr/stdout
- Codex last message
- Codex exit code
- wrapper timeline
- isolated worktree status
- isolated worktree diff name-only
- isolated worktree diff stat
- isolated worktree patch
- isolated worktree hashes before/after
- copied-back files
- final repository diff via the shared diagnostics collector

## Fixed conditions preserved

- model: `gpt-5.4-nano`
- attempts: `1`
- retry policy: `none`
- fallback policy: `none`
- auto-merge: disabled
- visible files: `lab/index.html`, `lab/style.css`, `lab/app.js`
- final writable files: `lab/index.html`, `lab/style.css`, `lab/app.js`

## Changed condition

- execution purpose changes from safe production writeback to agent-action observation
- sandbox mode is `danger-full-access-isolated-3file`, matching the successful direct-edit path but with thicker instrumentation

This is why the canary ID changes to `first-canary-006`.

## Scope

- No canary execution in this PR.
- No `/lab/` changes.
- No model, retry, fallback, or final file-scope changes.