### PR TITLE
Add policy-enforced agent feasibility check

### DIFF
--- a/.github/workflows/canary-007-policy-feasibility.yml
+++ b/.github/workflows/canary-007-policy-feasibility.yml
@@ -1,0 +1,104 @@
+name: Canary 007 Policy Feasibility
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: canary-007-policy-feasibility
+  cancel-in-progress: false
+
+jobs:
+  policy-feasibility:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare isolated work directory
+        run: |
+          mkdir -p .tmp/policy-work/lab .tmp/policy-feasibility
+          cp lab/index.html .tmp/policy-work/lab/index.html
+          cp lab/style.css .tmp/policy-work/lab/style.css
+          cp lab/app.js .tmp/policy-work/lab/app.js
+          cat > .tmp/policy-feasibility/policy-allowed-paths.json <<'EOF'
+          {
+            "allowed_paths": [
+              "/work/lab/index.html",
+              "/work/lab/style.css",
+              "/work/lab/app.js"
+            ],
+            "repo_root_mounted": false
+          }
+          EOF
+
+      - name: Check Docker availability
+        run: |
+          docker version > .tmp/policy-feasibility/docker-version.txt
+          docker info > .tmp/policy-feasibility/docker-info.txt
+
+      - name: Check isolated mount behavior
+        run: |
+          docker run --rm \
+            --network none \
+            --cap-drop ALL \
+            --security-opt no-new-privileges \
+            -v "$PWD/.tmp/policy-work:/work:rw" \
+            -w /work \
+            alpine:3.20 \
+            sh -ceu '
+              echo "inside container" > /work/container-write-test.txt
+              test -f /work/lab/index.html
+              test -f /work/lab/style.css
+              test -f /work/lab/app.js
+              if test -e /work/.git; then echo "unexpected .git visible"; exit 10; fi
+              if test -e /work/.github; then echo "unexpected .github visible"; exit 11; fi
+              if test -e /work/scripts; then echo "unexpected scripts visible"; exit 12; fi
+              find /work -maxdepth 3 -type f | sort
+            ' > .tmp/policy-feasibility/container-visible-files.txt
+
+      - name: Check host strace availability
+        run: |
+          set +e
+          if command -v strace >/dev/null 2>&1; then
+            echo "strace_available=true" > .tmp/policy-feasibility/strace-status.txt
+            strace -f -e trace=file -o .tmp/policy-feasibility/file-access-trace.txt sh -c 'test -f .tmp/policy-work/lab/index.html && test ! -e .tmp/policy-work/.github'
+            echo "$?" > .tmp/policy-feasibility/strace-exit-code.txt
+          else
+            echo "strace_available=false" > .tmp/policy-feasibility/strace-status.txt
+            echo "strace not available on host" > .tmp/policy-feasibility/file-access-trace.txt
+            echo "127" > .tmp/policy-feasibility/strace-exit-code.txt
+          fi
+
+      - name: Write feasibility summary
+        if: ${{ always() }}
+        run: |
+          python - <<'PY'
+          from __future__ import annotations
+          import json
+          from pathlib import Path
+
+          root = Path('.tmp/policy-feasibility')
+          visible = (root / 'container-visible-files.txt').read_text(encoding='utf-8', errors='replace') if (root / 'container-visible-files.txt').exists() else ''
+          docker_ok = (root / 'docker-version.txt').exists()
+          strace_status = (root / 'strace-status.txt').read_text(encoding='utf-8', errors='replace').strip() if (root / 'strace-status.txt').exists() else 'missing'
+          summary = {
+              'docker_available': docker_ok,
+              'isolated_mount_has_lab_files': all(name in visible for name in ['/work/lab/index.html', '/work/lab/style.css', '/work/lab/app.js']),
+              'unexpected_repo_paths_visible': any(name in visible for name in ['/.git', '/.github', '/scripts']),
+              'strace_status': strace_status,
+              'recommendation': 'Implement full 007 only after reviewing this artifact.'
+          }
+          (root / 'feasibility-summary.json').write_text(json.dumps(summary, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+          print(json.dumps(summary, indent=2, sort_keys=True))
+          PY
+
+      - name: Upload feasibility artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: canary-007-policy-feasibility-${{ github.run_number }}
+          path: .tmp/policy-feasibility
+          if-no-files-found: error

--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -14,9 +14,11 @@ on:
       - ".github/workflows/codex-writeback-canary-run.yml"
       - ".github/workflows/codex-offline-json-canary-run.yml"
       - ".github/workflows/codex-agent-observed-canary-run.yml"
+      - ".github/workflows/canary-007-policy-feasibility.yml"
       - "docs/codex-runner-contract.md"
       - "docs/canary-log-policy.md"
       - "docs/current-codex-implementation-path.md"
+      - "docs/canary-007-policy-enforced-agent.md"
   workflow_dispatch:
 
 permissions:

--- a/docs/canary-007-policy-enforced-agent.md
+++ b/docs/canary-007-policy-enforced-agent.md
@@ -1,0 +1,165 @@
+# Canary 007: policy-enforced agent design
+
+## Status
+
+Design and feasibility phase.
+
+Do not implement the full canary until the runner environment can support the required isolation and observation primitives.
+
+## Goal
+
+`first-canary-007` should test whether Codex can operate as a file-operating agent while the execution environment prevents access to unauthorized repository files.
+
+This differs from previous paths:
+
+```text
+first-canary-005: safe production-oriented offline JSON writeback
+first-canary-006: agent-observed direct edit in an isolated three-file worktree
+first-canary-007: agent behavior plus policy-enforced filesystem boundary
+```
+
+## Core hypothesis
+
+```text
+H:
+If Codex runs inside an OS-level isolated environment containing only the allowed lab files,
+then Codex can still perform agent-style file operations while unauthorized repository files
+are not readable or writable from the agent process.
+```
+
+## Required properties
+
+A valid 007 implementation must provide these properties:
+
+```text
+- Codex sees and edits only an isolated work directory.
+- The full repository is not mounted into the Codex execution environment.
+- The final copy-back path remains limited to lab/index.html, lab/style.css, and lab/app.js.
+- Access attempts and denials are logged when feasible.
+- The run uploads thick diagnostics artifacts.
+- Auto-merge remains disabled.
+```
+
+## Candidate enforcement mechanisms
+
+### Docker isolation
+
+Preferred first feasibility target.
+
+The container should mount only a prepared work directory, for example:
+
+```text
+/work/lab/index.html
+/work/lab/style.css
+/work/lab/app.js
+```
+
+The repository root should not be mounted.
+
+### File-access tracing
+
+Useful for observation. It is not sufficient as enforcement by itself.
+
+Potential mechanism:
+
+```text
+strace -f -e trace=file
+```
+
+The trace should be treated as an analysis artifact, not as a security boundary.
+
+### Final output guard
+
+Still required even if Docker isolation works.
+
+```text
+changed_files subset of:
+  lab/index.html
+  lab/style.css
+  lab/app.js
+```
+
+## Feasibility smoke test
+
+Before implementing the full 007 canary, add a manual workflow that checks whether GitHub-hosted runners support the required primitives.
+
+Minimum smoke checks:
+
+```text
+- docker version works
+- docker run works
+- a mounted isolated work directory is visible inside the container
+- repository root is not mounted inside the container
+- strace is available on the host or can be installed in a temporary step
+- file access trace can be written as an artifact
+```
+
+## PASS conditions for feasibility
+
+```text
+PASS:
+- Docker can run a container on ubuntu-latest.
+- The container can read a mounted allowed work directory.
+- The container cannot read repository files that were not mounted.
+- A file-access trace or equivalent observation artifact can be produced.
+```
+
+## FAIL conditions for feasibility
+
+```text
+FAIL:
+- Docker is unavailable.
+- Container run fails.
+- The test unintentionally exposes the repository root to the container.
+- No useful access trace or denial evidence can be collected.
+```
+
+## UNCERTAIN conditions
+
+```text
+UNCERTAIN:
+- Docker works but strace is unavailable.
+- Isolation works but action tracing is too noisy or incomplete.
+- Codex CLI dependencies cannot be represented in the isolated environment.
+```
+
+## Expected 007 artifacts
+
+A full 007 run should upload at least:
+
+```text
+policy-allowed-paths.json
+policy-container-mounts.txt
+policy-denied-access.txt
+file-access-trace.txt
+agent-wrapper-timeline.jsonl
+codex-events.jsonl
+codex-stdout.txt
+codex-stderr.txt
+codex-last-message.txt
+codex-exit-code.txt
+worktree-hashes-before.json
+worktree-hashes-after.json
+worktree-diff.patch
+worktree-diff-stat.txt
+copied-back-files.txt
+failure-summary.json
+artifact-manifest.json
+```
+
+## Security note
+
+The goal is not to trust the model to obey path rules. The goal is to make unauthorized paths unavailable or denied by the execution environment.
+
+Prompt rules are instructions. They are not enforcement.
+
+## Current recommendation
+
+Proceed in this order:
+
+```text
+1. Add a feasibility smoke workflow.
+2. Run it manually on GitHub-hosted ubuntu-latest.
+3. Record the result in runs/.
+4. Implement full first-canary-007 only if feasibility is PASS or sufficiently understood.
+```


### PR DESCRIPTION
## Summary

Adds the design document and manual feasibility workflow for `first-canary-007-policy-enforced-agent`.

## Changed files

- `docs/canary-007-policy-enforced-agent.md`
- `.github/workflows/canary-007-policy-feasibility.yml`
- `.github/workflows/script-check.yml`

## Why

`first-canary-006` observes Codex as a file-operating agent, but it does not prove that unauthorized repository files are unavailable at the execution-environment boundary.

`first-canary-007` should test agent behavior plus policy-enforced filesystem isolation. Before implementing the full canary, this PR adds a manual feasibility workflow for Docker isolation and file-access tracing primitives on GitHub-hosted runners.

## Scope

- Design and feasibility only.
- Does not run Codex.
- Does not implement the full 007 canary.
- Does not modify `/lab/`.
- No model, retry, fallback, or sandbox changes to existing canaries.

## Feasibility checks

The manual workflow checks:

- Docker availability
- isolated work directory mount behavior
- whether repo root paths are absent from the container-visible work directory
- host strace availability
- artifact upload for feasibility evidence

## Next step after merge

Run `Canary 007 Policy Feasibility` manually on `main`, inspect the uploaded artifact, and record the result before implementing the full 007 canary.