### PR TITLE
Add weekly Issue finalizer

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -10,6 +10,7 @@ on:
       - ".github/workflows/script-check.yml"
       - ".github/workflows/issue-safety-scan.yml"
       - ".github/workflows/public-results-export.yml"
+      - ".github/workflows/weekly-issue-finalizer.yml"
       - ".github/workflows/codex-first-canary-run.yml"
       - ".github/workflows/codex-isolated-3file-canary-run.yml"
       - ".github/workflows/codex-isolated-3file-relaxed-canary-run.yml"
@@ -28,6 +29,7 @@ on:
       - "docs/current-codex-implementation-path.md"
       - "docs/public-results-export.md"
       - "docs/public-agent-run-bundle.md"
+      - "docs/issue-lifecycle.md"
       - "docs/canary-007-policy-enforced-agent.md"
       - "docs/canary-008-selected-prompt-task-packet.md"
       - "docs/canary-009-selected-issue-instructions.md"
@@ -134,6 +136,12 @@ jobs:
 
       - name: Run public agent run bundle builder test
         run: python scripts/test_build_public_agent_run_bundle.py
+
+      - name: Run weekly Issue finalizer test
+        run: python scripts/test_weekly_issue_finalizer.py
+
+      - name: Run weekly Issue finalizer workflow contract test
+        run: python scripts/test_weekly_issue_finalizer_workflow_contract.py
 
       - name: Run task packet generator test
         run: python scripts/test_create_codex_task_packet.py

