### PR TITLE
Update Codex path docs after seventh canary

### DIFF
--- a/docs/canary-007-policy-enforced-agent.md
+++ b/docs/canary-007-policy-enforced-agent.md
@@ -2,13 +2,21 @@
 
 ## Status
 
-Design and feasibility phase.
+PASS, candidate phase.
 
-Do not implement the full canary until the runner environment can support the required isolation and observation primitives.
+`first-canary-007` has completed one successful full run and produced a merged pull request.
+
+```text
+success_record: runs/first-canary-007-policy-enforced-agent-success.md
+successful_pr: #142 Run Codex policy-enforced agent canary
+merge_commit_sha: 11ccdf4153a67a14970b12f7b8d21db337ff04c8
+```
+
+Do not treat this single success as a complete proof of filesystem security. Treat it as evidence that the policy-enforced agent path is feasible and can now be tested for repeated-run stability.
 
 ## Goal
 
-`first-canary-007` should test whether Codex can operate as a file-operating agent while the execution environment prevents access to unauthorized repository files.
+`first-canary-007` tests whether Codex can operate as a file-operating agent while the execution environment avoids mounting the full repository into the agent container.
 
 This differs from previous paths:
 
@@ -24,8 +32,44 @@ first-canary-007: agent behavior plus policy-enforced filesystem boundary
 H:
 If Codex runs inside an OS-level isolated environment containing only the allowed lab files,
 then Codex can still perform agent-style file operations while unauthorized repository files
-are not readable or writable from the agent process.
+are not present in the agent work directory.
 ```
+
+## Implemented design
+
+The full 007 workflow uses:
+
+```text
+workflow: Codex Policy Agent Canary Run
+runner: scripts/run_codex_policy_agent_canary.sh
+container image: node:20-bookworm
+container_work_root: /work
+container_runtime_root: /codex-runtime
+diagnostics_root: /diagnostics
+repo_root_mounted: false
+model: gpt-5.4-nano
+attempts_per_candidate: 1
+retry_policy: none
+fallback_policy: none
+auto_merge_policy: disabled
+final_writable_files: lab/index.html, lab/style.css, lab/app.js
+```
+
+The container receives:
+
+```text
+/work/lab/index.html
+/work/lab/style.css
+/work/lab/app.js
+```
+
+The container also receives a separate runtime mount:
+
+```text
+/codex-runtime
+```
+
+The repository root is not mounted into the container.
 
 ## Required properties
 
@@ -34,132 +78,139 @@ A valid 007 implementation must provide these properties:
 ```text
 - Codex sees and edits only an isolated work directory.
 - The full repository is not mounted into the Codex execution environment.
+- Runtime state is separated from the work directory.
 - The final copy-back path remains limited to lab/index.html, lab/style.css, and lab/app.js.
-- Access attempts and denials are logged when feasible.
+- Access checks and diagnostics are uploaded when feasible.
 - The run uploads thick diagnostics artifacts.
 - Auto-merge remains disabled.
 ```
 
-## Candidate enforcement mechanisms
+## Feasibility result
 
-### Docker isolation
+The feasibility smoke test passed before the full implementation.
 
-Preferred first feasibility target.
-
-The container should mount only a prepared work directory, for example:
+Recorded at:
 
 ```text
-/work/lab/index.html
-/work/lab/style.css
-/work/lab/app.js
+runs/canary-007-policy-feasibility-pass.md
 ```
 
-The repository root should not be mounted.
-
-### File-access tracing
-
-Useful for observation. It is not sufficient as enforcement by itself.
-
-Potential mechanism:
+Observed feasibility summary:
 
 ```text
-strace -f -e trace=file
+Docker available: true
+container write test: true
+isolated mount has lab files: true
+unexpected repo paths visible: false
+strace available: true
 ```
 
-The trace should be treated as an analysis artifact, not as a security boundary.
+## Full run result
 
-### Final output guard
-
-Still required even if Docker isolation works.
+The first full 007 run passed.
 
 ```text
