### PR TITLE
Add public results export for participant analysis

### DIFF
--- a/.github/workflows/public-results-export.yml
+++ b/.github/workflows/public-results-export.yml
@@ -1,0 +1,166 @@
+name: Public Results Export
+
+on:
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: "Maximum Issues, PRs, and workflow runs to export"
+        required: false
+        default: "100"
+      commit_results:
+        description: "Commit data/public-results.json and data/public-results.md to the current branch"
+        required: false
+        default: "true"
+  schedule:
+    - cron: "17 3 * * *"
+
+permissions:
+  contents: write
+  issues: read
+  pull-requests: read
+  actions: read
+
+concurrency:
+  group: public-results-export
+  cancel-in-progress: true
+
+jobs:
+  public-results-export:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch public repository data
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_LIMIT: ${{ inputs.limit }}
+        run: |
+          set -euo pipefail
+          mkdir -p .tmp/public-results data
+          limit="${INPUT_LIMIT:-100}"
+          if [ -z "$limit" ]; then limit=100; fi
+          owner="${GITHUB_REPOSITORY%/*}"
+          repo="${GITHUB_REPOSITORY#*/}"
+
+          cat > .tmp/public-results/query.graphql <<'GRAPHQL'
+          query($owner: String!, $repo: String!, $limit: Int!) {
+            repository(owner: $owner, name: $repo) {
+              issues(first: $limit, orderBy: {field: UPDATED_AT, direction: DESC}) {
+                nodes {
+                  number
+                  title
+                  body
+                  state
+                  url
+                  createdAt
+                  updatedAt
+                  closedAt
+                  author { login }
+                  labels(first: 50) { nodes { name } }
+                  reactionGroups { content users { totalCount } }
+                  comments { totalCount }
+                }
+              }
+              pullRequests(first: $limit, orderBy: {field: UPDATED_AT, direction: DESC}) {
+                nodes {
+                  number
+                  title
+                  body
+                  state
+                  url
+                  createdAt
+                  updatedAt
+                  closedAt
+                  mergedAt
+                  author { login }
+                  mergedBy { login }
+                  baseRefName
+                  headRefName
+                  headRefOid
+                  mergeCommit { oid }
+                  labels(first: 50) { nodes { name } }
+                  reactionGroups { content users { totalCount } }
+                  comments { totalCount }
+                  changedFiles
+                  additions
+                  deletions
+                  reviewDecision
+                  files(first: 100) { nodes { path additions deletions } }
+                }
+              }
+            }
+          }
+          GRAPHQL
+
+          gh api graphql \
+            -f owner="$owner" \
+            -f repo="$repo" \
+            -F limit="$limit" \
+            -f query="$(cat .tmp/public-results/query.graphql)" \
+            > .tmp/public-results/repository.graphql.json
+
+          python - <<'PY'
+          from __future__ import annotations
+          import json
+          from pathlib import Path
+          raw = json.loads(Path('.tmp/public-results/repository.graphql.json').read_text(encoding='utf-8'))
+          repo = raw['data']['repository']
+          Path('.tmp/public-results/issues.json').write_text(json.dumps(repo['issues']['nodes'], indent=2, ensure_ascii=False) + '\n', encoding='utf-8')
+          Path('.tmp/public-results/pull-requests.json').write_text(json.dumps(repo['pullRequests']['nodes'], indent=2, ensure_ascii=False) + '\n', encoding='utf-8')
+          PY
+
+          gh run list \
+            --repo "$GITHUB_REPOSITORY" \
+            --limit "$limit" \
+            --json databaseId,name,workflowName,displayTitle,event,status,conclusion,createdAt,updatedAt,headBranch,headSha,url \
+            > .tmp/public-results/workflow-runs.json
+
+          gh label list \
+            --repo "$GITHUB_REPOSITORY" \
+            --limit 200 \
+            --json name,color,description \
+            > .tmp/public-results/labels.json
+
+      - name: Build public results export
+        run: |
+          python scripts/build_public_results_export.py \
+            --issues .tmp/public-results/issues.json \
+            --prs .tmp/public-results/pull-requests.json \
+            --workflow-runs .tmp/public-results/workflow-runs.json \
+            --labels .tmp/public-results/labels.json \
+            --runs-dir runs \
+            --out-json data/public-results.json \
+            --out-md data/public-results.md
+
+      - name: Upload public results artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: public-results-export-${{ github.run_number }}
+          path: |
+            data/public-results.json
+            data/public-results.md
+            .tmp/public-results
+          if-no-files-found: error
+
+      - name: Commit public results snapshot
+        env:
+          INPUT_COMMIT_RESULTS: ${{ inputs.commit_results }}
+        run: |
+          set -euo pipefail
+          commit_results="${INPUT_COMMIT_RESULTS:-true}"
+          if [ "$commit_results" != "true" ]; then
+            echo "commit_results is not true; skipping commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/public-results.json data/public-results.md
+          if git diff --cached --quiet; then
+            echo "No public results changes to commit."
+            exit 0
+          fi
+          git commit -m "Update public results export"
+          git push

