### PR TITLE
Skip git repo check for policy agent workdir

### DIFF
--- a/scripts/run_codex_policy_agent_canary.sh
+++ b/scripts/run_codex_policy_agent_canary.sh
@@ -73,7 +73,7 @@ At the end, provide a short action summary listing files inspected, files change
 PROMPT
 prompt="$(cat /codex-runtime/prompt.md)"
 set +e
-codex exec --cd /work --model "${CODEX_MODEL:-gpt-5.4-nano}" --sandbox danger-full-access --json --output-last-message /diagnostics/codex-last-message.txt "$prompt" > /diagnostics/codex-events.jsonl 2> /diagnostics/codex-stderr.txt
+codex exec --cd /work --skip-git-repo-check --model "${CODEX_MODEL:-gpt-5.4-nano}" --sandbox danger-full-access --json --output-last-message /diagnostics/codex-last-message.txt "$prompt" > /diagnostics/codex-events.jsonl 2> /diagnostics/codex-stderr.txt
 rc=$?
 set -e
 printf '%s\n' "$rc" > /diagnostics/codex-exit-code.txt


### PR DESCRIPTION
## Summary

Fixes the full `first-canary-007` runner after Codex failed because `/work` is intentionally not a Git repository.

## Observed failure

The uploaded diagnostics showed:

```text
Not inside a trusted directory and --skip-git-repo-check was not specified.
```

## Cause

The policy-enforced canary intentionally does not mount the repository root into the container. Therefore `/work` contains only the allowed lab files and is not a Git working tree.

## Fix

Add `--skip-git-repo-check` to `codex exec` inside the container.

## Scope

- Aligns Codex execution with the non-repo `/work` policy boundary.
- Does not change model, attempt count, retry, fallback, final writable files, or policy mounts.
- Does not run Codex in this PR.
- Does not modify `/lab/`.