-changed_files subset of:
-  lab/index.html
-  lab/style.css
-  lab/app.js
+PR: #142
+merge_commit_sha: 11ccdf4153a67a14970b12f7b8d21db337ff04c8
+changed_files: lab/index.html
 ```
 
-## Feasibility smoke test
+Diff summary:
 
-Before implementing the full 007 canary, add a manual workflow that checks whether GitHub-hosted runners support the required primitives.
-
-Minimum smoke checks:
-
-```text
-- docker version works
-- docker run works
-- a mounted isolated work directory is visible inside the container
-- repository root is not mounted inside the container
-- strace is available on the host or can be installed in a temporary step
-- file access trace can be written as an artifact
+```diff
+-      <strong>Canary (6th):</strong> this is the sixth bounded Codex implementation-agent canary.
++      <strong>Canary (7th):</strong> this is the seventh bounded Codex implementation-agent canary.
 ```
 
-## PASS conditions for feasibility
+The successful diagnostics indicated:
 
 ```text
-PASS:
-- Docker can run a container on ubuntu-latest.
-- The container can read a mounted allowed work directory.
-- The container cannot read repository files that were not mounted.
-- A file-access trace or equivalent observation artifact can be produced.
-```
-
-## FAIL conditions for feasibility
-
-```text
-FAIL:
-- Docker is unavailable.
-- Container run fails.
-- The test unintentionally exposes the repository root to the container.
-- No useful access trace or denial evidence can be collected.
-```
-
-## UNCERTAIN conditions
-
-```text
-UNCERTAIN:
-- Docker works but strace is unavailable.
-- Isolation works but action tracing is too noisy or incomplete.
-- Codex CLI dependencies cannot be represented in the isolated environment.
+npm install: PASS
+codex login: PASS
+codex exec: PASS
+container exit code: 0
+Codex exit code: 0
+policy denied access: empty
 ```
 
 ## Expected 007 artifacts
 
-A full 007 run should upload at least:
+A full 007 run should upload artifacts such as:
 
 ```text
 policy-allowed-paths.json
 policy-container-mounts.txt
 policy-denied-access.txt
-file-access-trace.txt
-agent-wrapper-timeline.jsonl
+container-visible-files-before.txt
+container-visible-files-after.txt
+container-runtime-files-after.txt
 codex-events.jsonl
-codex-stdout.txt
 codex-stderr.txt
 codex-last-message.txt
 codex-exit-code.txt
-worktree-hashes-before.json
-worktree-hashes-after.json
-worktree-diff.patch
-worktree-diff-stat.txt
-copied-back-files.txt
+policy-agent-diff.patch
+policy-agent-diff-name-only.txt
+policy-agent-copied-files.txt
 failure-summary.json
 artifact-manifest.json
 ```
 
 ## Security note
 
-The goal is not to trust the model to obey path rules. The goal is to make unauthorized paths unavailable or denied by the execution environment.
+The goal is not to trust the model to obey path rules. The goal is to make the intended repository paths absent from the agent work directory and to keep final copy-back constrained to the allowed lab files.
 
 Prompt rules are instructions. They are not enforcement.
 
-## Current recommendation
+## What this canary proves
 
-Proceed in this order:
+The first successful run supports these claims:
 
 ```text
-1. Add a feasibility smoke workflow.
-2. Run it manually on GitHub-hosted ubuntu-latest.
-3. Record the result in runs/.
-4. Implement full first-canary-007 only if feasibility is PASS or sufficiently understood.
+- Codex can run inside the policy container.
+- Codex can authenticate and execute from a non-repository /work directory when --skip-git-repo-check is specified.
+- Codex can edit the prepared lab files under /work.
+- The workflow can copy back only allowed files.
+- The final repository diff can remain within the allowed lab file set.
 ```
