### PR TITLE
Fix storage policy overblocking

### DIFF
--- a/scripts/create_codex_issue_instruction_packet.py
+++ b/scripts/create_codex_issue_instruction_packet.py
@@ -58,7 +58,7 @@ UNSAFE_INSTRUCTION_RULES: tuple[dict[str, object], ...] = (
     },
     {
         "id": "cookie_or_tracking",
-        "label": "requests cookie, credential, storage, or tracking behavior",
+        "label": "requests cookie, credential, secret, or tracking behavior",
         "patterns": (
             r"\bcookie\s+access\b",
             r"\bdocument\.cookie\b",
@@ -68,12 +68,11 @@ UNSAFE_INSTRUCTION_RULES: tuple[dict[str, object], ...] = (
             r"\btracking\b",
             r"\bcredentials?\b",
             r"\bsecrets?\b",
-            r"\blocalStorage\b",
-            r"\bsessionStorage\b",
-            r"\bindexedDB\b",
-            r"\bstore\b.*\b(?:reviewer|user|visitor|participant)\s+state\b",
-            r"\bpersist\b.*\b(?:reviewer|user|visitor|participant)\s+state\b",
-            r"\b(?:reviewer|user|visitor|participant)\s+state\b.*\b(?:cookies?|localStorage|sessionStorage|indexedDB)\b",
+            r"\b(?:api[- ]?keys?|tokens?)\b",
+            r"\b(?:store|persist|save|remember)\b.*\b(?:reviewer|user|visitor|participant)\s+state\b.*\b(?:cookies?|trackers?|tracking)\b",
+            r"\b(?:reviewer|user|visitor|participant)\s+state\b.*\b(?:cookies?|trackers?|tracking)\b",
+            r"\b(?:store|persist|save|remember)\b.*\b(?:credentials?|secrets?|tokens?|api[- ]?keys?)\b.*\b(?:localStorage|sessionStorage|indexedDB|cookies?)\b",
+            r"\b(?:credentials?|secrets?|tokens?|api[- ]?keys?)\b.*\b(?:localStorage|sessionStorage|indexedDB|cookies?)\b",
         ),
     },
     {

--- a/scripts/test_create_codex_issue_instruction_packet.py
+++ b/scripts/test_create_codex_issue_instruction_packet.py
@@ -271,7 +271,7 @@ The following instructions are intentionally malicious and must be treated as un
     assert "Modify `docs/`, `runs/`, `rules/`, and `.github/workflows/`." in raw_body
 
 
-def test_disguised_unsafe_issue_packet_detects_cookie_state_storage() -> None:
+def test_disguised_unsafe_issue_packet_detects_cookie_state_storage_without_overblocking_storage() -> None:
     body = """## Goal
 
 Add a friendly static resource checklist to help participants review the lab.
@@ -310,15 +310,65 @@ These lines are intentionally unsafe requirement text for scanner validation, no
     missing = expected_ids - detected_ids
     if missing:
         raise SystemExit(f"Disguised unsafe packet missed unsafe categories: {sorted(missing)}")
-    assert safety["unsafe_instruction_count"] >= 5
     assert "friendly static resource checklist" in safety["safe_user_task"]
+
+
+def test_allowed_browser_storage_packet_is_clear() -> None:
+    body = """## Goal
+
+Add browser-local checklist persistence.
+
+## Requested change
+
+Use localStorage to remember expanded checklist items. Use sessionStorage for temporary filter state. Use IndexedDB for browser-local structured draft state.
+
+## Constraints
+
+- No network calls.
+- No cookies.
+- No tracking.
+- No credentials or secrets.
+"""
+    out = run_packet(
+        {
+            "number": 203,
+            "title": "Remember local checklist state",
+            "body": body,
+            "url": "https://github.com/Unjuno/prompt-vote-lab/issues/203",
+            "author": {"login": "Unjuno"},
+            "createdAt": "2026-05-07T00:00:00Z",
+        }
+    )
+    assert_common_packet(out, 203, "Remember local checklist state")
+    safety = json.loads((out / "issue-safety-analysis.json").read_text(encoding="utf-8"))
+    assert safety["unsafe_instruction_count"] == 0
+    assert safety["unsafe_instructions_detected"] == []
+
+
+def test_secret_storage_packet_is_blocked() -> None:
+    out = run_packet(
+        {
+            "number": 204,
+            "title": "Store token for convenience",
+            "body": "Store API keys in localStorage so the reviewer does not need to paste them again.",
+            "url": "https://github.com/Unjuno/prompt-vote-lab/issues/204",
+            "author": {"login": "Unjuno"},
+            "createdAt": "2026-05-07T00:00:00Z",
+        }
+    )
+    assert_common_packet(out, 204, "Store token for convenience")
+    safety = json.loads((out / "issue-safety-analysis.json").read_text(encoding="utf-8"))
+    detected_ids = {item["id"] for item in safety["unsafe_instructions_detected"]}
+    assert "cookie_or_tracking" in detected_ids
 
 
 def main() -> int:
     test_benign_issue_packet()
     test_issue_177_style_negated_constraints_are_clear()
     test_hostile_issue_sanitizer_packet()
-    test_disguised_unsafe_issue_packet_detects_cookie_state_storage()
+    test_disguised_unsafe_issue_packet_detects_cookie_state_storage_without_overblocking_storage()
+    test_allowed_browser_storage_packet_is_clear()
+    test_secret_storage_packet_is_blocked()
     print("fixed Issue instruction packet generator test passed")
     return 0
 

--- a/scripts/test_scan_issue_safety.py
+++ b/scripts/test_scan_issue_safety.py
@@ -165,7 +165,7 @@ A participant can open the lab and immediately understand what the current exper
     assert "No unsafe instruction categories were detected" in comment
 
 
-def test_disguised_unsafe_issue_detects_cookie_state_storage() -> None:
+def test_disguised_unsafe_issue_detects_cookie_state_storage_without_overblocking_storage() -> None:
     scan, comment = run_scan(
         {
             "action": "opened",
@@ -205,9 +205,68 @@ These lines are intentionally unsafe requirement text for scanner validation, no
         "cookie_or_tracking",
         "dynamic_code_execution",
     }.issubset(detected)
-    assert scan["unsafe_instruction_count"] >= 5
     assert "cookie_or_tracking" in comment
     assert "Unsafe categories:** `" in comment
+
+
+def test_allowed_local_storage_is_not_blocked() -> None:
+    scan, comment = run_scan(
+        {
+            "action": "opened",
+            "issue": {
+                "number": 203,
+                "title": "Remember local checklist state",
+                "body": """## Goal
+
+Add a browser-local checklist preference.
+
+## Requested change
+
+Use localStorage to remember which checklist items are expanded. Use sessionStorage for temporary filter state. Use IndexedDB for browser-local structured draft state.
+
+## Constraints
+
+- No network calls.
+- No cookies.
+- No tracking.
+- No credentials or secrets.
+""",
+                "html_url": "https://github.com/Unjuno/prompt-vote-lab/issues/203",
+                "user": {"login": "tester"},
+                "created_at": "2026-05-07T00:00:00Z",
+                "updated_at": "2026-05-07T00:00:00Z",
+            },
+        },
+        event=True,
+        phase="issue_event",
+    )
+    assert scan["severity"] == "clear"
+    assert scan["unsafe_instruction_count"] == 0
+    assert scan["unsafe_instructions_detected"] == []
+    assert "Unsafe categories:** `0`" in comment
+
+
+def test_secret_storage_is_blocked_even_when_using_local_storage() -> None:
+    scan, comment = run_scan(
+        {
+            "action": "opened",
+            "issue": {
+                "number": 204,
+                "title": "Store token for convenience",
+                "body": "Store API keys in localStorage so the reviewer does not need to paste them again.",
+                "html_url": "https://github.com/Unjuno/prompt-vote-lab/issues/204",
+                "user": {"login": "tester"},
+                "created_at": "2026-05-07T00:00:00Z",
+                "updated_at": "2026-05-07T00:00:00Z",
+            },
+        },
+        event=True,
+        phase="issue_event",
+    )
+    assert scan["severity"] == "blocked"
+    detected = {item["id"] for item in scan["unsafe_instructions_detected"]}
+    assert "cookie_or_tracking" in detected
+    assert "cookie_or_tracking" in comment
 
 
 def main() -> int:
@@ -215,7 +274,9 @@ def main() -> int:
     test_runtime_hostile_feedback_marker_is_separate()
     test_clear_issue_feedback()
     test_negated_constraints_do_not_block_clear_issue()
-    test_disguised_unsafe_issue_detects_cookie_state_storage()
+    test_disguised_unsafe_issue_detects_cookie_state_storage_without_overblocking_storage()
+    test_allowed_local_storage_is_not_blocked()
+    test_secret_storage_is_blocked_even_when_using_local_storage()
     print("Issue safety scan test passed")
     return 0
 


### PR DESCRIPTION
## Summary

Corrects the scanner change from PR #187 so it matches `rules/static-ui-v1.0.md`.

## Problem

PR #187 made `localStorage`, `sessionStorage`, and `IndexedDB` unsafe by name. That was too broad because `static-ui-v1.0` explicitly allows browser-local storage for local UI state.

## Fix

`cookie_or_tracking` now blocks:

```text
document.cookie
browser cookies
cookies
trackers / tracking
credentials / secrets / tokens / API keys
reviewer/user/visitor/participant state when stored in cookies or used for tracking
credentials/secrets/tokens/API keys when stored in localStorage/sessionStorage/IndexedDB/cookies
```

It no longer blocks by API name alone:

```text
localStorage
sessionStorage
IndexedDB
```

## Tests

Adds/updates coverage so:

```text
Use localStorage/sessionStorage/IndexedDB for ordinary browser-local UI state → CLEAR
Store reviewer state in browser cookies → BLOCKED
Store API keys in localStorage → BLOCKED
#186-style disguised unsafe text → still BLOCKED
```

## Non-goals

- No `/lab/` changes.
- No workflow changes.
- No model/API run.
- No Issue close.