### PR TITLE
Fix weekly finalizer close reason mapping

### DIFF
--- a/.github/workflows/weekly-issue-finalizer.yml
+++ b/.github/workflows/weekly-issue-finalizer.yml
@@ -91,9 +91,10 @@ jobs:
           plan = json.loads(Path('.tmp/weekly-issue-finalizer/plan.json').read_text(encoding='utf-8'))
           for item in plan.get('to_close', []):
               number = str(item['number'])
-              reason = item['close_reason']
+              reason = str(item['close_reason'])
+              gh_reason = reason.replace('_', ' ')
               comment = f".tmp/weekly-issue-finalizer/comments/{number}.md"
               print(f"gh issue comment {shlex.quote(number)} --repo \"$GITHUB_REPOSITORY\" --body-file {shlex.quote(comment)}")
-              print(f"gh issue close {shlex.quote(number)} --repo \"$GITHUB_REPOSITORY\" --reason {shlex.quote(reason)}")
+              print(f"gh issue close {shlex.quote(number)} --repo \"$GITHUB_REPOSITORY\" --reason {shlex.quote(gh_reason)}")
           PY
           bash .tmp/weekly-issue-finalizer/close-commands.sh

--- a/scripts/test_weekly_issue_finalizer_workflow_contract.py
+++ b/scripts/test_weekly_issue_finalizer_workflow_contract.py
@@ -26,6 +26,8 @@ REQUIRED_WORKFLOW_TEXT = [
     "if: ${{ inputs.dry_run != 'true' }}",
     "gh issue comment",
     "gh issue close",
+    "gh_reason = reason.replace('_', ' ')",
+    "--reason {shlex.quote(gh_reason)}",
 ]
 
 FORBIDDEN_WORKFLOW_TEXT = [


### PR DESCRIPTION
## Summary

Fixes the Weekly Issue Finalizer close step so internal close reasons are mapped to GitHub CLI reason strings before calling `gh issue close`.

## Problem

The finalizer plan uses internal machine-readable values such as:

```text
not_planned
```

The workflow passed that value directly to:

```text
gh issue close --reason <value>
```

This allowed the comment step to succeed while the close step could fail for blocked/not-planned outcomes.

## Fix

The workflow now maps underscore-separated internal reasons to CLI-facing reason strings at the final shell-command generation step:

```text
gh_reason = reason.replace('_', ' ')
```

So the plan can continue using stable internal values while the CLI receives its expected format.

## Tests

Updates the weekly finalizer workflow contract test to require:

```text
gh_reason = reason.replace('_', ' ')
--reason {shlex.quote(gh_reason)}
```

## Non-goals

- No `/lab/` changes.
- No model/API run.
- No schedule/auto-run changes.
- No change to finalizer eligibility policy.