+
+## What this canary does not yet prove
+
+This canary does not yet prove:
+
+```text
+- repeated-run stability
+- full tracing of every file-access attempt
+- network restriction to only required API endpoints
+- formal proof that every possible container path outside the mounted areas is unreachable
+- that 007 should immediately replace 005 as the stable production-oriented path
+```
+
+## Promotion rule
+
+007 is currently a successful candidate path.
+
+Promotion condition:
+
+```text
+Promote 007 from candidate to standard agent path after at least 2 consecutive successful full 007 runs under the same fixed conditions, with matching policy diagnostics.
+```
+
+A successful repeated run must show:
+
+```text
+- Codex exit code 0
+- container exit code 0
+- final changed files subset of lab/index.html, lab/style.css, lab/app.js
+- repository root not mounted into the container work directory
+- container-visible work files limited to the prepared lab files plus expected runtime files
+- policy-denied-access empty or explained
+- safety-check PASS
+- static-site-check PASS
+- manual PR review and merge
+```
+
+## Current recommendation
+
+Use 005 for routine production-oriented implementation until 007 has at least one repeated success under unchanged fixed conditions.
+
+Use 007 for agent-style implementation experiments that require stronger filesystem-boundary evidence.

--- a/docs/current-codex-implementation-path.md
+++ b/docs/current-codex-implementation-path.md
@@ -2,13 +2,19 @@
 
 ## Status
 
-The current production-oriented implementation path is:
+The current stable production-oriented implementation path remains:
 
 ```text
 first-canary-005: offline context + JSON full-file replacement
 ```
 
-This path is preferred over direct repository editing for routine Prompt Vote Lab implementation runs.
+The strongest agent-boundary candidate path is now:
+
+```text
+first-canary-007: policy-enforced agent container
+```
+
+Do not silently replace `first-canary-005` with `first-canary-007` after only one successful 007 run. Treat 007 as the stronger candidate until repeated runs demonstrate stability.
 
 ## Why this path is current
 
@@ -20,6 +26,8 @@ first-canary-002: isolated three-file worktree + workspace-write -> FAIL
 first-canary-003: isolated three-file worktree + danger-full-access -> PASS
 first-canary-004: read-only repository context + unified diff writeback -> FAIL
 first-canary-005: empty context + JSON full-file replacement -> PASS
+first-canary-006: isolated three-file agent-observed direct edit -> PASS
+first-canary-007: Docker-mounted workdir-only policy agent -> PASS
 ```
 
 The result means:
@@ -30,11 +38,13 @@ The result means:
 - Relaxed direct editing can work, but it is not the safest default.
 - Repo-context writeback still allowed Codex to attempt an internal write path.
 - Offline-context JSON writeback gives the workflow control over actual file writes.
+- Agent-observed direct edit is useful for behavior analysis.
+- Policy-enforced container execution can run Codex as an agent without mounting the repository root into the agent work directory.
 ```
 
 ## Current default
 
-Use `first-canary-005` style execution for production-oriented implementation runs.
+Use `first-canary-005` style execution for routine production-oriented implementation runs.
 
 ```text
 runner: codex-cli-offline-json-writeback
@@ -49,7 +59,29 @@ final_writable_files: lab/index.html, lab/style.css, lab/app.js
 manual_review: required
 ```
 
-## How the current path works
+## Stronger candidate path
+
+Use `first-canary-007` for agent-style runs that need a stronger filesystem boundary.
+
+```text
+runner: codex-cli-policy-enforced-agent-container
+model: gpt-5.4-nano
+attempts_per_candidate: 1
+retry_policy: none
+fallback_policy: none
+auto_merge_policy: disabled
+sandbox_mode: docker-mounted-workdir-only
+execution_mode: policy-enforced agent direct edit
+container_work_root: /work
+container_runtime_root: /codex-runtime
+repo_root_mounted: false
+final_writable_files: lab/index.html, lab/style.css, lab/app.js
+manual_review: required
+```
+
+007 is not yet the default production-oriented implementation path because it has only one successful full run and has more operational dependencies than 005, including Docker, container npm installation, Codex runtime mounting, and API access from inside the container.
+
+## How the current stable path works
 
 ```text
 1. The workflow checks out the repository.
@@ -65,9 +97,25 @@ manual_review: required
 11. A human reviews and merges manually.
 ```
 
