### PR TITLE
Add policy-enforced Codex agent canary

### DIFF
--- a/.github/workflows/codex-policy-agent-canary-run.yml
+++ b/.github/workflows/codex-policy-agent-canary-run.yml
@@ -1,0 +1,187 @@
+name: Codex Policy Agent Canary Run
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: codex-policy-agent-canary-run
+  cancel-in-progress: false
+
+jobs:
+  codex-policy-agent-canary-run:
+    runs-on: ubuntu-latest
+    env:
+      CODEX_MODEL: gpt-5.4-nano
+      RUN_WEEK: first-canary-007
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Capture diagnostics baseline
+        run: |
+          mkdir -p .tmp/canary-diagnostics
+          git status --porcelain > .tmp/canary-diagnostics/git-status-before.txt
+          python - <<'PY' > .tmp/canary-diagnostics/file-hashes-before.json
+          import hashlib
+          import json
+          from pathlib import Path
+          files = ["lab/index.html", "lab/style.css", "lab/app.js"]
+          out = {}
+          for name in files:
+              p = Path(name)
+              out[name] = {"exists": p.exists(), "sha256": hashlib.sha256(p.read_bytes()).hexdigest() if p.exists() else None, "size_bytes": p.stat().st_size if p.exists() else None}
+          print(json.dumps(out, indent=2, sort_keys=True))
+          PY
+
+      - name: Run Codex policy-enforced agent once
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY_ }}
+        run: |
+          set +e
+          bash scripts/run_codex_policy_agent_canary.sh
+          rc=$?
+          echo "$rc" > .tmp/codex-exit-code.txt
+          exit "$rc"
+
+      - name: Validate changed files and checks
+        run: |
+          changed_files="$(git diff --name-only --)"
+          if [ -z "$changed_files" ]; then
+            echo "Codex produced no changes."
+            exit 1
+          fi
+          echo "$changed_files" | while read -r file; do
+            case "$file" in
+              lab/index.html|lab/style.css|lab/app.js) ;;
+              *) echo "Forbidden changed file: $file"; exit 1 ;;
+            esac
+          done
+          bash scripts/safety-check.sh origin/main HEAD
+          bash scripts/static-site-check.sh
+
+      - name: Collect diagnostics artifact
+        if: ${{ always() }}
+        run: |
+          python scripts/collect_canary_diagnostics.py \
+            --out-dir .tmp/canary-diagnostics \
+            --canary-id first-canary-007 \
+            --model "$CODEX_MODEL" \
+            --runner-mode codex-cli-policy-enforced-agent-container \
+            --sandbox-mode docker-mounted-workdir-only \
+            --status "${{ job.status }}" \
+            --failure-step codex_or_policy_or_validation \
+            --allowed-file lab/index.html \
+            --allowed-file lab/style.css \
+            --allowed-file lab/app.js
+
+      - name: Upload diagnostics artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-policy-agent-canary-diagnostics-${{ github.run_number }}
+          path: .tmp/canary-diagnostics
+          if-no-files-found: warn
+
+      - name: Write public run log
+        if: ${{ always() }}
+        run: |
+          mkdir -p .tmp
+          base_sha="$(git rev-parse origin/main 2>/dev/null || echo unrecorded)"
+          changed_csv="$(git diff --name-only -- 2>/dev/null | paste -sd, -)"
+          status="passed"
+          if [ "${{ job.status }}" != "success" ]; then status="failed"; fi
+          python scripts/write_public_run_log.py \
+            --out .tmp/public-run-log.json \
+            --provider openai-codex \
+            --runner codex-cli-policy-enforced-agent-container \
+            --model "$CODEX_MODEL" \
+            --workflow "Codex Policy Agent Canary Run" \
+            --run-number "${{ github.run_number }}" \
+            --week "$RUN_WEEK" \
+            --candidate-rank 1 \
+            --issue-number 0 \
+            --vote-count 0 \
+            --base-sha "$base_sha" \
+            --branch "codex-policy-agent-canary-007-${{ github.run_number }}" \
+            --attempt-count 1 \
+            --retry-policy none \
+            --fallback-policy none \
+            --auto-merge-policy disabled \
+            --status "$status" \
+            --changed-files "$changed_csv"
+
+      - name: Upload public run log
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-policy-agent-canary-public-log-${{ github.run_number }}
+          path: .tmp/public-run-log.json
+          if-no-files-found: warn
+
+      - name: Commit and create PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branch="codex-policy-agent-canary-007-${{ github.run_number }}"
+          base_sha="$(git rev-parse origin/main)"
+          changed_files="$(git diff --name-only -- | paste -sd ', ' -)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add lab/index.html lab/style.css lab/app.js
+          git commit -m "Run Codex policy-enforced agent canary"
+          git push --set-upstream origin "$branch"
+          cat > .tmp/codex-policy-agent-canary-pr-body.md <<EOF
+          Implements the seventh Codex implementation-agent canary.
+
+          ## Purpose
+
+          This verifies Codex as a file-operating agent inside a Docker container that mounts only a prepared work directory containing the allowed lab files. The repository root is not mounted into the container.
+
+          ## Configuration
+
+          - Week: $RUN_WEEK
+          - Rank: 1
+          - Issue: #0
+          - Votes: 0
+          - Inherited lab base: \`$base_sha\`
+          - Provider: \`openai-codex\`
+          - Runner: \`codex-cli-policy-enforced-agent-container\`
+          - Sandbox mode: \`docker-mounted-workdir-only\`
+          - Codex model: \`$CODEX_MODEL\`
+          - Attempts: \`1\`
+          - Retry policy: \`none\`
+          - Fallback: \`none\`
+          - Auto-merge: disabled
+          - Final writable files: \`lab/index.html\`, \`lab/style.css\`, \`lab/app.js\`
+
+          ## Changed files
+
+          $changed_files
+
+          ## Internal checks
+
+          - policy-enforced container runner completed before PR creation
+          - changed-file guard passed before PR creation
+          - safety-check passed before PR creation
+          - static-site-check passed before PR creation
+
+          ## Diagnostics
+
+          Internal diagnostics artifact is uploaded for mount, policy, Codex event, and diff analysis.
+
+          ## Merge policy
+
+          Manual review is required. Do not auto-merge.
+          EOF
+          gh pr create \
+            --title "Run Codex policy-enforced agent canary" \
+            --body-file .tmp/codex-policy-agent-canary-pr-body.md \
+            --base main \
+            --head "$branch"

--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -15,6 +15,7 @@ on:
       - ".github/workflows/codex-offline-json-canary-run.yml"
       - ".github/workflows/codex-agent-observed-canary-run.yml"
       - ".github/workflows/canary-007-policy-feasibility.yml"
+      - ".github/workflows/codex-policy-agent-canary-run.yml"
       - "docs/codex-runner-contract.md"
       - "docs/canary-log-policy.md"
       - "docs/current-codex-implementation-path.md"

--- a/scripts/run_codex_policy_agent_canary.sh
+++ b/scripts/run_codex_policy_agent_canary.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${OPENAI_API_KEY:-}" ]; then
+  echo "Required API key environment variable is not configured."
+  exit 1
+fi
+
+mkdir -p .tmp .tmp/canary-diagnostics
+root="$PWD"
+work="$root/.tmp/policy-agent-work"
+base="$root/.tmp/policy-agent-base"
+diag="$root/.tmp/canary-diagnostics"
+rm -rf "$work" "$base"
+mkdir -p "$work/lab" "$base/lab"
+
+cp lab/index.html "$work/lab/index.html"
+cp lab/style.css "$work/lab/style.css"
+cp lab/app.js "$work/lab/app.js"
+cp lab/index.html "$base/lab/index.html"
+cp lab/style.css "$base/lab/style.css"
+cp lab/app.js "$base/lab/app.js"
+chmod -R a+rwX "$work" "$diag"
+
+cat > "$diag/policy-allowed-paths.json" <<'EOF'
+{
+  "container_work_root": "/work",
+  "repo_root_mounted": false,
+  "allowed_container_paths": ["/work/lab/index.html", "/work/lab/style.css", "/work/lab/app.js"],
+  "final_copyback_paths": ["lab/index.html", "lab/style.css", "lab/app.js"]
+}
+EOF
+
+cat > .tmp/policy-agent-inner.sh <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p /diagnostics /tmp/codex-home
+id > /diagnostics/container-id.txt
+find /work -maxdepth 3 -type f | sort > /diagnostics/container-visible-files-before.txt
+mount > /diagnostics/policy-container-mounts.txt
+: > /diagnostics/policy-denied-access.txt
+for forbidden in /work/.git /work/.github /work/scripts /work/docs /work/runs; do
+  if test -e "$forbidden"; then echo "$forbidden" >> /diagnostics/policy-denied-access.txt; exit 20; fi
+done
+node --version > /diagnostics/node-version.txt
+npm --version > /diagnostics/npm-version.txt
+npm install -g @openai/codex > /diagnostics/npm-install-codex.txt 2> /diagnostics/npm-install-codex-stderr.txt
+codex --version > /diagnostics/codex-version.txt
+printf '%s' "$OPENAI_API_KEY" | CODEX_HOME=/tmp/codex-home codex login --with-api-key > /diagnostics/codex-login-stdout.txt 2> /diagnostics/codex-login-stderr.txt
+cat > /tmp/prompt.md <<'PROMPT'
+You are Codex running a policy-enforced Prompt Vote Lab canary.
+
+Goal: make a small static lab change that clearly marks this as the seventh bounded Codex implementation-agent canary.
+
+Visible files:
+- lab/index.html
+- lab/style.css
+- lab/app.js
+
+Operate on files normally inside /work. The repository root is intentionally unavailable. Edit only the visible files. Keep the change small. Do not change voting, selection, evidence, report, or canary policy logic. Do not commit, branch, or open a PR.
+
+At the end, provide a short action summary listing files inspected, files changed, unavailable paths, and files deliberately not changed. Do not include private chain-of-thought.
+PROMPT
+prompt="$(cat /tmp/prompt.md)"
+set +e
+CODEX_HOME=/tmp/codex-home codex exec --cd /work --model "${CODEX_MODEL:-gpt-5.4-nano}" --sandbox danger-full-access --json --output-last-message /diagnostics/codex-last-message.txt "$prompt" > /diagnostics/codex-events.jsonl 2> /diagnostics/codex-stderr.txt
+rc=$?
+set -e
+printf '%s\n' "$rc" > /diagnostics/codex-exit-code.txt
+find /work -maxdepth 3 -type f | sort > /diagnostics/container-visible-files-after.txt
+exit "$rc"
+EOF
+chmod +x .tmp/policy-agent-inner.sh
+
+docker run --rm \
+  --cap-drop ALL \
+  --security-opt no-new-privileges \
+  -e OPENAI_API_KEY="$OPENAI_API_KEY" \
+  -e CODEX_MODEL="${CODEX_MODEL:-gpt-5.4-nano}" \
+  -v "$work:/work:rw" \
+  -v "$diag:/diagnostics:rw" \
+  -v "$root/.tmp/policy-agent-inner.sh:/runner.sh:ro" \
+  -w /work \
+  node:20-bookworm \
+  /runner.sh > .tmp/codex-stdout.txt 2> .tmp/codex-stderr.txt
+
+cp "$diag/codex-events.jsonl" .tmp/codex-events.jsonl 2>/dev/null || : > .tmp/codex-events.jsonl
+cp "$diag/codex-last-message.txt" .tmp/codex-last-message.txt 2>/dev/null || : > .tmp/codex-last-message.txt
+cp "$diag/codex-exit-code.txt" .tmp/codex-exit-code.txt 2>/dev/null || echo 1 > .tmp/codex-exit-code.txt
+
+python - <<'PY'
+from __future__ import annotations
+import difflib
+from pathlib import Path
+pairs = [('index.html','lab/index.html'),('style.css','lab/style.css'),('app.js','lab/app.js')]
+changed=[]; patch=[]
+for short, display in pairs:
+    old=Path('.tmp/policy-agent-base/lab', short).read_text(encoding='utf-8').splitlines(True)
+    new=Path('.tmp/policy-agent-work/lab', short).read_text(encoding='utf-8').splitlines(True)
+    if old != new:
+        changed.append(display)
+        patch.extend(difflib.unified_diff(old,new,fromfile='a/'+display,tofile='b/'+display))
+Path('.tmp/policy-agent-diff-name-only.txt').write_text('\n'.join(changed)+('\n' if changed else ''), encoding='utf-8')
+Path('.tmp/policy-agent-diff.patch').write_text(''.join(patch), encoding='utf-8')
+PY
+
+cp .tmp/policy-agent-diff-name-only.txt "$diag/policy-agent-diff-name-only.txt"
+cp .tmp/policy-agent-diff.patch "$diag/policy-agent-diff.patch"
+
+: > .tmp/policy-agent-copied-files.txt
+for file in lab/index.html lab/style.css lab/app.js; do
+  if ! diff -q "$file" ".tmp/policy-agent-work/$file" >/dev/null; then
+    cp ".tmp/policy-agent-work/$file" "$file"
+    echo "$file" >> .tmp/policy-agent-copied-files.txt
+  fi
+done
+cp .tmp/policy-agent-copied-files.txt "$diag/policy-agent-copied-files.txt"


### PR DESCRIPTION
## Summary

Adds the full `first-canary-007-policy-enforced-agent` workflow.

## Changed files

- `.github/workflows/codex-policy-agent-canary-run.yml`
- `.github/workflows/script-check.yml`
- `scripts/run_codex_policy_agent_canary.sh`

## Experiment definition

This canary runs Codex inside a Docker container that mounts only a prepared work directory containing the three allowed lab files. The repository root is not mounted into the container.

## Fixed conditions preserved

- model: `gpt-5.4-nano`
- attempts: `1`
- retry policy: `none`
- fallback policy: `none`
- auto-merge: disabled
- final writable files: `lab/index.html`, `lab/style.css`, `lab/app.js`

## Policy boundary

The model is not trusted to obey path rules. The workflow provides a container environment where only `/work` is mounted for agent operation, and `/work` contains only:

- `lab/index.html`
- `lab/style.css`
- `lab/app.js`

The workflow copies back only the allowed lab files and then runs the normal changed-file guard, safety-check, and static-site-check.

## Diagnostics

The workflow uploads diagnostics for:

- allowed path policy
- container visible files
- mount table
- denied-path check output
- Codex events
- Codex last message
- Codex stderr/stdout
- policy-agent diff
- copied-back files
- shared final repository diagnostics

## Scope

- Adds full 007 workflow.
- Does not run the canary in this PR.
- Does not modify `/lab/`.