--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -9,6 +9,7 @@ on:
       - "tests/fixtures/**"
       - ".github/workflows/script-check.yml"
       - ".github/workflows/issue-safety-scan.yml"
+      - ".github/workflows/public-results-export.yml"
       - ".github/workflows/codex-first-canary-run.yml"
       - ".github/workflows/codex-isolated-3file-canary-run.yml"
       - ".github/workflows/codex-isolated-3file-relaxed-canary-run.yml"
@@ -20,9 +21,12 @@ on:
       - ".github/workflows/codex-task-packet-canary-run.yml"
       - ".github/workflows/codex-fixed-issue-instruction-canary-run.yml"
       - "README.md"
+      - "data/public-results.json"
+      - "data/public-results.md"
       - "docs/codex-runner-contract.md"
       - "docs/canary-log-policy.md"
       - "docs/current-codex-implementation-path.md"
+      - "docs/public-results-export.md"
       - "docs/canary-007-policy-enforced-agent.md"
       - "docs/canary-008-selected-prompt-task-packet.md"
       - "docs/canary-009-selected-issue-instructions.md"
@@ -120,6 +124,12 @@ jobs:
 
       - name: Run usable experiment ops doc test
         run: python scripts/test_usable_experiment_ops_doc.py
+
+      - name: Run public results export builder test
+        run: python scripts/test_build_public_results_export.py
+
+      - name: Run public results export workflow contract test
+        run: python scripts/test_public_results_export_workflow_contract.py
 
       - name: Run task packet generator test
         run: python scripts/test_create_codex_task_packet.py

--- a/data/public-results.json
+++ b/data/public-results.json
@@ -1,0 +1,26 @@
+{
+  "issues": [],
+  "labels": [],
+  "pull_requests": [],
+  "run_records": [],
+  "schema_version": "prompt-vote-lab-public-results-export-v1",
+  "scope": {
+    "interpretation": "none; participant analysis expected",
+    "privacy": "public GitHub repository data only",
+    "raw_actions_logs": "not collected",
+    "secrets": "not collected"
+  },
+  "summary": {
+    "authorized_canary_issue_count": 0,
+    "blocked_issue_count": 0,
+    "clear_issue_count": 0,
+    "issue_count": 0,
+    "merged_pr_count": 0,
+    "open_issue_count": 0,
+    "open_pr_count": 0,
+    "pr_count": 0,
+    "run_record_count": 0,
+    "workflow_run_count": 0
+  },
+  "workflow_runs": []
+}

--- a/data/public-results.md
+++ b/data/public-results.md
@@ -1,0 +1,18 @@
+# Prompt Vote Lab public results export
+
+Generated at: `not generated yet`
+
+This file is a raw results surface for participants. It does not score prompts or recommend improvements.
+
+## Summary
+
+| metric | value |
+| --- | --- |
+| issue_count | 0 |
+| pr_count | 0 |
+| workflow_run_count | 0 |
+| run_record_count | 0 |
+
+## Raw JSON
+
+See `public-results.json` in the same directory.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,20 +11,21 @@ Prompt Vote Lab is a prompt game and experiment. Players compete by writing prom
 1. [Experiment model](./experiment-model.md) — game model and boundaries.
 2. [How to participate](./how-to-participate.md) — submit, vote, and review.
 3. [Usable experiment operations](./usable-experiment-ops.md) — current manual canary and comparison-run operations.
