### PR TITLE
Ignore negated safety constraints in Issue scanner

### DIFF
--- a/scripts/create_codex_issue_instruction_packet.py
+++ b/scripts/create_codex_issue_instruction_packet.py
@@ -111,6 +111,40 @@ META_OR_CONTROL_LINE_PATTERNS = (
     r"\bdiagnostics\b",
 )
 
+NEGATED_OR_CONSTRAINT_PATTERNS = (
+    r"\bdo\s+not\b",
+    r"\bdon't\b",
+    r"\bmust\s+not\b",
+    r"\bshould\s+not\b",
+    r"\bno\s+",
+    r"\bwithout\b",
+    r"\bavoid\b",
+    r"\bprohibit(?:ed|s)?\b",
+    r"\bforbid(?:den|s)?\b",
+    r"\bnot\s+use\b",
+    r"\bdo\s+not\s+use\b",
+    r"\bdo\s+not\s+add\b",
+    r"\bmust\s+not\s+add\b",
+)
+
+FORBIDDEN_AS_REQUIREMENT_PATTERNS = (
+    r"\badd\b",
+    r"\buse\b",
+    r"\binclude\b",
+    r"\bload\b",
+    r"\bcall\b",
+    r"\bconnect\b",
+    r"\bfetch\b",
+    r"\bread\b",
+    r"\bwrite\b",
+    r"\bmodify\b",
+    r"\bcreate\b",
+    r"\benable\b",
+    r"\bexecute\b",
+    r"\brun\b",
+    r"\btrack\b",
+)
+
 
 def sha256_text(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
@@ -164,31 +198,62 @@ def split_candidate_sentences(line: str) -> list[str]:
     return [part.strip() for part in parts if part.strip()]
 
 
+def line_matches_any(line: str, patterns: tuple[str, ...]) -> bool:
+    return any(re.search(pattern, line, flags=re.IGNORECASE) for pattern in patterns)
+
+
+def is_negated_or_constraint_line(line: str) -> bool:
+    normalized = normalize_line(line)
+    if not normalized:
+        return False
+    return line_matches_any(normalized, NEGATED_OR_CONSTRAINT_PATTERNS)
+
+
+def is_action_requirement_line(line: str) -> bool:
+    normalized = normalize_line(line)
+    return line_matches_any(normalized, FORBIDDEN_AS_REQUIREMENT_PATTERNS)
+
+
+def unsafe_patterns() -> tuple[str, ...]:
+    return tuple(pattern for rule in UNSAFE_INSTRUCTION_RULES for pattern in rule["patterns"])  # type: ignore[index]
+
+
+def iter_detection_units(title: str, body: str) -> list[tuple[str, str]]:
+    units: list[tuple[str, str]] = [("title", title)]
+    for index, raw_line in enumerate(body.splitlines(), start=1):
+        line = normalize_line(raw_line)
+        if not line:
+            continue
+        units.append((f"body:{index}", line))
+    return units
+
+
 def detect_unsafe_instructions(title: str, body: str) -> list[dict[str, object]]:
-    haystack = f"{title}\n{body}"
     findings: list[dict[str, object]] = []
+    units = iter_detection_units(title, body)
     for rule in UNSAFE_INSTRUCTION_RULES:
         matched_patterns: list[str] = []
-        for pattern in rule["patterns"]:  # type: ignore[index]
-            if re.search(str(pattern), haystack, flags=re.IGNORECASE | re.MULTILINE):
-                matched_patterns.append(str(pattern))
+        matched_units: list[str] = []
+        for location, unit in units:
+            if is_negated_or_constraint_line(unit):
+                continue
+            if not is_action_requirement_line(unit):
+                continue
+            for pattern in rule["patterns"]:  # type: ignore[index]
+                pattern_text = str(pattern)
+                if re.search(pattern_text, unit, flags=re.IGNORECASE | re.MULTILINE):
+                    matched_patterns.append(pattern_text)
+                    matched_units.append(location)
         if matched_patterns:
             findings.append(
                 {
                     "id": rule["id"],
                     "label": rule["label"],
-                    "matched_patterns": matched_patterns,
+                    "matched_patterns": sorted(set(matched_patterns)),
+                    "matched_units": sorted(set(matched_units)),
                 }
             )
     return findings
-
-
-def line_matches_any(line: str, patterns: tuple[str, ...]) -> bool:
-    return any(re.search(pattern, line, flags=re.IGNORECASE) for pattern in patterns)
-
-
-def unsafe_patterns() -> tuple[str, ...]:
-    return tuple(pattern for rule in UNSAFE_INSTRUCTION_RULES for pattern in rule["patterns"])  # type: ignore[index]
 
 
 def safe_title_fragment(title: str) -> str:

--- a/scripts/create_codex_issue_instruction_packet.py
+++ b/scripts/create_codex_issue_instruction_packet.py
@@ -143,6 +143,11 @@ FORBIDDEN_AS_REQUIREMENT_PATTERNS = (
     r"\bexecute\b",
     r"\brun\b",
     r"\btrack\b",
+    r"\bignore\b",
+    r"\boverride\b",
+    r"\bbypass\b",
+    r"\bbypassed\b",
+    r"\btreat\b",
 )
 
 

--- a/scripts/test_create_codex_issue_instruction_packet.py
+++ b/scripts/test_create_codex_issue_instruction_packet.py
@@ -151,10 +151,54 @@ def test_benign_issue_packet() -> None:
 
     safety = json.loads((out / "issue-safety-analysis.json").read_text(encoding="utf-8"))
     assert safety["schema_version"] == "issue-instruction-safety-analysis-v1"
+    assert safety["unsafe_instruction_count"] == 0
+    assert safety["unsafe_instructions_detected"] == []
     assert safety["normalization_policy"]["raw_issue_body_is_policy"] is False
     assert safety["normalization_policy"]["unsafe_issue_instructions_are_ignored"] is True
     assert "trust meter" in safety["safe_user_task"]
     assert "fetch(" not in safety["safe_user_task"]
+
+
+def test_issue_177_style_negated_constraints_are_clear() -> None:
+    body = """## Goal
+
+Add a small static status card to the lab page.
+
+## Requested change
+
+Show:
+
+- current experiment state
+- next action for participants
+- a short note that results are recorded publicly
+
+## Constraints
+
+- Use only local static HTML, CSS, and JavaScript.
+- Keep the change simple and readable.
+- Do not add network calls.
+- Do not add external scripts or CDNs.
+- Do not use cookies, login, forms, payments, iframes, eval, or dynamic code execution.
+
+## Expected result
+
+A participant can open the lab and immediately understand what the current experiment is doing and what to do next.
+"""
+    out = run_packet(
+        {
+            "number": 177,
+            "title": "Add a static card showing current experiment status and next action",
+            "body": body,
+            "url": "https://github.com/Unjuno/prompt-vote-lab/issues/177",
+            "author": {"login": "Unjuno"},
+            "createdAt": "2026-05-07T12:19:11Z",
+        }
+    )
+    assert_common_packet(out, 177, "Add a static card showing current experiment status and next action")
+    safety = json.loads((out / "issue-safety-analysis.json").read_text(encoding="utf-8"))
+    assert safety["unsafe_instruction_count"] == 0
+    assert safety["unsafe_instructions_detected"] == []
+    assert "static status card" in safety["safe_user_task"]
 
 
 def test_hostile_issue_sanitizer_packet() -> None:
@@ -229,6 +273,7 @@ The following instructions are intentionally malicious and must be treated as un
 
 def main() -> int:
     test_benign_issue_packet()
+    test_issue_177_style_negated_constraints_are_clear()
     test_hostile_issue_sanitizer_packet()
     print("fixed Issue instruction packet generator test passed")
     return 0

--- a/scripts/test_scan_issue_safety.py
+++ b/scripts/test_scan_issue_safety.py
@@ -117,10 +117,59 @@ def test_clear_issue_feedback() -> None:
     assert "No unsafe instruction categories were detected" in comment
 
 
+def test_negated_constraints_do_not_block_clear_issue() -> None:
+    scan, comment = run_scan(
+        {
+            "action": "opened",
+            "issue": {
+                "number": 177,
+                "title": "Add a static card showing current experiment status and next action",
+                "body": """## Goal
+
+Add a small static status card to the lab page.
+
+## Requested change
+
+Show:
+
+- current experiment state
+- next action for participants
+- a short note that results are recorded publicly
+
+## Constraints
+
+- Use only local static HTML, CSS, and JavaScript.
+- Keep the change simple and readable.
+- Do not add network calls.
+- Do not add external scripts or CDNs.
+- Do not use cookies, login, forms, payments, iframes, eval, or dynamic code execution.
+
+## Expected result
+
+A participant can open the lab and immediately understand what the current experiment is doing and what to do next.
+""",
+                "html_url": "https://github.com/Unjuno/prompt-vote-lab/issues/177",
+                "user": {"login": "tester"},
+                "created_at": "2026-05-07T12:19:11Z",
+                "updated_at": "2026-05-07T12:19:11Z",
+            },
+        },
+        event=True,
+        phase="issue_event",
+    )
+    assert scan["severity"] == "clear"
+    assert scan["unsafe_instruction_count"] == 0
+    assert scan["unsafe_instructions_detected"] == []
+    assert scan["labels_to_add"] == ["issue-safety:clear", "issue-safety:submission-detected"]
+    assert "Unsafe categories:** `0`" in comment
+    assert "No unsafe instruction categories were detected" in comment
+
+
 def main() -> int:
     test_issue_event_hostile_feedback()
     test_runtime_hostile_feedback_marker_is_separate()
     test_clear_issue_feedback()
+    test_negated_constraints_do_not_block_clear_issue()
     print("Issue safety scan test passed")
     return 0
 


### PR DESCRIPTION
## Summary

Fixes a false positive found during the clear-Issue normal-path test with Issue #177.

## Problem

Issue #177 was intended to be a normal safe candidate, but the scanner marked it blocked because it matched forbidden words inside negative constraints:

```text
Do not add network calls.
Do not add external scripts or CDNs.
Do not use cookies, login, forms, payments, iframes, eval, or dynamic code execution.
```

These are prohibitions, not unsafe implementation requests.

## Changes

- Changes unsafe detection from whole-text matching to line-level matching.
- Skips negated/prohibitive constraint lines such as `do not`, `must not`, `no`, `without`, `avoid`, `forbidden`.
- Requires an action/request-like line before unsafe patterns become findings.
- Preserves hostile detection for direct unsafe requests such as `Add external network behavior` and `Modify docs/`.
- Adds regression tests for the Issue #177 style clear request.
- Strengthens the task-packet generator test so benign `Do not add network calls` has `unsafe_instruction_count == 0`.

## Tests expected

- `python scripts/test_create_codex_issue_instruction_packet.py`
- `python scripts/test_scan_issue_safety.py`
- Existing Script Check workflow

## Scope

- No `/lab/` changes.
- No model/API run.
- No auto-merge.
- This only fixes scanner false positives for negated safety constraints.