### PR TITLE
Fix policy feasibility container permissions

### DIFF
--- a/.github/workflows/canary-007-policy-feasibility.yml
+++ b/.github/workflows/canary-007-policy-feasibility.yml
@@ -33,6 +33,8 @@ jobs:
             "repo_root_mounted": false
           }
           EOF
+          id > .tmp/policy-feasibility/host-id.txt
+          stat -c '%U:%G %a %n' .tmp/policy-work .tmp/policy-work/lab > .tmp/policy-feasibility/host-policy-work-stat.txt
 
       - name: Check Docker availability
         run: |
@@ -45,10 +47,12 @@ jobs:
             --network none \
             --cap-drop ALL \
             --security-opt no-new-privileges \
+            --user "$(id -u):$(id -g)" \
             -v "$PWD/.tmp/policy-work:/work:rw" \
             -w /work \
             alpine:3.20 \
             sh -ceu '
+              id > /work/container-id.txt
               echo "inside container" > /work/container-write-test.txt
               test -f /work/lab/index.html
               test -f /work/lab/style.css
@@ -58,6 +62,8 @@ jobs:
               if test -e /work/scripts; then echo "unexpected scripts visible"; exit 12; fi
               find /work -maxdepth 3 -type f | sort
             ' > .tmp/policy-feasibility/container-visible-files.txt
+          cp .tmp/policy-work/container-id.txt .tmp/policy-feasibility/container-id.txt
+          cp .tmp/policy-work/container-write-test.txt .tmp/policy-feasibility/container-write-test.txt
 
       - name: Check host strace availability
         run: |
@@ -86,6 +92,7 @@ jobs:
           strace_status = (root / 'strace-status.txt').read_text(encoding='utf-8', errors='replace').strip() if (root / 'strace-status.txt').exists() else 'missing'
           summary = {
               'docker_available': docker_ok,
+              'container_write_test': (root / 'container-write-test.txt').exists(),
               'isolated_mount_has_lab_files': all(name in visible for name in ['/work/lab/index.html', '/work/lab/style.css', '/work/lab/app.js']),
               'unexpected_repo_paths_visible': any(name in visible for name in ['/.git', '/.github', '/scripts']),
               'strace_status': strace_status,


### PR DESCRIPTION
## Summary

Fixes the Canary 007 policy feasibility workflow after the first manual run failed at the container write check.

## Observed failure

The container could read the mounted `/work` directory, but failed to create `/work/container-write-test.txt`:

```text
sh: can't create /work/container-write-test.txt: Permission denied
```

## Cause

The workflow used `--cap-drop ALL`. Inside the container, root no longer had capability-based permission override for the bind-mounted host directory owned by the GitHub runner user.

## Fix

Run the container as the host runner UID/GID:

```text
--user "$(id -u):$(id -g)"
```

This keeps `--cap-drop ALL` and `no-new-privileges`, while giving the container process normal owner permissions on the mounted isolated work directory.

## Added diagnostics

- `host-id.txt`
- `host-policy-work-stat.txt`
- `container-id.txt`
- `container-write-test.txt`
- `container_write_test` field in `feasibility-summary.json`

## Scope

- Fixes feasibility workflow only.
- Does not run Codex.
- Does not implement the full 007 canary.
- Does not modify `/lab/`.