### PR TITLE
Gate blocked Issues before agent execution

### DIFF
--- a/.github/workflows/codex-fixed-issue-instruction-canary-run.yml
+++ b/.github/workflows/codex-fixed-issue-instruction-canary-run.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Capture diagnostics baseline
         run: |
-          mkdir -p .tmp/canary-diagnostics .tmp/issue-source .tmp/issue-safety-runtime
+          mkdir -p .tmp/canary-diagnostics .tmp/issue-source .tmp/issue-safety-runtime .tmp/issue-execution-gate
           git status --porcelain > .tmp/canary-diagnostics/git-status-before.txt
           python - <<'PY' > .tmp/canary-diagnostics/file-hashes-before.json
           import hashlib
@@ -56,7 +56,7 @@ jobs:
           fi
           gh issue view "$ISSUE_NUMBER" \
             --repo "$GITHUB_REPOSITORY" \
-            --json number,title,body,url,author,createdAt \
+            --json number,title,body,url,author,createdAt,labels \
             > .tmp/issue-source/selected-issue.raw.json
           cp .tmp/issue-source/selected-issue.raw.json .tmp/canary-diagnostics/source-issue.raw.json
 
@@ -85,6 +85,27 @@ jobs:
             --scan-json .tmp/issue-safety-runtime/scan.json \
             --comment-md .tmp/issue-safety-runtime/comment.md \
             --issue-number "$ISSUE_NUMBER"
+
+      - name: Check Issue execution gate
+        run: |
+          set +e
+          python scripts/check_issue_execution_gate.py \
+            --scan-json .tmp/issue-safety-runtime/scan.json \
+            --issue-json .tmp/issue-source/selected-issue.raw.json \
+            --out-json .tmp/issue-execution-gate/gate.json \
+            --out-md .tmp/issue-execution-gate/gate.md
+          gate_rc=$?
+          cp .tmp/issue-execution-gate/gate.json .tmp/canary-diagnostics/issue-execution-gate.json 2>/dev/null || true
+          cp .tmp/issue-execution-gate/gate.md .tmp/canary-diagnostics/issue-execution-gate.md 2>/dev/null || true
+          exit "$gate_rc"
+
+      - name: Upload Issue execution gate artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-fixed-issue-execution-gate-${{ github.run_number }}
+          path: .tmp/issue-execution-gate
+          if-no-files-found: warn
 
       - name: Run Codex fixed Issue instruction packet once
         env:
@@ -229,6 +250,7 @@ jobs:
 
           - fixed Issue fetched before task packet generation
           - runtime Issue safety scan completed before task packet execution
+          - issue execution gate passed before Codex execution
           - instruction packet runner completed before PR creation
           - changed-file guard passed before PR creation
           - safety-check passed before PR creation
@@ -236,7 +258,7 @@ jobs:
 
           ## Diagnostics
 
-          Internal diagnostics artifact is uploaded for source Issue, runtime Issue safety scan, instruction packet, credential presence, mount, Codex event, and diff analysis.
+          Internal diagnostics artifact is uploaded for source Issue, runtime Issue safety scan, issue execution gate, instruction packet, credential presence, mount, Codex event, and diff analysis.
 
           ## Merge policy
 

--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -129,6 +129,9 @@ jobs:
       - name: Run Issue safety scan test
         run: python scripts/test_scan_issue_safety.py
 
+      - name: Run Issue execution gate test
+        run: python scripts/test_check_issue_execution_gate.py
+
       - name: Run terminal metadata extraction test
         run: python scripts/test_extract_pr_metadata.py
 

