### PR TITLE
Preserve Issue safety phase labels

### DIFF
--- a/scripts/scan_issue_safety.py
+++ b/scripts/scan_issue_safety.py
@@ -18,14 +18,9 @@ BLOCKED_LABEL = "issue-safety:blocked"
 POST_DETECTED_LABEL = "issue-safety:submission-detected"
 RUNTIME_DETECTED_LABEL = "issue-safety:runtime-detected"
 AUTHORIZED_CANARY_LABEL = "authorized-canary"
-
-ALL_LABELS = [
-    CLEAR_LABEL,
-    REVIEW_LABEL,
-    BLOCKED_LABEL,
-    POST_DETECTED_LABEL,
-    RUNTIME_DETECTED_LABEL,
-]
+STATUS_LABELS = [CLEAR_LABEL, REVIEW_LABEL, BLOCKED_LABEL]
+PHASE_LABELS = [POST_DETECTED_LABEL, RUNTIME_DETECTED_LABEL]
+ALL_LABELS = STATUS_LABELS + PHASE_LABELS
 
 LABEL_METADATA = {
     CLEAR_LABEL: {
@@ -98,18 +93,25 @@ def issue_from_raw_json(path: Path) -> dict[str, Any]:
     }
 
 
+def labels_for_scan(unsafe_count: int, phase: str) -> tuple[list[str], list[str]]:
+    status_to_add = [CLEAR_LABEL] if unsafe_count == 0 else [REVIEW_LABEL, BLOCKED_LABEL]
+    phase_to_add = [POST_DETECTED_LABEL] if phase == "issue_event" else [RUNTIME_DETECTED_LABEL]
+
+    labels_to_add = status_to_add + phase_to_add
+
+    # Status labels are mutually exclusive and should reflect the latest scan result.
+    # Phase labels are cumulative evidence: a runtime scan must not erase prior posting/edit detection,
+    # and a posting/edit scan must not erase prior runtime evidence.
+    labels_to_remove = [label for label in STATUS_LABELS if label not in status_to_add]
+    return labels_to_add, labels_to_remove
+
+
 def scan_issue(issue: dict[str, Any], phase: str) -> dict[str, Any]:
     findings = packet.detect_unsafe_instructions(issue["issue_title"], issue["body"])
     safe_task = packet.make_safe_task(issue["issue_title"], issue["body"])
     unsafe_count = len(findings)
     severity = "clear" if unsafe_count == 0 else "blocked"
-    labels_to_add = [CLEAR_LABEL] if unsafe_count == 0 else [REVIEW_LABEL, BLOCKED_LABEL]
-    if phase == "issue_event":
-        labels_to_add.append(POST_DETECTED_LABEL)
-    elif phase == "runtime":
-        labels_to_add.append(RUNTIME_DETECTED_LABEL)
-
-    labels_to_remove = [label for label in ALL_LABELS if label not in labels_to_add]
+    labels_to_add, labels_to_remove = labels_for_scan(unsafe_count, phase)
 
     return {
         "schema_version": "issue-safety-scan-v1",

--- a/scripts/test_scan_issue_safety.py
+++ b/scripts/test_scan_issue_safety.py
@@ -59,7 +59,7 @@ def test_issue_event_hostile_feedback() -> None:
     assert "issue-safety:blocked" in scan["labels_to_add"]
     assert "issue-safety:review" in scan["labels_to_add"]
     assert "issue-safety:submission-detected" in scan["labels_to_add"]
-    assert "issue-safety:runtime-detected" in scan["labels_to_remove"]
+    assert "issue-safety:runtime-detected" not in scan["labels_to_remove"]
     detected = {item["id"] for item in scan["unsafe_instructions_detected"]}
     assert {"policy_override", "file_scope_escalation", "network_behavior", "cookie_or_tracking"}.issubset(detected)
     assert "<!-- prompt-vote-lab:issue-safety-scan:v1 -->" in comment
@@ -84,7 +84,7 @@ def test_runtime_hostile_feedback_marker_is_separate() -> None:
     assert scan["phase"] == "runtime"
     assert scan["severity"] == "blocked"
     assert "issue-safety:runtime-detected" in scan["labels_to_add"]
-    assert "issue-safety:submission-detected" in scan["labels_to_remove"]
+    assert "issue-safety:submission-detected" not in scan["labels_to_remove"]
     detected = {item["id"] for item in scan["unsafe_instructions_detected"]}
     assert {"network_behavior", "self_merge_or_repo_mutation"}.issubset(detected)
     assert "<!-- prompt-vote-lab:issue-runtime-safety-scan:v1 -->" in comment
@@ -112,6 +112,8 @@ def test_clear_issue_feedback() -> None:
     assert scan["unsafe_instruction_count"] == 0
     assert scan["labels_to_add"] == ["issue-safety:clear", "issue-safety:submission-detected"]
     assert "issue-safety:blocked" in scan["labels_to_remove"]
+    assert "issue-safety:review" in scan["labels_to_remove"]
+    assert "issue-safety:runtime-detected" not in scan["labels_to_remove"]
     assert "No unsafe instruction categories were detected" in comment
 
 


### PR DESCRIPTION
## Summary

Fixes Issue safety scan label behavior so posting/editing evidence and runtime evidence can coexist.

## Problem

After Issue #170 was manually rescanned and then used in a 009 runtime gate test, the Issue retained `issue-safety:runtime-detected` but lost `issue-safety:submission-detected`. The comments were still correct, but the labels no longer represented both detection phases.

## Changes

- Splits Issue safety labels into:
  - status labels: `issue-safety:clear`, `issue-safety:review`, `issue-safety:blocked`
  - phase labels: `issue-safety:submission-detected`, `issue-safety:runtime-detected`
- Keeps status labels mutually exclusive and based on the latest scan.
- Keeps phase labels cumulative evidence.
- Updates tests so runtime scans do not remove submission-detected, and submission scans do not remove runtime-detected.

## Tests expected

- `python scripts/test_scan_issue_safety.py`
- Existing Script Check workflow

## Scope

- No `/lab/` changes.
- No Codex/model/API run.
- No workflow dispatch changes.
- No auto-merge.