-4. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
-5. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
-6. [Automation map](./automation-map.md) — workflow boundaries.
-7. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
-8. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
-9. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and pre-canary cleanup.
-10. [Fixed first canary prompt](./first-canary-prompt.md) — the only allowed first real canary prompt.
-11. [First canary readiness checklist](./first-canary-readiness.md) — final check before running the first real canary.
-12. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
-13. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
-14. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
-15. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
-16. [Report policy](./report-policy.md) — weekly report draft policy.
-17. [Pre-API freeze checklist](./pre-api-freeze.md) — gates before paid agent runs.
+4. [Public results export](./public-results-export.md) — raw public data snapshots for participant analysis.
+5. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
+6. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
+7. [Automation map](./automation-map.md) — workflow boundaries.
+8. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
+9. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
+10. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and pre-canary cleanup.
+11. [Fixed first canary prompt](./first-canary-prompt.md) — the only allowed first real canary prompt.
+12. [First canary readiness checklist](./first-canary-readiness.md) — final check before running the first real canary.
+13. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
+14. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
+15. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
+16. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
+17. [Report policy](./report-policy.md) — weekly report draft policy.
+18. [Pre-API freeze checklist](./pre-api-freeze.md) — gates before paid agent runs.
 
 ## Current reputation status
 
@@ -39,6 +40,19 @@ Report generation is currently model-free.
 The workflow can draft `runs/<week>-report.md` from explicit inputs and repository files, then open a reviewable PR.
 
 It does not publish externally and does not compute automated trust ratings.
+
+## Public results status
+
+Public results export is raw data, not analysis.
+
+Participants can inspect:
+
+```text
+data/public-results.json
+data/public-results.md
+```
+
+The export is intended for participant-side analysis of prompt outcomes, votes, labels, PRs, workflow runs, and run records.
 
 ## Current usable experiment status
 
