### PR TITLE
Add manual Issue safety rescan

### DIFF
--- a/.github/workflows/issue-safety-scan.yml
+++ b/.github/workflows/issue-safety-scan.yml
@@ -6,35 +6,71 @@ on:
       - opened
       - edited
       - reopened
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to rescan manually"
+        required: true
+        type: number
 
 permissions:
   contents: read
   issues: write
 
 concurrency:
-  group: issue-safety-scan-${{ github.event.issue.number }}
+  group: issue-safety-scan-${{ github.event.issue.number || inputs.issue_number }}
   cancel-in-progress: true
 
 jobs:
   issue-safety-scan:
     runs-on: ubuntu-latest
+    env:
+      ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Scan Issue safety on submit or edit
+      - name: Prepare Issue source
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          mkdir -p .tmp/issue-safety-scan
-          python scripts/scan_issue_safety.py \
-            --issue-event-json "$GITHUB_EVENT_PATH" \
-            --phase issue_event \
-            --out-json .tmp/issue-safety-scan/scan.json \
-            --out-md .tmp/issue-safety-scan/comment.md
+          mkdir -p .tmp/issue-safety-scan .tmp/issue-source
+          if [ "${{ github.event_name }}" = "issues" ]; then
+            cp "$GITHUB_EVENT_PATH" .tmp/issue-source/issue-event.json
+            echo "event" > .tmp/issue-source/source-mode.txt
+          else
+            if [ -z "$ISSUE_NUMBER" ] || [ "$ISSUE_NUMBER" = "0" ]; then
+              echo "issue_number input must be positive"
+              exit 1
+            fi
+            gh issue view "$ISSUE_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json number,title,body,url,author,createdAt,updatedAt \
+              > .tmp/issue-source/issue.raw.json
+            echo "manual" > .tmp/issue-source/source-mode.txt
+          fi
+
+      - name: Scan Issue safety
+        run: |
+          mode="$(cat .tmp/issue-source/source-mode.txt)"
+          if [ "$mode" = "event" ]; then
+            python scripts/scan_issue_safety.py \
+              --issue-event-json .tmp/issue-source/issue-event.json \
+              --phase issue_event \
+              --out-json .tmp/issue-safety-scan/scan.json \
+              --out-md .tmp/issue-safety-scan/comment.md
+          else
+            python scripts/scan_issue_safety.py \
+              --issue-json .tmp/issue-source/issue.raw.json \
+              --phase issue_event \
+              --out-json .tmp/issue-safety-scan/scan.json \
+              --out-md .tmp/issue-safety-scan/comment.md
+          fi
 
       - name: Upload scan artifact
         uses: actions/upload-artifact@v4
         with:
-          name: issue-safety-scan-${{ github.event.issue.number }}-${{ github.run_number }}
+          name: issue-safety-scan-${{ env.ISSUE_NUMBER }}-${{ github.run_number }}
           path: .tmp/issue-safety-scan
           if-no-files-found: error
 
@@ -45,4 +81,4 @@ jobs:
           bash scripts/apply_issue_safety_feedback.sh \
             --scan-json .tmp/issue-safety-scan/scan.json \
             --comment-md .tmp/issue-safety-scan/comment.md \
-            --issue-number "${{ github.event.issue.number }}"
+            --issue-number "$ISSUE_NUMBER"

--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -129,6 +129,9 @@ jobs:
       - name: Run Issue safety scan test
         run: python scripts/test_scan_issue_safety.py
 
+      - name: Run Issue safety workflow contract test
+        run: python scripts/test_issue_safety_workflow_contract.py
+
       - name: Run Issue execution gate test
         run: python scripts/test_check_issue_execution_gate.py
 

--- a/scripts/test_issue_safety_workflow_contract.py
+++ b/scripts/test_issue_safety_workflow_contract.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "issue-safety-scan.yml"
+
+REQUIRED_TEXT = [
+    "name: Issue Safety Scan",
+    "issues:",
+    "- opened",
+    "- edited",
+    "- reopened",
+    "workflow_dispatch:",
+    "issue_number:",
+    "contents: read",
+    "issues: write",
+    "ISSUE_NUMBER:",
+    "gh issue view \"$ISSUE_NUMBER\"",
+    "--json number,title,body,url,author,createdAt,updatedAt",
+    "python scripts/scan_issue_safety.py",
+    "--phase issue_event",
+    "bash scripts/apply_issue_safety_feedback.sh",
+    "issue-safety-scan-${{ env.ISSUE_NUMBER }}-${{ github.run_number }}",
+]
+
+FORBIDDEN_TEXT = [
+    "contents: write",
+    "pull-requests: write",
+    "OPENAI_API_KEY",
+    "bash scripts/run_codex_issue_instruction_canary.sh",
+]
+
+
+def main() -> int:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    missing = [item for item in REQUIRED_TEXT if item not in text]
+    if missing:
+        raise SystemExit(f"Missing Issue Safety Scan workflow contract text: {missing}")
+    found = [item for item in FORBIDDEN_TEXT if item in text]
+    if found:
+        raise SystemExit(f"Forbidden Issue Safety Scan workflow text found: {found}")
+    print("Issue safety workflow contract test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a manual fallback path for Issue Safety Scan so maintainers can rescan any Issue by number when the automatic `issues` event does not fire or when an API-created Issue needs explicit confirmation.

## Changes

- Adds `workflow_dispatch` to `.github/workflows/issue-safety-scan.yml`.
- Accepts an `issue_number` input for manual rescans.
- Fetches the Issue via `gh issue view` and runs the same `issue_event` scan path.
- Keeps permissions limited to `contents: read` and `issues: write`.
- Adds `scripts/test_issue_safety_workflow_contract.py` to lock in the manual rescan contract.
- Registers the new contract test in Script Check.

## Reason

Issue #170 was created as a controlled safety canary, but the immediate issue-event feedback was not visible through the connector after creation. This PR adds a deterministic manual rescan path rather than relying only on the automatic event trigger.

## Tests expected

- `python scripts/test_issue_safety_workflow_contract.py`
- Existing Script Check workflow

## Scope

- No `/lab/` changes.
- No Codex/model/API run.
- No auto-merge.
- No vote-winner selection.