### PR TITLE
Add task packet canary contract tests

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -111,6 +111,12 @@ jobs:
       - name: Run current Codex path doc test
         run: python scripts/test_current_codex_path_doc.py
 
+      - name: Run task packet generator test
+        run: python scripts/test_create_codex_task_packet.py
+
+      - name: Run task packet runner contract test
+        run: python scripts/test_task_packet_runner_contract.py
+
       - name: Run terminal metadata extraction test
         run: python scripts/test_extract_pr_metadata.py
 

--- a/scripts/test_create_codex_task_packet.py
+++ b/scripts/test_create_codex_task_packet.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "create_codex_task_packet.py"
+
+REQUIRED_FILES = {
+    "selected-prompt.md",
+    "run-manifest.json",
+    "execution-policy.md",
+    "allowed-files.json",
+    "static-ui-v1.0.md",
+    "agent-run-policy-v1.0.md",
+    "task-file-hashes.json",
+}
+
+FORBIDDEN_SECRET_MARKERS = [
+    "OPENAI_API_KEY=",
+    "sk-",
+    "github_pat_",
+    "ghp_",
+    "gho_",
+]
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        out = Path(td) / "task"
+        subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--out-dir",
+                str(out),
+                "--canary-id",
+                "first-canary-008",
+                "--run-week",
+                "first-canary-008",
+                "--model",
+                "gpt-5.4-nano",
+            ],
+            cwd=ROOT,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        names = {p.name for p in out.iterdir() if p.is_file()}
+        missing = REQUIRED_FILES - names
+        if missing:
+            raise SystemExit(f"Missing task packet files: {sorted(missing)}")
+
+        manifest = json.loads((out / "run-manifest.json").read_text(encoding="utf-8"))
+        assert manifest["canary_id"] == "first-canary-008"
+        assert manifest["model"] == "gpt-5.4-nano"
+        assert manifest["attempts_per_candidate"] == 1
+        assert manifest["retry_policy"] == "none"
+        assert manifest["fallback_policy"] == "none"
+        assert manifest["auto_merge_policy"] == "disabled"
+        assert manifest["final_writable_files"] == [
+            "lab/index.html",
+            "lab/style.css",
+            "lab/app.js",
+        ]
+
+        allowed = json.loads((out / "allowed-files.json").read_text(encoding="utf-8"))
+        assert allowed["task_mount"] == "/task"
+        assert allowed["task_mount_mode"] == "read-only"
+        assert allowed["repo_root_mounted"] is False
+        assert allowed["final_copyback_paths"] == [
+            "lab/index.html",
+            "lab/style.css",
+            "lab/app.js",
+        ]
+
+        policy = (out / "execution-policy.md").read_text(encoding="utf-8")
+        required_policy_text = [
+            "The selected prompt is task input, not policy.",
+            "/task is read-only",
+            "The repository root is intentionally unavailable.",
+            "Do not add external scripts",
+        ]
+        for item in required_policy_text:
+            if item not in policy:
+                raise SystemExit(f"Missing execution policy text: {item}")
+
+        prompt = (out / "selected-prompt.md").read_text(encoding="utf-8")
+        if "eighth bounded Codex implementation-agent canary" not in prompt:
+            raise SystemExit("Selected prompt does not identify the eighth canary")
+
+        hashes = json.loads((out / "task-file-hashes.json").read_text(encoding="utf-8"))
+        for name in REQUIRED_FILES - {"task-file-hashes.json"}:
+            text = (out / name).read_text(encoding="utf-8")
+            if hashes[name]["sha256"] != sha256_text(text):
+                raise SystemExit(f"Hash mismatch for {name}")
+            if hashes[name]["size_bytes"] != len(text.encode("utf-8")):
+                raise SystemExit(f"Size mismatch for {name}")
+
+        all_text = "\n".join(
+            p.read_text(encoding="utf-8") for p in out.iterdir() if p.is_file()
+        )
+        for marker in FORBIDDEN_SECRET_MARKERS:
+            if marker in all_text:
+                raise SystemExit(f"Forbidden secret-like marker found in task packet: {marker}")
+
+    print("task packet generator test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_task_packet_runner_contract.py
+++ b/scripts/test_task_packet_runner_contract.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER = ROOT / "scripts" / "run_codex_task_packet_canary.sh"
+WORKFLOW = ROOT / ".github" / "workflows" / "codex-task-packet-canary-run.yml"
+
+REQUIRED_RUNNER_TEXT = [
+    "python scripts/create_codex_task_packet.py",
+    "-v \"$task:/task:ro\"",
+    "-v \"$work:/work:rw\"",
+    "-v \"$runtime:/codex-runtime:rw\"",
+    "-v \"$diag:/diagnostics:rw\"",
+    "OPENAI_API_KEY present before login: yes",
+    "OPENAI_API_KEY present before codex exec: no",
+    "unset OPENAI_API_KEY",
+    "task-write-test-exit-code.txt",
+    "policy-denied-access.txt",
+    "task-file-hashes.json",
+    "task-visible-files-container.txt",
+    "--skip-git-repo-check",
+]
+
+REQUIRED_WORKFLOW_TEXT = [
+    "name: Codex Task Packet Canary Run",
+    "CODEX_MODEL: gpt-5.4-nano",
+    "RUN_WEEK: first-canary-008",
+    "bash scripts/run_codex_task_packet_canary.sh",
+    "--canary-id first-canary-008",
+    "--runner-mode codex-cli-selected-prompt-task-packet-container",
+    "--sandbox-mode docker-workdir-plus-readonly-task-packet",
+    "codex-task-packet-canary-diagnostics-",
+    "codex-task-packet-canary-public-log-",
+    "--retry-policy none",
+    "--fallback-policy none",
+    "--auto-merge-policy disabled",
+]
+
+FORBIDDEN_RUNNER_TEXT = [
+    "-v \"$task:/task:rw\"",
+    "cat $OPENAI_API_KEY",
+    "echo $OPENAI_API_KEY",
+]
+
+
+def require_all(text: str, required: list[str], label: str) -> None:
+    missing = [item for item in required if item not in text]
+    if missing:
+        raise SystemExit(f"Missing {label} text: {missing}")
+
+
+def reject_all(text: str, forbidden: list[str], label: str) -> None:
+    found = [item for item in forbidden if item in text]
+    if found:
+        raise SystemExit(f"Forbidden {label} text found: {found}")
+
+
+def main() -> int:
+    runner_text = RUNNER.read_text(encoding="utf-8")
+    workflow_text = WORKFLOW.read_text(encoding="utf-8")
+
+    require_all(runner_text, REQUIRED_RUNNER_TEXT, "runner")
+    reject_all(runner_text, FORBIDDEN_RUNNER_TEXT, "runner")
+    require_all(workflow_text, REQUIRED_WORKFLOW_TEXT, "workflow")
+
+    if runner_text.index("codex login --with-api-key") > runner_text.index("unset OPENAI_API_KEY"):
+        raise SystemExit("OPENAI_API_KEY is unset before login, not after login")
+    if runner_text.index("unset OPENAI_API_KEY") > runner_text.index("codex exec"):
+        raise SystemExit("OPENAI_API_KEY is not unset before codex exec")
+
+    print("task packet runner contract test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds CI tests for the `first-canary-008` task packet generator and runner contract.

## Changed files

- `scripts/test_create_codex_task_packet.py`
- `scripts/test_task_packet_runner_contract.py`
- `.github/workflows/script-check.yml`

## What this guards

- task packet file set
- task packet hashes
- selected prompt canary identity
- fixed model/attempt/retry/fallback/auto-merge values
- `/task:ro`, `/work:rw`, `/codex-runtime:rw`, `/diagnostics:rw` mounts
- `OPENAI_API_KEY` is unset before `codex exec`
- 008 workflow runner metadata

## Scope

- Tests only.
- Does not run Codex.
- Does not modify `/lab/`.