@@ -100,6 +114,7 @@ GitHub rendered views show the documents as readable Markdown.
 ```text
 /      = stable explanation layer
 /lab/  = changing implementation target
+/data/ = raw public results snapshots
 /docs/ = rendered project explanation
 /rules/ = operational constraints
 /runs/ = recorded run history

--- a/docs/public-results-export.md
+++ b/docs/public-results-export.md
@@ -1,0 +1,111 @@
+# Public results export
+
+## Purpose
+
+Prompt Vote Lab is an experiment. Participants should be able to inspect raw public result data and analyze it themselves.
+
+This export is intentionally descriptive, not interpretive.
+
+It does not score prompts, rank authors, recommend improvements, or explain why a prompt succeeded.
+
+## Outputs
+
+The public results export writes:
+
+```text
+data/public-results.json
+data/public-results.md
+```
+
+The JSON file is the primary machine-readable data source.
+
+The Markdown file is a lightweight table view for humans.
+
+## What is collected
+
+The export collects public GitHub repository data:
+
+```text
+Issues
+Pull Requests
+Issue labels
+PR labels
+Issue reactions
+PR reactions
+Issue comment counts
+PR comment counts
+PR changed file counts
+PR additions/deletions
+PR changed file paths
+workflow run metadata
+run record markdown files under runs/
+```
+
+## What is not collected
+
+The export does not collect:
+
+```text
+API keys
+GitHub tokens
+secrets
+raw Actions logs
+payment identifiers
+private user data
+unpublished local files
+raw model stderr
+raw Codex JSONL beyond committed public artifacts
+```
+
+## Workflow
+
+Manual run:
+
+```text
+Actions → Public Results Export → Run workflow
+```
+
+Inputs:
+
+```text
+limit: max Issues, PRs, and workflow runs to export
+commit_results: true/false
+```
+
+Scheduled run:
+
+```text
+17 3 * * * UTC
+```
+
+## Participant usage
+
+Participants may use `data/public-results.json` to analyze:
+
+```text
+which prompt styles attracted votes
+which Issues were blocked or clear
+which PRs changed more files or lines
+which runs merged or failed
+which safety labels appeared before runtime
+which workflow runs failed or passed
+how comparison runs behaved over time
+```
+
+The project does not automatically turn this data into a score.
+
+## Current limitation
+
+This is a public repository snapshot, not a data warehouse.
+
+If deeper analysis is needed, participants should download the JSON and analyze it externally.
+
+## Stability
+
+The current schema is:
+
+```text
+prompt-vote-lab-public-results-export-v1
+```
+
+Breaking schema changes should use a new schema version.

--- a/scripts/build_public_results_export.py
+++ b/scripts/build_public_results_export.py
@@ -25,6 +25,18 @@ def write_json(path: Path, data: Any) -> None:
     path.write_text(json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def connection_nodes(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, dict):
+        nodes = value.get("nodes")
+        if isinstance(nodes, list):
+            return nodes
+    return []
+
+
 def reaction_count(item: dict[str, Any], content: str) -> int:
     for group in item.get("reactionGroups") or []:
         if str(group.get("content") or "").upper() == content.upper():
@@ -34,7 +46,7 @@ def reaction_count(item: dict[str, Any], content: str) -> int:
 
 def compact_labels(item: dict[str, Any]) -> list[str]:
     out: list[str] = []
-    for label in item.get("labels") or []:
+    for label in connection_nodes(item.get("labels")):
         if isinstance(label, dict):
             name = str(label.get("name") or "").strip()
         else:
@@ -49,6 +61,15 @@ def compact_author(item: dict[str, Any]) -> str:
     if isinstance(author, dict):
         return str(author.get("login") or "unknown")
     return str(author or "unknown")
+
+
+def comment_count(item: dict[str, Any]) -> int | None:
+    comments = item.get("comments")
+    if isinstance(comments, dict):
+        return int(comments.get("totalCount") or 0)
+    if comments is None:
+        return None
+    return int(comments)
 
 
 def normalize_issue(issue: dict[str, Any]) -> dict[str, Any]:
@@ -66,7 +87,7 @@ def normalize_issue(issue: dict[str, Any]) -> dict[str, Any]:
         "labels": labels,
         "reaction_plus_one_count": reaction_count(issue, "THUMBS_UP"),
         "reaction_minus_one_count": reaction_count(issue, "THUMBS_DOWN"),
-        "comment_count": int(issue.get("comments", {}).get("totalCount") or 0) if isinstance(issue.get("comments"), dict) else issue.get("comments"),
+        "comment_count": comment_count(issue),
         "body": body,
         "body_length": len(body),
         "safety": {
@@ -83,9 +104,8 @@ def normalize_issue(issue: dict[str, Any]) -> dict[str, Any]:
 def normalize_pr(pr: dict[str, Any]) -> dict[str, Any]:
     labels = compact_labels(pr)
     body = str(pr.get("body") or "")
-    files = pr.get("files") or []
     compact_files = []
-    for file in files:
+    for file in connection_nodes(pr.get("files")):
         if isinstance(file, dict):
             compact_files.append(
                 {
@@ -114,7 +134,7 @@ def normalize_pr(pr: dict[str, Any]) -> dict[str, Any]:
         "additions": pr.get("additions"),
         "deletions": pr.get("deletions"),
         "review_decision": pr.get("reviewDecision"),
-        "comment_count": int(pr.get("comments", {}).get("totalCount") or 0) if isinstance(pr.get("comments"), dict) else pr.get("comments"),
+        "comment_count": comment_count(pr),
         "reaction_plus_one_count": reaction_count(pr, "THUMBS_UP"),
         "files": compact_files,
         "body": body,

--- a/scripts/build_public_results_export.py
+++ b/scripts/build_public_results_export.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "prompt-vote-lab-public-results-export-v1"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def read_json(path: Path, fallback: Any) -> Any:
+    if not path.exists():
+        return fallback
+    return json.loads(path.read_text(encoding="utf-8") or json.dumps(fallback))
+
+
+def write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def reaction_count(item: dict[str, Any], content: str) -> int:
+    for group in item.get("reactionGroups") or []:
+        if str(group.get("content") or "").upper() == content.upper():
+            return int(group.get("users", {}).get("totalCount") or 0)
+    return 0
+
+
+def compact_labels(item: dict[str, Any]) -> list[str]:
+    out: list[str] = []
+    for label in item.get("labels") or []:
+        if isinstance(label, dict):
+            name = str(label.get("name") or "").strip()
+        else:
+            name = str(label).strip()
+        if name:
+            out.append(name)
+    return sorted(set(out))
+
+
+def compact_author(item: dict[str, Any]) -> str:
+    author = item.get("author") or {}
+    if isinstance(author, dict):
+        return str(author.get("login") or "unknown")
+    return str(author or "unknown")
+
+
+def normalize_issue(issue: dict[str, Any]) -> dict[str, Any]:
+    labels = compact_labels(issue)
+    body = str(issue.get("body") or "")
+    return {
+        "number": issue.get("number"),
+        "title": issue.get("title"),
+        "state": issue.get("state"),
+        "url": issue.get("url"),
+        "author": compact_author(issue),
+        "created_at": issue.get("createdAt"),
+        "updated_at": issue.get("updatedAt"),
+        "closed_at": issue.get("closedAt"),
+        "labels": labels,
+        "reaction_plus_one_count": reaction_count(issue, "THUMBS_UP"),
+        "reaction_minus_one_count": reaction_count(issue, "THUMBS_DOWN"),
+        "comment_count": int(issue.get("comments", {}).get("totalCount") or 0) if isinstance(issue.get("comments"), dict) else issue.get("comments"),
+        "body": body,
+        "body_length": len(body),
+        "safety": {
+            "clear": "issue-safety:clear" in labels,
+            "review": "issue-safety:review" in labels,
+            "blocked": "issue-safety:blocked" in labels,
+            "submission_detected": "issue-safety:submission-detected" in labels,
+            "runtime_detected": "issue-safety:runtime-detected" in labels,
+            "authorized_canary": "authorized-canary" in labels,
+        },
+    }
+
+
+def normalize_pr(pr: dict[str, Any]) -> dict[str, Any]:
+    labels = compact_labels(pr)
+    body = str(pr.get("body") or "")
+    files = pr.get("files") or []
+    compact_files = []
+    for file in files:
+        if isinstance(file, dict):
+            compact_files.append(
+                {
+                    "path": file.get("path"),
+                    "additions": file.get("additions"),
+                    "deletions": file.get("deletions"),
+                }
+            )
+    return {
+        "number": pr.get("number"),
+        "title": pr.get("title"),
+        "state": pr.get("state"),
+        "url": pr.get("url"),
+        "author": compact_author(pr),
+        "created_at": pr.get("createdAt"),
+        "updated_at": pr.get("updatedAt"),
+        "closed_at": pr.get("closedAt"),
+        "merged_at": pr.get("mergedAt"),
+        "merged_by": compact_author({"author": pr.get("mergedBy")}) if pr.get("mergedBy") else None,
+        "base_ref_name": pr.get("baseRefName"),
+        "head_ref_name": pr.get("headRefName"),
+        "head_ref_oid": pr.get("headRefOid"),
+        "merge_commit_oid": (pr.get("mergeCommit") or {}).get("oid") if isinstance(pr.get("mergeCommit"), dict) else None,
+        "labels": labels,
+        "changed_files": pr.get("changedFiles"),
+        "additions": pr.get("additions"),
+        "deletions": pr.get("deletions"),
+        "review_decision": pr.get("reviewDecision"),
+        "comment_count": int(pr.get("comments", {}).get("totalCount") or 0) if isinstance(pr.get("comments"), dict) else pr.get("comments"),
+        "reaction_plus_one_count": reaction_count(pr, "THUMBS_UP"),
+        "files": compact_files,
+        "body": body,
+        "body_length": len(body),
+    }
+
+
+def normalize_run(run: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "database_id": run.get("databaseId"),
+        "name": run.get("name"),
+        "workflow_name": run.get("workflowName"),
+        "display_title": run.get("displayTitle"),
+        "event": run.get("event"),
+        "status": run.get("status"),
+        "conclusion": run.get("conclusion"),
+        "created_at": run.get("createdAt"),
+        "updated_at": run.get("updatedAt"),
+        "head_branch": run.get("headBranch"),
+        "head_sha": run.get("headSha"),
+        "url": run.get("url"),
+    }
+
+
+def run_records(runs_dir: Path) -> list[dict[str, Any]]:
+    records = []
+    if not runs_dir.exists():
+        return records
+    for path in sorted(runs_dir.glob("*.md")):
+        text = path.read_text(encoding="utf-8")
+        records.append(
+            {
+                "path": str(path),
+                "title": text.splitlines()[0].lstrip("# ").strip() if text.splitlines() else path.name,
+                "size_bytes": path.stat().st_size,
+                "content": text,
+            }
+        )
+    return records
+
+
+def summarize(issues: list[dict[str, Any]], prs: list[dict[str, Any]], runs: list[dict[str, Any]], records: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "issue_count": len(issues),
+        "open_issue_count": sum(1 for issue in issues if issue.get("state") == "OPEN"),
+        "blocked_issue_count": sum(1 for issue in issues if issue.get("safety", {}).get("blocked")),
+        "clear_issue_count": sum(1 for issue in issues if issue.get("safety", {}).get("clear")),
+        "authorized_canary_issue_count": sum(1 for issue in issues if issue.get("safety", {}).get("authorized_canary")),
+        "pr_count": len(prs),
+        "open_pr_count": sum(1 for pr in prs if pr.get("state") == "OPEN"),
+        "merged_pr_count": sum(1 for pr in prs if pr.get("merged_at")),
+        "workflow_run_count": len(runs),
+        "run_record_count": len(records),
+    }
+
+
+def markdown_table(headers: list[str], rows: list[list[Any]]) -> str:
+    lines = ["| " + " | ".join(headers) + " |", "| " + " | ".join(["---"] * len(headers)) + " |"]
+    for row in rows:
+        lines.append("| " + " | ".join(str(cell).replace("\n", " ") for cell in row) + " |")
+    return "\n".join(lines) + "\n"
+
+
+def render_md(export: dict[str, Any]) -> str:
+    summary = export["summary"]
+    issues = export["issues"][:30]
+    prs = export["pull_requests"][:30]
+    runs = export["workflow_runs"][:30]
+    lines = [
+        "# Prompt Vote Lab public results export",
+        "",
+        f"Generated at: `{export['generated_at']}`",
+        "",
+        "This file is a raw results surface for participants. It does not score prompts or recommend improvements.",
+        "",
+        "## Summary",
+        "",
+        markdown_table(
+            ["metric", "value"],
+            [[key, value] for key, value in summary.items()],
+        ),
+        "## Recent Issues",
+        "",
+        markdown_table(
+            ["#", "state", "+1", "labels", "title"],
+            [[i.get("number"), i.get("state"), i.get("reaction_plus_one_count"), ", ".join(i.get("labels") or []), i.get("title")] for i in issues],
+        ),
+        "## Recent Pull Requests",
+        "",
+        markdown_table(
+            ["#", "state", "changed", "+/-", "title"],
+            [[p.get("number"), p.get("state"), p.get("changed_files"), f"{p.get('additions')}/{p.get('deletions')}", p.get("title")] for p in prs],
+        ),
+        "## Recent Workflow Runs",
+        "",
+        markdown_table(
+            ["id", "workflow", "event", "status", "conclusion", "title"],
+            [[r.get("database_id"), r.get("workflow_name"), r.get("event"), r.get("status"), r.get("conclusion"), r.get("display_title")] for r in runs],
+        ),
+        "## Raw JSON",
+        "",
+        "See `public-results.json` in the same export artifact or committed data snapshot.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--issues", required=True)
+    parser.add_argument("--prs", required=True)
+    parser.add_argument("--workflow-runs", required=True)
+    parser.add_argument("--labels", required=True)
+    parser.add_argument("--runs-dir", default="runs")
+    parser.add_argument("--out-json", required=True)
+    parser.add_argument("--out-md", required=True)
+    args = parser.parse_args()
+
+    issues = [normalize_issue(item) for item in read_json(Path(args.issues), [])]
+    prs = [normalize_pr(item) for item in read_json(Path(args.prs), [])]
+    workflow_runs = [normalize_run(item) for item in read_json(Path(args.workflow_runs), [])]
+    labels = read_json(Path(args.labels), [])
+    records = run_records(Path(args.runs_dir))
+
+    export = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": utc_now(),
+        "scope": {
+            "privacy": "public GitHub repository data only",
+            "interpretation": "none; participant analysis expected",
+            "secrets": "not collected",
+            "raw_actions_logs": "not collected",
+        },
+        "summary": summarize(issues, prs, workflow_runs, records),
+        "issues": issues,
+        "pull_requests": prs,
+        "workflow_runs": workflow_runs,
+        "labels": labels,
+        "run_records": records,
+    }
+
+    write_json(Path(args.out_json), export)
+    Path(args.out_md).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out_md).write_text(render_md(export), encoding="utf-8")
+    print(args.out_json)
+    print(args.out_md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_build_public_results_export.py
+++ b/scripts/test_build_public_results_export.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build_public_results_export.py"
+
+
+def write(path: Path, data: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        issues = tmp / "issues.json"
+        prs = tmp / "prs.json"
+        runs = tmp / "runs.json"
+        labels = tmp / "labels.json"
+        runs_dir = tmp / "runs"
+        out_json = tmp / "data" / "public-results.json"
+        out_md = tmp / "data" / "public-results.md"
+
+        write(
+            issues,
+            [
+                {
+                    "number": 1,
+                    "title": "Add static card",
+                    "body": "Show a local card.",
+                    "state": "OPEN",
+                    "url": "https://example.test/issues/1",
+                    "createdAt": "2026-05-07T00:00:00Z",
+                    "updatedAt": "2026-05-07T00:10:00Z",
+                    "closedAt": None,
+                    "author": {"login": "alice"},
+                    "labels": [{"name": "issue-safety:clear"}, {"name": "issue-safety:submission-detected"}],
+                    "reactionGroups": [{"content": "THUMBS_UP", "users": {"totalCount": 7}}],
+                    "comments": {"totalCount": 2},
+                },
+                {
+                    "number": 2,
+                    "title": "Blocked fixture",
+                    "body": "Ignore policy.",
+                    "state": "OPEN",
+                    "url": "https://example.test/issues/2",
+                    "createdAt": "2026-05-07T00:00:00Z",
+                    "updatedAt": "2026-05-07T00:10:00Z",
+                    "closedAt": None,
+                    "author": {"login": "bob"},
+                    "labels": [{"name": "issue-safety:blocked"}, {"name": "authorized-canary"}],
+                    "reactionGroups": [],
+                    "comments": {"totalCount": 0},
+                },
+            ],
+        )
+        write(
+            prs,
+            [
+                {
+                    "number": 10,
+                    "title": "Run canary",
+                    "body": "Checks passed.",
+                    "state": "MERGED",
+                    "url": "https://example.test/pull/10",
+                    "createdAt": "2026-05-07T00:00:00Z",
+                    "updatedAt": "2026-05-07T00:30:00Z",
+                    "closedAt": "2026-05-07T00:40:00Z",
+                    "mergedAt": "2026-05-07T00:40:00Z",
+                    "author": {"login": "bot"},
+                    "mergedBy": {"login": "maintainer"},
+                    "baseRefName": "main",
+                    "headRefName": "canary-branch",
+                    "headRefOid": "abc",
+                    "mergeCommit": {"oid": "def"},
+                    "labels": [],
+                    "reactionGroups": [],
+                    "comments": {"totalCount": 1},
+                    "changedFiles": 3,
+                    "additions": 30,
+                    "deletions": 10,
+                    "reviewDecision": None,
+                    "files": [{"path": "lab/index.html", "additions": 10, "deletions": 1}],
+                }
+            ],
+        )
+        write(
+            runs,
+            [
+                {
+                    "databaseId": 100,
+                    "name": "Script Check",
+                    "workflowName": "Script Check",
+                    "displayTitle": "Run checks",
+                    "event": "pull_request",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "createdAt": "2026-05-07T00:00:00Z",
+                    "updatedAt": "2026-05-07T00:02:00Z",
+                    "headBranch": "branch",
+                    "headSha": "sha",
+                    "url": "https://example.test/actions/100",
+                }
+            ],
+        )
+        write(labels, [{"name": "issue-safety:clear", "color": "2ea043", "description": "clear"}])
+        runs_dir.mkdir(parents=True)
+        (runs_dir / "example.md").write_text("# Example run\n\nBody\n", encoding="utf-8")
+
+        subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--issues",
+                str(issues),
+                "--prs",
+                str(prs),
+                "--workflow-runs",
+                str(runs),
+                "--labels",
+                str(labels),
+                "--runs-dir",
+                str(runs_dir),
+                "--out-json",
+                str(out_json),
+                "--out-md",
+                str(out_md),
+            ],
+            cwd=ROOT,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        export = json.loads(out_json.read_text(encoding="utf-8"))
+        assert export["schema_version"] == "prompt-vote-lab-public-results-export-v1"
+        assert export["scope"]["interpretation"] == "none; participant analysis expected"
+        assert export["summary"]["issue_count"] == 2
+        assert export["summary"]["blocked_issue_count"] == 1
+        assert export["summary"]["clear_issue_count"] == 1
+        assert export["summary"]["authorized_canary_issue_count"] == 1
+        assert export["summary"]["merged_pr_count"] == 1
+        assert export["issues"][0]["reaction_plus_one_count"] == 7
+        assert export["issues"][0]["body"] == "Show a local card."
+        assert export["pull_requests"][0]["files"][0]["path"] == "lab/index.html"
+        assert export["run_records"][0]["content"].startswith("# Example run")
+        md = out_md.read_text(encoding="utf-8")
+        assert "This file is a raw results surface for participants" in md
+        assert "## Recent Issues" in md
+        assert "## Recent Pull Requests" in md
+
+    print("public results export builder test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_public_results_export_workflow_contract.py
+++ b/scripts/test_public_results_export_workflow_contract.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "public-results-export.yml"
+DOC = ROOT / "docs" / "public-results-export.md"
+DATA_JSON = ROOT / "data" / "public-results.json"
+DATA_MD = ROOT / "data" / "public-results.md"
+
+REQUIRED_WORKFLOW_TEXT = [
+    "name: Public Results Export",
+    "workflow_dispatch:",
+    "schedule:",
+    "contents: write",
+    "issues: read",
+    "pull-requests: read",
+    "actions: read",
+    "gh api graphql",
+    "gh run list",
+    "gh label list",
+    "python scripts/build_public_results_export.py",
+    "data/public-results.json",
+    "data/public-results.md",
+    "public-results-export-${{ github.run_number }}",
+]
+
+FORBIDDEN_WORKFLOW_TEXT = [
+    "OPENAI_API_KEY",
+    "secrets.OPENAI",
+    "run_codex_issue_instruction_canary",
+    "codex exec",
+    "gh pr merge",
+]
+
+REQUIRED_DOC_TEXT = [
+    "This export is intentionally descriptive, not interpretive.",
+    "It does not score prompts",
+    "Issues",
+    "Pull Requests",
+    "workflow run metadata",
+    "API keys",
+    "raw Actions logs",
+    "prompt-vote-lab-public-results-export-v1",
+]
+
+REQUIRED_DATA_TEXT = [
+    "prompt-vote-lab-public-results-export-v1",
+    "public GitHub repository data only",
+    "none; participant analysis expected",
+]
+
+
+def require_all(text: str, required: list[str], label: str) -> None:
+    missing = [item for item in required if item not in text]
+    if missing:
+        raise SystemExit(f"Missing {label} text: {missing}")
+
+
+def reject_all(text: str, forbidden: list[str], label: str) -> None:
+    found = [item for item in forbidden if item in text]
+    if found:
+        raise SystemExit(f"Forbidden {label} text found: {found}")
+
+
+def main() -> int:
+    workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    doc_text = DOC.read_text(encoding="utf-8")
+    data_json_text = DATA_JSON.read_text(encoding="utf-8")
+    data_md_text = DATA_MD.read_text(encoding="utf-8")
+
+    require_all(workflow_text, REQUIRED_WORKFLOW_TEXT, "public results workflow")
+    reject_all(workflow_text, FORBIDDEN_WORKFLOW_TEXT, "public results workflow")
+    require_all(doc_text, REQUIRED_DOC_TEXT, "public results doc")
+    require_all(data_json_text, REQUIRED_DATA_TEXT, "public results json")
+    require_all(data_md_text, ["raw results surface", "See `public-results.json`"], "public results markdown")
+
+    print("public results export workflow contract test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a raw public results export so participants can analyze Prompt Vote Lab outcomes themselves.

## Scope

This intentionally does not add AI analysis, recommendations, prompt advice, author scoring, or reputation calculation.

It only collects public repository data and exposes it as JSON plus a Markdown table view.

## Changes

- Adds `scripts/build_public_results_export.py`.
- Adds `.github/workflows/public-results-export.yml`.
- Adds initial `data/public-results.json` and `data/public-results.md` snapshots.
- Adds `docs/public-results-export.md`.
- Links the public results export from `docs/README.md`.
- Adds tests for the export builder and workflow contract.
- Registers the tests in `Script Check`.

## Collected public data

The export collects:

```text
Issues
Pull Requests
Issue labels
PR labels
Issue reactions
PR reactions
Issue comment counts
PR comment counts
PR changed file counts
PR additions/deletions
PR changed file paths
workflow run metadata
run record markdown files under runs/
```

## Explicitly not collected

```text
API keys
GitHub tokens
secrets
raw Actions logs
payment identifiers
private user data
unpublished local files
raw model stderr
raw Codex JSONL beyond committed public artifacts
```

## Participant behavior

Participants can download or inspect `data/public-results.json` and run their own analysis.

The repository does not automatically score prompts, explain success, or recommend prompt rewrites.

## Tests expected

- `python scripts/test_build_public_results_export.py`
- `python scripts/test_public_results_export_workflow_contract.py`
- Existing Script Check workflow

## Non-goals

- No `/lab/` changes.
- No Codex/model/API run.
- No scoring.
- No automated prompt advice.
- No auto-merge.