### PR TITLE
Fix task packet diagnostics artifacts

### DIFF
--- a/scripts/collect_canary_diagnostics.py
+++ b/scripts/collect_canary_diagnostics.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import os
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -91,6 +90,10 @@ def classify_failure(changed_files: list[str], allowed_files: list[str], codex_s
     return "unknown_failure"
 
 
+def normalize_status(status: str) -> str:
+    return status.strip().lower()
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Collect canary diagnostics artifacts.")
     parser.add_argument("--out-dir", default=".tmp/canary-diagnostics")
@@ -151,7 +154,11 @@ def main() -> int:
     changed_files = parse_name_only(name_only)
     codex_stderr = (out_dir / "codex-stderr.txt").read_text(encoding="utf-8", errors="replace")
     codex_events = (out_dir / "codex-events.jsonl").read_text(encoding="utf-8", errors="replace")
-    failure_type = classify_failure(changed_files, allowed_files, codex_stderr, codex_events)
+    normalized_status = normalize_status(args.status)
+    if normalized_status == "success":
+        failure_type = "none"
+    else:
+        failure_type = classify_failure(changed_files, allowed_files, codex_stderr, codex_events)
 
     check_results = {
         "changed_files": changed_files,

--- a/scripts/run_codex_task_packet_canary.sh
+++ b/scripts/run_codex_task_packet_canary.sh
@@ -38,6 +38,8 @@ cp "$task/run-manifest.json" "$diag/task-run-manifest.json"
 cp "$task/allowed-files.json" "$diag/task-allowed-files.json"
 cp "$task/execution-policy.md" "$diag/task-execution-policy.md"
 cp "$task/selected-prompt.md" "$diag/task-selected-prompt.md"
+cp "$task/static-ui-v1.0.md" "$diag/task-static-ui-v1.0.md"
+cp "$task/agent-run-policy-v1.0.md" "$diag/task-agent-run-policy-v1.0.md"
 
 cat > "$diag/policy-allowed-paths.json" <<'EOF'
 {

--- a/scripts/test_collect_canary_diagnostics.py
+++ b/scripts/test_collect_canary_diagnostics.py
@@ -44,10 +44,21 @@ def main() -> int:
         "lab/style.css",
     ]
 
+    assert module.normalize_status(" success ") == "success"
+    assert module.normalize_status("FAILURE") == "failure"
+
     assert module.classify_failure([], module.DEFAULT_ALLOWED_FILES, "bwrap failed", "") == "sandbox_failure"
     assert module.classify_failure([], module.DEFAULT_ALLOWED_FILES, "401 Unauthorized", "") == "auth_failure"
     assert module.classify_failure([], module.DEFAULT_ALLOWED_FILES, "", "") == "no_changes"
     assert module.classify_failure(["README.md"], module.DEFAULT_ALLOWED_FILES, "", "") == "forbidden_changed_file"
+
+    # Successful runs must not retain a failure classifier such as auth_failure
+    # merely because Codex stderr mentions authentication during a successful login.
+    status = "success"
+    failure_type = "none" if module.normalize_status(status) == "success" else module.classify_failure(
+        ["lab/index.html"], module.DEFAULT_ALLOWED_FILES, "authentication", ""
+    )
+    assert failure_type == "none"
 
     print("canary diagnostics collector test passed")
     return 0

--- a/scripts/test_task_packet_runner_contract.py
+++ b/scripts/test_task_packet_runner_contract.py
@@ -20,6 +20,8 @@ REQUIRED_RUNNER_TEXT = [
     "policy-denied-access.txt",
     "task-file-hashes.json",
     "task-visible-files-container.txt",
+    "task-static-ui-v1.0.md",
+    "task-agent-run-policy-v1.0.md",
     "--skip-git-repo-check",
 ]
 


### PR DESCRIPTION
## Summary

Fixes two issues found while reviewing the `first-canary-008` diagnostics artifact.

## Changed files

- `scripts/run_codex_task_packet_canary.sh`
- `scripts/collect_canary_diagnostics.py`
- `scripts/test_collect_canary_diagnostics.py`
- `scripts/test_task_packet_runner_contract.py`

## Fixes

1. Include raw policy snapshot files in the 008 diagnostics artifact:
   - `task-static-ui-v1.0.md`
   - `task-agent-run-policy-v1.0.md`

2. Stop writing a failure classifier for successful runs:
   - successful diagnostics now use `failure_type: none`
   - this prevents successful login/authentication text from being misclassified as `auth_failure`

## Scope

- Diagnostics and tests only.
- Does not run Codex.
- Does not modify `/lab/`.
- Does not change model, retry, fallback, file-scope, or mounts.