--- a/scripts/check_issue_execution_gate.py
+++ b/scripts/check_issue_execution_gate.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+AUTHORIZED_CANARY_LABEL = "authorized-canary"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def label_names(issue: dict[str, Any]) -> list[str]:
+    labels = issue.get("labels") or []
+    names: list[str] = []
+    for label in labels:
+        if isinstance(label, dict):
+            name = str(label.get("name") or "").strip()
+        else:
+            name = str(label).strip()
+        if name:
+            names.append(name)
+    return names
+
+
+def evaluate_gate(scan: dict[str, Any], issue: dict[str, Any]) -> dict[str, Any]:
+    labels = sorted(set(label_names(issue)))
+    unsafe_count = int(scan.get("unsafe_instruction_count") or 0)
+    severity = str(scan.get("severity") or "clear")
+    has_authorized_canary = AUTHORIZED_CANARY_LABEL in labels
+    needs_gate = unsafe_count > 0 or severity == "blocked"
+    execution_allowed = (not needs_gate) or has_authorized_canary
+    if execution_allowed and needs_gate:
+        reason = "Issue allowed only because authorized-canary label is present."
+    elif execution_allowed:
+        reason = "Issue safety scan is clear."
+    else:
+        reason = "Issue requires authorized-canary label before agent execution."
+
+    return {
+        "schema_version": "issue-execution-gate-v1",
+        "checked_at": utc_now(),
+        "issue_number": int(scan.get("issue_number") or issue.get("number") or 0),
+        "issue_title": str(scan.get("issue_title") or issue.get("title") or ""),
+        "unsafe_instruction_count": unsafe_count,
+        "severity": severity,
+        "labels": labels,
+        "required_exception_label": AUTHORIZED_CANARY_LABEL,
+        "has_authorized_canary_label": has_authorized_canary,
+        "gate_required": needs_gate,
+        "execution_allowed": execution_allowed,
+        "reason": reason,
+    }
+
+
+def render_markdown(gate: dict[str, Any]) -> str:
+    status = "PASS" if gate["execution_allowed"] else "STOP"
+    lines = [
+        "# Issue execution gate",
+        "",
+        f"Status: **{status}**",
+        "",
+        f"Issue: #{gate['issue_number']} {gate['issue_title']}",
+        f"Unsafe categories: `{gate['unsafe_instruction_count']}`",
+        f"Severity: `{gate['severity']}`",
+        f"Required exception label: `{gate['required_exception_label']}`",
+        f"Has exception label: `{str(gate['has_authorized_canary_label']).lower()}`",
+        "",
+        f"Reason: {gate['reason']}",
+        "",
+        "Labels:",
+    ]
+    if gate["labels"]:
+        lines.extend(f"- `{name}`" for name in gate["labels"])
+    else:
+        lines.append("- none")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scan-json", required=True)
+    parser.add_argument("--issue-json", required=True)
+    parser.add_argument("--out-json", required=True)
+    parser.add_argument("--out-md", required=True)
+    args = parser.parse_args()
+
+    scan = read_json(Path(args.scan_json))
+    issue = read_json(Path(args.issue_json))
+    gate = evaluate_gate(scan, issue)
+
+    Path(args.out_json).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out_json).write_text(json.dumps(gate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    Path(args.out_md).write_text(render_markdown(gate), encoding="utf-8")
+    print(json.dumps({"execution_allowed": gate["execution_allowed"], "reason": gate["reason"]}, sort_keys=True))
+    return 0 if gate["execution_allowed"] else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/scan_issue_safety.py
+++ b/scripts/scan_issue_safety.py
@@ -17,6 +17,7 @@ REVIEW_LABEL = "issue-safety:review"
 BLOCKED_LABEL = "issue-safety:blocked"
 POST_DETECTED_LABEL = "issue-safety:submission-detected"
 RUNTIME_DETECTED_LABEL = "issue-safety:runtime-detected"
+AUTHORIZED_CANARY_LABEL = "authorized-canary"
 
 ALL_LABELS = [
     CLEAR_LABEL,
@@ -46,6 +47,10 @@ LABEL_METADATA = {
     RUNTIME_DETECTED_LABEL: {
         "color": "a371f7",
         "description": "Unsafe instruction categories were detected during a fixed-Issue runtime packet run.",
+    },
+    AUTHORIZED_CANARY_LABEL: {
+        "color": "8250df",
+        "description": "Maintainer-approved exception for a controlled canary run of a blocked Issue.",
     },
 }
 
@@ -137,8 +142,8 @@ def recommended_action(unsafe_count: int, phase: str) -> str:
     if unsafe_count == 0:
         return "No unsafe instruction categories were detected. The Issue can proceed to normal review."
     if phase == "issue_event":
-        return "Revise the Issue before using it for an agent run, or keep it as an explicit hostile canary."
-    return "Do not merge a runtime result unless the final diff remains within lab/ and the unsafe parts are explicitly ignored."
+        return "Revise the Issue before using it for an agent run, or keep it as an explicitly authorized canary."
+    return "Agent execution is blocked unless the maintainer adds the authorized-canary label for a controlled canary run."
 
 
 def render_comment(scan: dict[str, Any]) -> str:
@@ -170,7 +175,8 @@ def render_comment(scan: dict[str, Any]) -> str:
                 "### Required correction",
                 "",
                 "Remove or reword the unsafe instructions if this Issue is intended for a normal agent run.",
-                "Keep the unsafe text only when this Issue is deliberately being used as a hostile canary.",
+                "Keep the unsafe text only when this Issue is deliberately being used as an authorized canary.",
+                f"A blocked Issue requires the `{AUTHORIZED_CANARY_LABEL}` label before agent execution.",
                 "",
             ]
         )

--- a/scripts/test_check_issue_execution_gate.py
+++ b/scripts/test_check_issue_execution_gate.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check_issue_execution_gate.py"
+
+
+def run_gate(scan: dict[str, object], issue: dict[str, object]) -> tuple[int, dict[str, object], str]:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        scan_json = tmp / "scan.json"
+        issue_json = tmp / "issue.json"
+        out_json = tmp / "gate.json"
+        out_md = tmp / "gate.md"
+        scan_json.write_text(json.dumps(scan), encoding="utf-8")
+        issue_json.write_text(json.dumps(issue), encoding="utf-8")
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--scan-json",
+                str(scan_json),
+                "--issue-json",
+                str(issue_json),
+                "--out-json",
+                str(out_json),
+                "--out-md",
+                str(out_md),
+            ],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        return result.returncode, json.loads(out_json.read_text(encoding="utf-8")), out_md.read_text(encoding="utf-8")
+
+
+def test_clear_issue_allowed() -> None:
+    rc, gate, md = run_gate(
+        {
+            "issue_number": 300,
+            "issue_title": "Add local cards",
+            "unsafe_instruction_count": 0,
+            "severity": "clear",
+        },
+        {"number": 300, "title": "Add local cards", "labels": [{"name": "issue-safety:clear"}]},
+    )
+    assert rc == 0
+    assert gate["execution_allowed"] is True
+    assert gate["gate_required"] is False
+    assert gate["reason"] == "Issue safety scan is clear."
+    assert "Status: **PASS**" in md
+
+
+def test_blocked_issue_stops_without_authorized_label() -> None:
+    rc, gate, md = run_gate(
+        {
+            "issue_number": 301,
+            "issue_title": "Unsafe request",
+            "unsafe_instruction_count": 2,
+            "severity": "blocked",
+        },
+        {"number": 301, "title": "Unsafe request", "labels": [{"name": "issue-safety:blocked"}]},
+    )
+    assert rc == 3
+    assert gate["execution_allowed"] is False
+    assert gate["gate_required"] is True
+    assert gate["has_authorized_canary_label"] is False
+    assert gate["required_exception_label"] == "authorized-canary"
+    assert "Status: **STOP**" in md
+
+
+def test_blocked_issue_allowed_with_authorized_label() -> None:
+    rc, gate, md = run_gate(
+        {
+            "issue_number": 302,
+            "issue_title": "Controlled canary request",
+            "unsafe_instruction_count": 3,
+            "severity": "blocked",
+        },
+        {
+            "number": 302,
+            "title": "Controlled canary request",
+            "labels": [{"name": "issue-safety:blocked"}, {"name": "authorized-canary"}],
+        },
+    )
+    assert rc == 0
+    assert gate["execution_allowed"] is True
+    assert gate["gate_required"] is True
+    assert gate["has_authorized_canary_label"] is True
+    assert gate["reason"] == "Issue allowed only because authorized-canary label is present."
+    assert "Status: **PASS**" in md
+
+
+def main() -> int:
+    test_clear_issue_allowed()
+    test_blocked_issue_stops_without_authorized_label()
+    test_blocked_issue_allowed_with_authorized_label()
+    print("Issue execution gate test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_issue_instruction_runner_contract.py
+++ b/scripts/test_issue_instruction_runner_contract.py
@@ -39,10 +39,15 @@ REQUIRED_WORKFLOW_TEXT = [
     "CODEX_MODEL: gpt-5.4-nano",
     "RUN_WEEK: first-canary-009",
     "gh issue view \"$ISSUE_NUMBER\"",
-    "--json number,title,body,url,author,createdAt",
+    "--json number,title,body,url,author,createdAt,labels",
     "python scripts/scan_issue_safety.py",
     "--phase runtime",
     "bash scripts/apply_issue_safety_feedback.sh",
+    "python scripts/check_issue_execution_gate.py",
+    "--scan-json .tmp/issue-safety-runtime/scan.json",
+    "--issue-json .tmp/issue-source/selected-issue.raw.json",
+    "issue execution gate passed before Codex execution",
+    "codex-fixed-issue-execution-gate-",
     "runtime Issue safety scan completed before task packet execution",
     "bash scripts/run_codex_issue_instruction_canary.sh",
     "--canary-id first-canary-009",
@@ -83,6 +88,8 @@ def main() -> int:
     reject_all(runner_text, FORBIDDEN_RUNNER_TEXT, "runner")
     require_all(workflow_text, REQUIRED_WORKFLOW_TEXT, "workflow")
 
+    if workflow_text.index("Check Issue execution gate") > workflow_text.index("Run Codex fixed Issue instruction packet once"):
+        raise SystemExit("Issue execution gate must run before Codex execution")
     if runner_text.index("codex login --with-api-key") > runner_text.index("unset OPENAI_API_KEY"):
         raise SystemExit("OPENAI_API_KEY is unset before login, not after login")
     if runner_text.index("unset OPENAI_API_KEY") > runner_text.index("codex exec"):


### PR DESCRIPTION
## Summary

Adds a runtime execution gate so blocked Issues do not proceed to Codex execution unless a maintainer explicitly marks the Issue as an authorized canary.

## Changes

- Adds `scripts/check_issue_execution_gate.py`.
- Updates the 009 fixed-Issue workflow to fetch Issue labels.
- Runs the execution gate after runtime Issue safety scan and before Codex execution.
- Blocks execution when the runtime scan is blocked and the Issue does not have `authorized-canary`.
- Allows execution when the scan is clear, or when the Issue is blocked but has `authorized-canary`.
- Adds `scripts/test_check_issue_execution_gate.py`.
- Updates the 009 workflow contract test and Script Check registration.
- Updates Issue safety feedback text to tell maintainers that blocked Issues require `authorized-canary` before agent execution.

## Operational policy

- Normal Issues: must pass the Issue safety scan.
- Blocked Issues: stop before Codex execution.
- Controlled canary Issues: require explicit maintainer label `authorized-canary`.
- Auto-merge remains disabled.
- Vote-winner automatic execution remains out of scope.

## Tests expected

- `python scripts/test_check_issue_execution_gate.py`
- `python scripts/test_issue_instruction_runner_contract.py`
- Existing Script Check workflow

## Scope

- No `/lab/` changes.
- No model/API run.
- No vote-winner selection.
- No auto-merge.