### PR TITLE
Restore single-card lab baseline

### DIFF
--- a/lab/index.html
+++ b/lab/index.html
@@ -17,6 +17,9 @@
     </nav>
 
     <p class="status">Awaiting first accepted prompt run</p>
+    <div class="baseline-panel" role="note" aria-label="Lab baseline">
+      <strong>Lab baseline:</strong> this area is ready for the next accepted prompt run.
+    </div>
     <h1 id="lab-title">Prompt Vote Lab</h1>
     <p class="note">
       This area is the constrained implementation target. It starts intentionally small and will be changed only by accepted experiment runs.

--- a/lab/style.css
+++ b/lab/style.css
@@ -107,3 +107,18 @@ noscript {
   display: block;
   margin-top: 16px;
 }
+
+.baseline-panel {
+  margin: 0 0 16px;
+  padding: 10px 14px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--muted);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.baseline-panel strong {
+  color: var(--fg);
+}


### PR DESCRIPTION
## Summary

Restores the early single-card lab baseline shape without restoring canary/run metadata into the lab UI.

## Changed files

- `lab/index.html`
- `lab/style.css`

## What changed

- Adds one small baseline card after the status line.
- Reuses the early card style pattern from the first useful lab UI state.
- Uses neutral text instead of `Canary (...)` metadata.

## Why

The lab should keep a clean experiment-target shape. Previous experiment outputs and canary records belong in `runs/`, but the active lab baseline can still include a simple card that makes the page feel initialized rather than empty.

## Scope

- Lab UI baseline only.
- No timer.
- No canary metadata.
- No workflow, docs, rules, or runner changes.