+## How the 007 candidate path works
+
+```text
+1. The workflow checks out the repository.
+2. The workflow copies lab/index.html, lab/style.css, and lab/app.js into a prepared work directory.
+3. The workflow mounts that work directory into a Docker container as /work.
+4. The workflow mounts a separate runtime directory as /codex-runtime.
+5. The repository root is not mounted into the container.
+6. Codex runs inside the container from /work with --skip-git-repo-check.
+7. Codex edits the prepared lab files as an agent.
+8. The workflow copies back only lab/index.html, lab/style.css, and lab/app.js.
+9. The workflow runs changed-file guard, safety-check, and static-site-check.
+10. The workflow creates a pull request.
+11. A human reviews and merges manually.
+```
+
 ## Allowed final write scope
 
-Only these files may be changed by the workflow-mediated writeback path:
+Only these files may be changed by the implementation paths:
 
 ```text
 lab/index.html
@@ -81,7 +129,7 @@ No other file path is a valid final output path.
 
 The safety boundary is not the model prompt alone.
 
-The boundary is the combination of:
+For 005, the boundary is the combination of:
 
 ```text
 - empty Codex execution context
@@ -98,19 +146,32 @@ The boundary is the combination of:
 - manual review
 ```
 
+For 007, the boundary is the combination of:
+
+```text
+- Docker-mounted workdir-only execution
+- repository root not mounted into the agent container
+- separate runtime mount at /codex-runtime
+- final copy-back limited to the three lab files
+- changed-file guard
+- safety-check
+- static-site-check
+- diagnostics artifact upload
+- manual review
+```
+
 Prompt instructions are still used, but they are not treated as enforcement.
 
 ## Why direct editing is not the default
 
-`first-canary-003` proved that isolated direct editing can work with relaxed sandbox mode:
+`first-canary-003` and `first-canary-006` proved that isolated direct editing can work with relaxed sandbox mode:
 
 ```text
-isolated three-file worktree + danger-full-access -> PASS
+first-canary-003: isolated three-file worktree + danger-full-access -> PASS
+first-canary-006: isolated three-file agent-observed direct edit -> PASS
 ```
 
-However, this mode should remain experimental because it relies on broad write capability inside the runner process. The final changed-file guard still helps, but the execution-time boundary is weaker than offline JSON writeback.
-
-Direct editing may still be useful for experiments that specifically evaluate Codex tool behavior, action traces, or sandbox behavior.
+However, these modes remain experimental because they rely on broad write capability inside the runner process. The final changed-file guard still helps, but the execution-time boundary is weaker than 007 and the mediated output boundary is less operationally stable than 005.
 
 ## Why first-canary-004 is not the default
 
@@ -126,9 +187,7 @@ For mediated output, provide only the required file contents and keep actual rep
 
 ## Remaining risks
 
-The current path is safer than relaxed direct editing, but not risk-free.
-
-Known residual risks:
+Known residual risks for 005:
 
 ```text
 - full-file JSON replacement can be verbose
@@ -139,17 +198,53 @@ Known residual risks:
 - manual review remains mandatory
 ```
 
-## Compatible improvements
-
-The following improvements are compatible with the current path if they preserve the same canary contract:
+Known residual risks for 007:
 
 ```text