--- a/.github/workflows/weekly-issue-finalizer.yml
+++ b/.github/workflows/weekly-issue-finalizer.yml
@@ -1,0 +1,99 @@
+name: Weekly Issue Finalizer
+
+on:
+  workflow_dispatch:
+    inputs:
+      week_id:
+        description: "Week label suffix, for example 2026-W19. Issues must have label week:<week_id>."
+        required: true
+        default: "2026-W19"
+      dry_run:
+        description: "If true, only produce the close plan artifact. If false, comment and close eligible Issues."
+        required: true
+        default: "true"
+      require_public_results_membership:
+        description: "If true, eligible Issues must already appear in data/public-results.json."
+        required: true
+        default: "true"
+      run_record_hint:
+        description: "Run record path or directory to mention in the close comment."
+        required: false
+        default: "runs/"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: weekly-issue-finalizer-${{ inputs.week_id }}
+  cancel-in-progress: false
+
+jobs:
+  weekly-issue-finalizer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fetch open Issues with week/outcome labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WEEK_ID: ${{ inputs.week_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p .tmp/weekly-issue-finalizer/comments
+          gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --label "week:${WEEK_ID}" \
+            --limit 200 \
+            --json number,title,url,labels,state \
+            > .tmp/weekly-issue-finalizer/issues.json
+
+      - name: Build finalizer plan
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          REQUIRE_PUBLIC_RESULTS_MEMBERSHIP: ${{ inputs.require_public_results_membership }}
+        run: |
+          set -euo pipefail
+          dry_flag=""
+          if [ "${DRY_RUN}" = "true" ]; then dry_flag="--dry-run"; fi
+          require_flag=""
+          if [ "${REQUIRE_PUBLIC_RESULTS_MEMBERSHIP}" = "true" ]; then require_flag="--require-public-results-membership"; fi
+          python scripts/weekly_issue_finalizer.py \
+            --issues-json .tmp/weekly-issue-finalizer/issues.json \
+            --public-results data/public-results.json \
+            --week-id "${{ inputs.week_id }}" \
+            --out-json .tmp/weekly-issue-finalizer/plan.json \
+            --out-md .tmp/weekly-issue-finalizer/plan.md \
+            --comments-dir .tmp/weekly-issue-finalizer/comments \
+            --run-record-hint "${{ inputs.run_record_hint }}" \
+            $dry_flag \
+            $require_flag
+
+      - name: Upload finalizer plan artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: weekly-issue-finalizer-${{ inputs.week_id }}-${{ github.run_number }}
+          path: .tmp/weekly-issue-finalizer
+          if-no-files-found: error
+
+      - name: Comment and close eligible Issues
+        if: ${{ inputs.dry_run != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python - <<'PY' > .tmp/weekly-issue-finalizer/close-commands.sh
+          import json
+          import shlex
+          from pathlib import Path
+          plan = json.loads(Path('.tmp/weekly-issue-finalizer/plan.json').read_text(encoding='utf-8'))
+          for item in plan.get('to_close', []):
+              number = str(item['number'])
+              reason = item['close_reason']
+              comment = f".tmp/weekly-issue-finalizer/comments/{number}.md"
+              print(f"gh issue comment {shlex.quote(number)} --repo \"$GITHUB_REPOSITORY\" --body-file {shlex.quote(comment)}")
+              print(f"gh issue close {shlex.quote(number)} --repo \"$GITHUB_REPOSITORY\" --reason {shlex.quote(reason)}")
+          PY
+          bash .tmp/weekly-issue-finalizer/close-commands.sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,20 +13,21 @@ Prompt Vote Lab is a prompt game and experiment. Players compete by writing prom
 3. [Usable experiment operations](./usable-experiment-ops.md) — current manual canary and comparison-run operations.
 4. [Public results export](./public-results-export.md) — raw public data snapshots for participant analysis.
 5. [Public agent run bundle](./public-agent-run-bundle.md) — redacted raw agent-run evidence; summaries are not primary evidence.
-6. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
-7. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
-8. [Automation map](./automation-map.md) — workflow boundaries.
-9. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
-10. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
-11. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and pre-canary cleanup.
-12. [Fixed first canary prompt](./first-canary-prompt.md) — the only allowed first real canary prompt.
-13. [First canary readiness checklist](./first-canary-readiness.md) — final check before running the first real canary.
-14. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
-15. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
-16. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
-17. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
-18. [Report policy](./report-policy.md) — weekly report draft policy.
-19. [Pre-API freeze checklist](./pre-api-freeze.md) — gates before paid agent runs.
+6. [Issue lifecycle](./issue-lifecycle.md) — weekly close policy; Issues are closed, not deleted.
+7. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
+8. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
+9. [Automation map](./automation-map.md) — workflow boundaries.
+10. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
+11. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
+12. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and pre-canary cleanup.
+13. [Fixed first canary prompt](./first-canary-prompt.md) — the only allowed first real canary prompt.
+14. [First canary readiness checklist](./first-canary-readiness.md) — final check before running the first real canary.
+15. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
+16. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
+17. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
+18. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
+19. [Report policy](./report-policy.md) — weekly report draft policy.
+20. [Pre-API freeze checklist](./pre-api-freeze.md) — gates before paid agent runs.
 
 ## Current reputation status
 
@@ -60,6 +61,21 @@ The export is intended for participant-side analysis of prompt outcomes, votes, 
 Fixed-Issue 009 runs also upload a redacted raw agent-run evidence bundle.
 
 The primary evidence is the allowlisted raw files in the bundle. The bundle index is a manifest only. It must not replace raw evidence with a model-written summary.
+
+## Issue lifecycle status
+
+Weekly Issues may be closed automatically after the experiment cycle is recorded.
+
+Closure requires:
+
+```text
+week:* label
+outcome:* label
+public results membership
+finalizer comment before close
+```
+
+Closed Issues remain visible. They are not deleted.
 
 ## Current usable experiment status
 

--- a/docs/issue-lifecycle.md
+++ b/docs/issue-lifecycle.md
@@ -1,0 +1,154 @@
+# Issue lifecycle
+
+## Purpose
+
+Prompt Vote Lab should not keep weekly experiment Issues open forever.
+
+Closed Issues remain visible in GitHub. Closing is not deletion.
+
+The project should keep evidence in:
+
+```text
+Issue comments
+runs/
+data/public-results.json
+data/public-results.md
+public agent-run artifacts
+```
+
+## Core rule
+
+Weekly cleanup is allowed only after the weekly experiment cycle is recorded.
+
+```text
+run
+→ review
+→ merge/reject
+→ runs/ record
+→ Public Results Export
+→ comment before close
+→ close eligible Issues
+```
+
+Do not close Issues before Public Results Export has run.
+
+## Required labels for automatic close
+
+An Issue is eligible only if it has exactly one matching week label and exactly one supported outcome label.
+
+```text
+week:<week_id>
+outcome:<result>
+```
+
+Example:
+
+```text
+week:2026-W19
+outcome:implemented
+```
+
+## Supported outcomes
+
+Completed:
+
+```text
+outcome:implemented
+outcome:archived-fixture
+```
+
+Closed as not planned:
+
+```text
+outcome:not-selected
+outcome:blocked
+outcome:rejected-after-run
+```
+
+## Protected labels
+
+The finalizer must skip Issues with any of these labels:
+
+```text
+carryover
+future-candidate
+discussion
+bug
+admin
+do-not-close
+pinned
+```
+
+Use `carryover` for prompts that should remain open for another week.
+
+Use `do-not-close` for any Issue that should never be touched by the weekly finalizer.
+
+## Close comment
+
+Before closing, the finalizer posts a comment with:
+
+```text
+week
+outcome
+close_reason
+public_results path
+public_results generation time
+run record hint
+statement that the Issue is closed, not deleted
+```
+
+This keeps the experiment trail visible inside the Issue thread.
+
+## Workflow
+
+The workflow is manual at first:
+
+```text
+Actions
+→ Weekly Issue Finalizer
+→ Run workflow
+```
+
+Inputs:
+
+```text
+week_id: 2026-W19
+dry_run: true by default
+require_public_results_membership: true by default
+run_record_hint: runs/
+```
+
+Default mode is `dry_run=true`.
+
+When `dry_run=true`, the workflow only uploads a plan artifact.
+
+When `dry_run=false`, the workflow posts the generated close comment and closes eligible Issues.
+
+## Why not close every open Issue
+
+Open Issues may include future proposals, carryover prompts, discussions, bugs, and admin tasks.
+
+Therefore the finalizer only searches for Issues with a matching `week:*` label.
+
+It then requires an `outcome:*` label before closing.
+
+## Recommended weekly operation
+
+```text
+1. Assign week:<week_id> to weekly candidate Issues.
+2. Run the weekly experiment.
+3. Review and merge/reject PRs.
+4. Add outcome:* labels.
+5. Add carryover or do-not-close where needed.
+6. Write runs/ records.
+7. Run Public Results Export.
+8. Run Weekly Issue Finalizer with dry_run=true.
+9. Inspect artifact plan.
+10. Run Weekly Issue Finalizer with dry_run=false.
+```
+
+## Current limitation
+
+The finalizer does not infer outcomes.
+
+A human or another explicit workflow must set `outcome:*` before the Issue can be closed.

--- a/scripts/test_weekly_issue_finalizer.py
+++ b/scripts/test_weekly_issue_finalizer.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "weekly_issue_finalizer.py"
+
+
+def write_json(path: Path, data: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        issues = tmp / "issues.json"
+        public_results = tmp / "public-results.json"
+        out_json = tmp / "plan.json"
+        out_md = tmp / "plan.md"
+        comments_dir = tmp / "comments"
+
+        write_json(
+            issues,
+            [
+                {
+                    "number": 177,
+                    "title": "Implemented clear Issue",
+                    "url": "https://example.test/issues/177",
+                    "labels": [
+                        {"name": "week:2026-W19"},
+                        {"name": "outcome:implemented"},
+                        {"name": "issue-safety:clear"},
+                    ],
+                },
+                {
+                    "number": 170,
+                    "title": "Archived fixture",
+                    "url": "https://example.test/issues/170",
+                    "labels": [
+                        {"name": "week:2026-W19"},
+                        {"name": "outcome:archived-fixture"},
+                        {"name": "authorized-canary"},
+                    ],
+                },
+                {
+                    "number": 164,
+                    "title": "Missing outcome must stay open",
+                    "url": "https://example.test/issues/164",
+                    "labels": [
+                        {"name": "week:2026-W19"},
+                        {"name": "hostile-test"},
+                    ],
+                },
+                {
+                    "number": 3,
+                    "title": "Carryover must stay open",
+                    "url": "https://example.test/issues/3",
+                    "labels": [
+                        {"name": "week:2026-W19"},
+                        {"name": "outcome:not-selected"},
+                        {"name": "carryover"},
+                    ],
+                },
+                {
+                    "number": 2,
+                    "title": "Wrong week must stay open",
+                    "url": "https://example.test/issues/2",
+                    "labels": [
+                        {"name": "week:2026-W20"},
+                        {"name": "outcome:not-selected"},
+                    ],
+                },
+                {
+                    "number": 1,
+                    "title": "Missing from public results must stay open when required",
+                    "url": "https://example.test/issues/1",
+                    "labels": [
+                        {"name": "week:2026-W19"},
+                        {"name": "outcome:not-selected"},
+                    ],
+                },
+            ],
+        )
+        write_json(
+            public_results,
+            {
+                "generated_at": "2026-05-07T14:11:36+00:00",
+                "issues": [
+                    {"number": 177, "title": "Implemented clear Issue"},
+                    {"number": 170, "title": "Archived fixture"},
+                    {"number": 164, "title": "Missing outcome must stay open"},
+                    {"number": 3, "title": "Carryover must stay open"},
+                    {"number": 2, "title": "Wrong week must stay open"},
+                ],
+            },
+        )
+
+        subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--issues-json",
+                str(issues),
+                "--public-results",
+                str(public_results),
+                "--week-id",
+                "2026-W19",
+                "--out-json",
+                str(out_json),
+                "--out-md",
+                str(out_md),
+                "--comments-dir",
+                str(comments_dir),
+                "--run-record-hint",
+                "runs/first-canary-009-clear-issue-177-success.md",
+                "--dry-run",
+                "--require-public-results-membership",
+            ],
+            cwd=ROOT,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        plan = json.loads(out_json.read_text(encoding="utf-8"))
+        assert plan["schema_version"] == "prompt-vote-lab-weekly-issue-finalizer-v1"
+        assert plan["dry_run"] is True
+        assert plan["summary"]["close_count"] == 2
+        assert plan["summary"]["skip_count"] == 4
+
+        close_by_number = {item["number"]: item for item in plan["to_close"]}
+        assert set(close_by_number) == {177, 170}
+        assert close_by_number[177]["close_reason"] == "completed"
+        assert close_by_number[170]["close_reason"] == "completed"
+
+        skip_by_number = {item["number"]: item for item in plan["skipped"]}
+        assert "expected_exactly_one_outcome_label" in skip_by_number[164]["skip_reasons"]
+        assert "protected_label_present" in skip_by_number[3]["skip_reasons"]
+        assert "missing_matching_week_label" in skip_by_number[2]["skip_reasons"]
+        assert "missing_from_public_results_snapshot" in skip_by_number[1]["skip_reasons"]
+
+        comment_177 = (comments_dir / "177.md").read_text(encoding="utf-8")
+        assert "<!-- prompt-vote-lab:weekly-issue-finalizer:v1 -->" in comment_177
+        assert "week: 2026-W19" in comment_177
+        assert "outcome: outcome:implemented" in comment_177
+        assert "close_reason: completed" in comment_177
+        assert "The Issue is not deleted" in comment_177
+        assert "Public results snapshot" in comment_177
+        assert "runs/first-canary-009-clear-issue-177-success.md" in comment_177
+
+        assert not (comments_dir / "164.md").exists()
+        md = out_md.read_text(encoding="utf-8")
+        assert "Weekly Issue Finalizer plan" in md
+        assert "Implemented clear Issue" in md
+        assert "Missing outcome must stay open" in md
+
+    print("weekly issue finalizer test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_weekly_issue_finalizer_workflow_contract.py
+++ b/scripts/test_weekly_issue_finalizer_workflow_contract.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "weekly-issue-finalizer.yml"
+DOC = ROOT / "docs" / "issue-lifecycle.md"
+SCRIPT = ROOT / "scripts" / "weekly_issue_finalizer.py"
+
+REQUIRED_WORKFLOW_TEXT = [
+    "name: Weekly Issue Finalizer",
+    "workflow_dispatch:",
+    "dry_run:",
+    "default: \"true\"",
+    "require_public_results_membership:",
+    "issues: write",
+    "contents: read",
+    "gh issue list",
+    "--label \"week:${WEEK_ID}\"",
+    "python scripts/weekly_issue_finalizer.py",
+    "--public-results data/public-results.json",
+    "--require-public-results-membership",
+    "Upload finalizer plan artifact",
+    "Comment and close eligible Issues",
+    "if: ${{ inputs.dry_run != 'true' }}",
+    "gh issue comment",
+    "gh issue close",
+]
+
+FORBIDDEN_WORKFLOW_TEXT = [
+    "schedule:",
+    "gh issue list \\\n            --repo \"$GITHUB_REPOSITORY\" \\\n            --state open \\\n            --limit 200",
+    "OPENAI_API_KEY",
+    "codex exec",
+]
+
+REQUIRED_SCRIPT_TEXT = [
+    "PROTECTED_LABELS",
+    "carryover",
+    "future-candidate",
+    "do-not-close",
+    "pinned",
+    "expected_exactly_one_week_label",
+    "expected_exactly_one_outcome_label",
+    "missing_from_public_results_snapshot",
+    "The Issue is not deleted.",
+    "Only Issues with both week:* and outcome:* labels are eligible",
+]
+
+REQUIRED_DOC_TEXT = [
+    "Issue lifecycle",
+    "closed, not deleted",
+    "week:*",
+    "outcome:*",
+    "Public Results Export",
+    "comment before close",
+    "carryover",
+    "do-not-close",
+]
+
+
+def require_all(text: str, required: list[str], label: str) -> None:
+    missing = [item for item in required if item not in text]
+    if missing:
+        raise SystemExit(f"Missing {label}: {missing}")
+
+
+def reject_all(text: str, forbidden: list[str], label: str) -> None:
+    found = [item for item in forbidden if item in text]
+    if found:
+        raise SystemExit(f"Forbidden {label}: {found}")
+
+
+def main() -> int:
+    workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    script_text = SCRIPT.read_text(encoding="utf-8")
+    doc_text = DOC.read_text(encoding="utf-8")
+
+    require_all(workflow_text, REQUIRED_WORKFLOW_TEXT, "workflow text")
+    reject_all(workflow_text, FORBIDDEN_WORKFLOW_TEXT, "workflow text")
+    require_all(script_text, REQUIRED_SCRIPT_TEXT, "script text")
+    require_all(doc_text, REQUIRED_DOC_TEXT, "doc text")
+
+    if workflow_text.index("Build finalizer plan") > workflow_text.index("Comment and close eligible Issues"):
+        raise SystemExit("Finalizer plan must be built before close step")
+    if workflow_text.index("Upload finalizer plan artifact") > workflow_text.index("Comment and close eligible Issues"):
+        raise SystemExit("Plan artifact must be uploaded before close step")
+
+    print("weekly issue finalizer workflow contract test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/weekly_issue_finalizer.py
+++ b/scripts/weekly_issue_finalizer.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "prompt-vote-lab-weekly-issue-finalizer-v1"
+OUTCOME_PREFIX = "outcome:"
+WEEK_PREFIX = "week:"
+PROTECTED_LABELS = {
+    "carryover",
+    "future-candidate",
+    "discussion",
+    "bug",
+    "admin",
+    "do-not-close",
+    "pinned",
+}
+COMPLETED_OUTCOMES = {
+    "outcome:implemented",
+    "outcome:archived-fixture",
+}
+NOT_PLANNED_OUTCOMES = {
+    "outcome:not-selected",
+    "outcome:blocked",
+    "outcome:rejected-after-run",
+}
+ALLOWED_OUTCOMES = COMPLETED_OUTCOMES | NOT_PLANNED_OUTCOMES
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def read_json(path: Path, fallback: Any) -> Any:
+    if not path.exists():
+        return fallback
+    try:
+        return json.loads(path.read_text(encoding="utf-8") or json.dumps(fallback))
+    except json.JSONDecodeError:
+        return fallback
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def labels_from_issue(issue: dict[str, Any]) -> list[str]:
+    labels = issue.get("labels") or []
+    out: list[str] = []
+    for label in labels:
+        if isinstance(label, dict):
+            name = str(label.get("name") or "").strip()
+        else:
+            name = str(label).strip()
+        if name:
+            out.append(name)
+    return sorted(set(out))
+
+
+def issue_number(issue: dict[str, Any]) -> int:
+    return int(issue.get("number") or issue.get("issue_number") or 0)
+
+
+def issue_title(issue: dict[str, Any]) -> str:
+    return str(issue.get("title") or "").strip()
+
+
+def issue_url(issue: dict[str, Any]) -> str:
+    return str(issue.get("url") or issue.get("html_url") or "").strip()
+
+
+def public_results_issue_numbers(public_results: dict[str, Any]) -> set[int]:
+    out: set[int] = set()
+    for issue in public_results.get("issues") or []:
+        try:
+            out.add(int(issue.get("number") or issue.get("issue_number") or 0))
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def public_results_generated_at(public_results: dict[str, Any]) -> str | None:
+    value = public_results.get("generated_at")
+    return str(value) if value else None
+
+
+def choose_close_reason(outcome_label: str) -> str:
+    if outcome_label in COMPLETED_OUTCOMES:
+        return "completed"
+    if outcome_label in NOT_PLANNED_OUTCOMES:
+        return "not_planned"
+    raise ValueError(f"Unsupported outcome label: {outcome_label}")
+
+
+def issue_decision(
+    issue: dict[str, Any],
+    *,
+    week_id: str,
+    public_issue_numbers: set[int],
+    require_public_results_membership: bool,
+) -> dict[str, Any]:
+    number = issue_number(issue)
+    labels = labels_from_issue(issue)
+    label_set = set(labels)
+    week_labels = sorted(label for label in labels if label.startswith(WEEK_PREFIX))
+    outcome_labels = sorted(label for label in labels if label.startswith(OUTCOME_PREFIX))
+    protected = sorted(label_set & PROTECTED_LABELS)
+
+    skip_reasons: list[str] = []
+    if not number:
+        skip_reasons.append("missing_issue_number")
+    if f"week:{week_id}" not in label_set:
+        skip_reasons.append("missing_matching_week_label")
+    if len(week_labels) != 1:
+        skip_reasons.append("expected_exactly_one_week_label")
+    if len(outcome_labels) != 1:
+        skip_reasons.append("expected_exactly_one_outcome_label")
+    if outcome_labels and outcome_labels[0] not in ALLOWED_OUTCOMES:
+        skip_reasons.append("unsupported_outcome_label")
+    if protected:
+        skip_reasons.append("protected_label_present")
+    if require_public_results_membership and number not in public_issue_numbers:
+        skip_reasons.append("missing_from_public_results_snapshot")
+
+    if skip_reasons:
+        return {
+            "number": number,
+            "title": issue_title(issue),
+            "url": issue_url(issue),
+            "labels": labels,
+            "action": "skip",
+            "skip_reasons": skip_reasons,
+            "week_labels": week_labels,
+            "outcome_labels": outcome_labels,
+            "protected_labels": protected,
+        }
+
+    outcome = outcome_labels[0]
+    close_reason = choose_close_reason(outcome)
+    return {
+        "number": number,
+        "title": issue_title(issue),
+        "url": issue_url(issue),
+        "labels": labels,
+        "action": "close",
+        "week_id": week_id,
+        "outcome": outcome,
+        "close_reason": close_reason,
+        "comment_file": f"comments/{number}.md",
+    }
+
+
+def render_close_comment(item: dict[str, Any], *, public_results_path: str, run_record_hint: str, generated_at: str | None) -> str:
+    lines = [
+        "<!-- prompt-vote-lab:weekly-issue-finalizer:v1 -->",
+        "## Weekly experiment cycle complete",
+        "",
+        "This Issue is being closed automatically because the weekly experiment cycle has been recorded.",
+        "",
+        "```text",
+        f"week: {item['week_id']}",
+        f"outcome: {item['outcome']}",
+        f"close_reason: {item['close_reason']}",
+        f"public_results: {public_results_path}",
+        f"public_results_generated_at: {generated_at or 'unknown'}",
+        "```",
+        "",
+        "The Issue is not deleted. It remains visible through its original URL and GitHub closed-Issue search.",
+        "",
+        "Evidence locations:",
+        "",
+        f"- Public results snapshot: `{public_results_path}`",
+    ]
+    if run_record_hint:
+        lines.append(f"- Run record hint: `{run_record_hint}`")
+    lines.extend(
+        [
+            "- This Issue thread contains the finalizer comment and all prior discussion.",
+            "",
+            "Reason for automatic close:",
+            "",
+            "```text",
+            "Only Issues with both week:* and outcome:* labels are eligible for automatic close.",
+            "Issues with carryover, future-candidate, discussion, bug, admin, do-not-close, or pinned labels are skipped.",
+            "```",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_markdown(plan: dict[str, Any]) -> str:
+    lines = [
+        "# Weekly Issue Finalizer plan",
+        "",
+        f"Generated at: `{plan['generated_at']}`",
+        f"Week: `{plan['week_id']}`",
+        f"Dry run: `{plan['dry_run']}`",
+        f"Require public results membership: `{plan['require_public_results_membership']}`",
+        "",
+        "## Summary",
+        "",
+        "| metric | value |",
+        "| --- | --- |",
+        f"| close_count | {plan['summary']['close_count']} |",
+        f"| skip_count | {plan['summary']['skip_count']} |",
+        "",
+        "## Issues to close",
+        "",
+        "| # | outcome | reason | title |",
+        "| --- | --- | --- | --- |",
+    ]
+    for item in plan["to_close"]:
+        lines.append(f"| {item['number']} | {item['outcome']} | {item['close_reason']} | {item['title']} |")
+    lines.extend(["", "## Skipped Issues", "", "| # | reasons | title |", "| --- | --- | --- |"])
+    for item in plan["skipped"]:
+        lines.append(f"| {item['number']} | {', '.join(item['skip_reasons'])} | {item['title']} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_plan(args: argparse.Namespace) -> dict[str, Any]:
+    issues_raw = read_json(Path(args.issues_json), [])
+    if isinstance(issues_raw, dict):
+        issues = issues_raw.get("issues") or issues_raw.get("items") or []
+    else:
+        issues = issues_raw
+    if not isinstance(issues, list):
+        raise ValueError("issues_json must contain a list or an object with issues/items")
+
+    public_results = read_json(Path(args.public_results), {})
+    public_numbers = public_results_issue_numbers(public_results)
+    generated_at = public_results_generated_at(public_results)
+
+    results = [
+        issue_decision(
+            issue,
+            week_id=args.week_id,
+            public_issue_numbers=public_numbers,
+            require_public_results_membership=args.require_public_results_membership,
+        )
+        for issue in issues
+    ]
+    to_close = [item for item in results if item["action"] == "close"]
+    skipped = [item for item in results if item["action"] == "skip"]
+
+    plan = {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": utc_now(),
+        "week_id": args.week_id,
+        "dry_run": args.dry_run,
+        "public_results_path": args.public_results,
+        "public_results_generated_at": generated_at,
+        "require_public_results_membership": args.require_public_results_membership,
+        "summary": {
+            "close_count": len(to_close),
+            "skip_count": len(skipped),
+        },
+        "to_close": to_close,
+        "skipped": skipped,
+    }
+    return plan
+
+
+def write_outputs(plan: dict[str, Any], args: argparse.Namespace) -> None:
+    out_json = Path(args.out_json)
+    out_md = Path(args.out_md)
+    comments_dir = Path(args.comments_dir)
+    write_text(out_json, json.dumps(plan, indent=2, ensure_ascii=False, sort_keys=True) + "\n")
+    write_text(out_md, render_markdown(plan))
+    comments_dir.mkdir(parents=True, exist_ok=True)
+    for item in plan["to_close"]:
+        comment = render_close_comment(
+            item,
+            public_results_path=args.public_results,
+            run_record_hint=args.run_record_hint,
+            generated_at=plan.get("public_results_generated_at"),
+        )
+        write_text(comments_dir / f"{item['number']}.md", comment)
+
+
+def valid_week_id(value: str) -> str:
+    if not re.fullmatch(r"\d{4}-W\d{2}|initial|test-week", value):
+        raise argparse.ArgumentTypeError("week_id must look like YYYY-Www, initial, or test-week")
+    return value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--issues-json", required=True)
+    parser.add_argument("--public-results", default="data/public-results.json")
+    parser.add_argument("--week-id", required=True, type=valid_week_id)
+    parser.add_argument("--out-json", required=True)
+    parser.add_argument("--out-md", required=True)
+    parser.add_argument("--comments-dir", required=True)
+    parser.add_argument("--run-record-hint", default="runs/")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--require-public-results-membership", action="store_true")
+    args = parser.parse_args()
+
+    plan = build_plan(args)
+    write_outputs(plan, args)
+    print(json.dumps(plan["summary"], indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a manual weekly Issue finalizer that comments on and closes only explicitly eligible weekly Issues.

## Policy

Issues are closed, not deleted. The finalizer writes a close comment before closing so the record remains in the Issue thread.

## Eligibility

An Issue can be closed only if it has:

```text
week:<week_id>
exactly one supported outcome:* label
no protected labels
```

Supported completed outcomes:

```text
outcome:implemented
outcome:archived-fixture
```

Supported not-planned outcomes:

```text
outcome:not-selected
outcome:blocked
outcome:rejected-after-run
```

Protected labels that force skip:

```text
carryover
future-candidate
discussion
bug
admin
do-not-close
pinned
```

## Workflow

Adds `.github/workflows/weekly-issue-finalizer.yml`.

The workflow is manual only and defaults to dry run:

```text
dry_run: true
require_public_results_membership: true
```

When `dry_run=true`, it uploads a plan artifact only.

When `dry_run=false`, it posts a generated close comment and then closes eligible Issues.

## Evidence order

The intended order is:

```text
run
→ review
→ merge/reject
→ runs/ record
→ Public Results Export
→ Weekly Issue Finalizer dry run
→ Weekly Issue Finalizer close run
```

## Tests

Adds:

```text
scripts/test_weekly_issue_finalizer.py
scripts/test_weekly_issue_finalizer_workflow_contract.py
```

Registers both in Script Check.

## Non-goals

- No schedule yet.
- No auto-close without labels.
- No model/API run.
- No `/lab/` changes.
- No deletion of Issues.