-- stricter JSON schema validation
+- only one successful full run has been observed
+- Docker and npm installation add moving parts
+- network access is not narrowed to only required API endpoints
+- full file-access tracing is not yet implemented
+- container path coverage is sampled through diagnostics, not formally proven
+- manual review remains mandatory
+```
+
+## Promotion rule for 007
+
+Do not promote 007 to the standard agent path after a single success.
+
+Promotion condition:
+
+```text
+007 may be promoted from candidate to standard agent path after at least 2 consecutive successful full 007 runs under the same fixed conditions, with matching policy diagnostics.
+```
+
+A successful repeated 007 run must show:
+
+```text
+- Codex exit code 0
+- container exit code 0
+- final changed files subset of lab/index.html, lab/style.css, lab/app.js
+- repository root not mounted into the container work directory
+- container-visible work files limited to the prepared lab files plus expected runtime files
+- policy-denied-access empty or explained
+- safety-check PASS
+- static-site-check PASS
+- manual PR review and merge
+```
+
+## Compatible improvements
+
+The following improvements are compatible if they preserve the same canary contract:
+
+```text
+- stricter JSON schema validation for 005
 - tighter maximum size checks
 - required rationale summary in a separate JSON field
 - better diagnostics summaries
 - stronger HTML/CSS/JS static checks
 - snapshot tests for expected lab structure
+- richer 007 diagnostics summaries
 ```
 
 These can be added without changing the core protocol if they remain backward-compatible.
@@ -169,14 +264,22 @@ Use a new canary ID if any of these change:
 - writeback protocol
 - direct-edit versus mediated-writeback mode
 - patch versus JSON replacement protocol
+- container mount policy
+- repository root visibility
 ```
 
 ## Current recommendation
 
-Use this as the default implementation path:
+Use this for routine production-oriented implementation:
 
 ```text
 first-canary-005-offline-context-json-writeback
 ```
 
-Keep `first-canary-003` as an experimental direct-edit proof and `first-canary-004` as a documented negative result.
+Use this for agent-style implementation experiments with stronger filesystem boundary:
+
+```text
+first-canary-007-policy-enforced-agent-container
+```
+
+Run 007 again under the same fixed conditions before considering promotion.

--- a/scripts/test_current_codex_path_doc.py
+++ b/scripts/test_current_codex_path_doc.py
@@ -8,21 +8,26 @@ DOC = ROOT / "docs" / "current-codex-implementation-path.md"
 
 REQUIRED_TEXT = [
     "first-canary-005: offline context + JSON full-file replacement",
+    "first-canary-007: policy-enforced agent container",
     "runner: codex-cli-offline-json-writeback",
+    "runner: codex-cli-policy-enforced-agent-container",
     "model: gpt-5.4-nano",
     "attempts_per_candidate: 1",
     "retry_policy: none",
     "fallback_policy: none",
     "auto_merge_policy: disabled",
     "sandbox_mode: read-only-empty-context",
+    "sandbox_mode: docker-mounted-workdir-only",
     "writeback_mode: validated JSON full-file replacement",
+    "repo_root_mounted: false",
     "lab/index.html",
     "lab/style.css",
     "lab/app.js",
     "manual_review: required",
     "Prompt instructions are still used, but they are not treated as enforcement.",
-    "first-canary-003",
-    "first-canary-004",
+    "first-canary-006: isolated three-file agent-observed direct edit -> PASS",
+    "first-canary-007: Docker-mounted workdir-only policy agent -> PASS",
+    "007 may be promoted from candidate to standard agent path after at least 2 consecutive successful full 007 runs",
     "Do not give Codex a repository working tree if the intended protocol is purely mediated output.",
 ]
 


### PR DESCRIPTION
## Summary

Updates the Codex implementation path documents after the successful `first-canary-007-policy-enforced-agent` run.

## Changed files

- `docs/current-codex-implementation-path.md`
- `docs/canary-007-policy-enforced-agent.md`
- `scripts/test_current_codex_path_doc.py`

## What changed

- Records 007 as a successful policy-enforced agent candidate path.
- Keeps 005 as the current stable production-oriented writeback path.
- Adds a promotion rule: 007 needs at least 2 consecutive successful full runs with matching policy diagnostics before becoming the standard agent path.
- Updates the CI doc guard so the 007 classification is not accidentally removed.

## Scope

- Documentation and test update only.
- No canary execution.
- No `/lab/` changes.
- No model, retry, fallback, file-scope, or policy mount changes.