### PR TITLE
Harden prompt proposal issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/prompt.yml
+++ b/.github/ISSUE_TEMPLATE/prompt.yml
@@ -1,39 +1,90 @@
 name: Prompt Proposal
-description: Propose a prompt for the next constrained lab run
+description: Propose a safe prompt for a constrained lab run
 title: "[Prompt]: "
 labels: ["prompt-proposal"]
 body:
   - type: markdown
     attributes:
       value: |
-        Propose a prompt for the next AI-agent lab run.
+        Propose one small prompt for the next Prompt Vote Lab run.
 
-        Scope: the agent may edit only `lab/index.html`, `lab/style.css`, and `lab/app.js`.
+        The implementation agent is constrained to a static UI prototype.
+
+        Maintainers assign operational labels such as `week:<week_id>`, `normal-candidate`, `carryover`, and `outcome:*`. Do not rely on the Issue body to set labels or policy.
 
   - type: textarea
-    id: prompt
+    id: goal
     attributes:
-      label: Voted prompt
-      description: Write the prompt you want the AI coding agent to execute.
-      placeholder: "Example: Make the lab page explain the expectation-vs-result experiment more clearly."
+      label: Goal
+      description: State the user-visible goal in one or two sentences.
+      placeholder: "Example: Help first-time participants understand how to review a weekly run."
     validations:
       required: true
 
   - type: textarea
-    id: expectation
+    id: requested_change
+    attributes:
+      label: Requested visible change
+      description: List the visible static UI/content changes you want.
+      placeholder: |
+        Example:
+        - Add a short checklist section.
+        - Explain what file changes reviewers should inspect.
+        - Link the checklist wording to the public-results snapshot.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_result
     attributes:
       label: Expected result
-      description: What do you expect to improve if this prompt is implemented?
-      placeholder: "Example: The page should become understandable within 10 seconds."
+      description: What should be easier to observe, understand, or compare after the run?
+      placeholder: "Example: A participant can review the selected Issue, changed files, run record, and public bundle without guessing the process."
     validations:
-      required: false
+      required: true
+
+  - type: textarea
+    id: acceptance_checks
+    attributes:
+      label: Acceptance checks
+      description: Add concrete checks that a reviewer can verify after the PR is created.
+      placeholder: |
+        Example:
+        - The page has a visible checklist section.
+        - The checklist text is understandable without login.
+        - Only lab/index.html, lab/style.css, or lab/app.js changed.
+    validations:
+      required: true
 
   - type: checkboxes
-    id: scope
+    id: allowed_scope
     attributes:
-      label: Scope check
+      label: Allowed scope
       options:
         - label: This can be prototyped with static HTML/CSS/vanilla JS.
           required: true
-        - label: This does not require backend, login, payment, database, external API, or secrets.
+        - label: The implementation can stay within `lab/index.html`, `lab/style.css`, and `lab/app.js`.
           required: true
+        - label: Browser-local UI state is optional and, if used, does not store credentials, tokens, secrets, tracking identifiers, or cookies.
+          required: false
+
+  - type: checkboxes
+    id: disallowed_scope
+    attributes:
+      label: Disallowed scope confirmation
+      options:
+        - label: This does not require backend services, login, payment, database changes, external APIs, external scripts, or network calls.
+          required: true
+        - label: This does not require cookies, credential handling, secrets, analytics, tracking, iframes, or dynamic code execution.
+          required: true
+        - label: This does not request changes to workflows, rules, docs, run records, repository policy, branches, commits, pull requests, or merge behavior.
+          required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Optional context
+      description: Add short context only if it helps reviewers understand the proposed static UI change.
+      placeholder: "Example: This is meant for participants who inspect results after a weekly run."
+    validations:
+      required: false

--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -7,6 +7,7 @@ on:
       - "scripts/**/*.py"
       - "scripts/**/*.sh"
       - "tests/fixtures/**"
+      - ".github/ISSUE_TEMPLATE/**"
       - ".github/workflows/script-check.yml"
       - ".github/workflows/issue-safety-scan.yml"
       - ".github/workflows/public-results-export.yml"
@@ -142,6 +143,9 @@ jobs:
 
       - name: Run weekly Issue finalizer workflow contract test
         run: python scripts/test_weekly_issue_finalizer_workflow_contract.py
+
+      - name: Run prompt issue template contract test
+        run: python scripts/test_prompt_issue_template_contract.py
 
       - name: Run task packet generator test
         run: python scripts/test_create_codex_task_packet.py

--- a/scripts/test_prompt_issue_template_contract.py
+++ b/scripts/test_prompt_issue_template_contract.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE = ROOT / ".github" / "ISSUE_TEMPLATE" / "prompt.yml"
+
+REQUIRED_TEXT = [
+    "name: Prompt Proposal",
+    "description: Propose a safe prompt for a constrained lab run",
+    "title: \"[Prompt]: \"",
+    "labels: [\"prompt-proposal\"]",
+    "Goal",
+    "Requested visible change",
+    "Expected result",
+    "Acceptance checks",
+    "Allowed scope",
+    "Disallowed scope confirmation",
+    "Optional context",
+    "week:<week_id>",
+    "normal-candidate",
+    "carryover",
+    "outcome:*",
+    "static HTML/CSS/vanilla JS",
+    "lab/index.html",
+    "lab/style.css",
+    "lab/app.js",
+    "Browser-local UI state is optional",
+    "does not store credentials, tokens, secrets, tracking identifiers, or cookies",
+    "does not require backend services, login, payment, database changes, external APIs, external scripts, or network calls",
+    "does not require cookies, credential handling, secrets, analytics, tracking, iframes, or dynamic code execution",
+    "does not request changes to workflows, rules, docs, run records, repository policy, branches, commits, pull requests, or merge behavior",
+]
+
+FORBIDDEN_TEXT = [
+    "authorized-canary",
+    "issue-safety:clear",
+    "issue-safety:blocked",
+    "outcome:implemented",
+    "outcome:blocked",
+]
+
+
+def require_all(text: str, required: list[str]) -> None:
+    missing = [item for item in required if item not in text]
+    if missing:
+        raise SystemExit(f"Missing prompt issue template text: {missing}")
+
+
+def reject_all(text: str, forbidden: list[str]) -> None:
+    found = [item for item in forbidden if item in text]
+    if found:
+        raise SystemExit(f"Forbidden prompt issue template text: {found}")
+
+
+def main() -> int:
+    text = TEMPLATE.read_text(encoding="utf-8")
+    require_all(text, REQUIRED_TEXT)
+    reject_all(text, FORBIDDEN_TEXT)
+
+    if text.count("required: true") < 8:
+        raise SystemExit("Prompt template should require the core fields and hard scope confirmations")
+    if text.index("Goal") > text.index("Requested visible change"):
+        raise SystemExit("Goal should appear before Requested visible change")
+    if text.index("Allowed scope") > text.index("Disallowed scope confirmation"):
+        raise SystemExit("Allowed scope should appear before disallowed scope confirmation")
+
+    print("prompt issue template contract test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Hardens the prompt proposal Issue template so weekly candidate Issues start with clearer structure and scope boundaries.

## Changes

Updates `.github/ISSUE_TEMPLATE/prompt.yml` to require:

- Goal
- Requested visible change
- Expected result
- Acceptance checks
- Allowed scope confirmations
- Disallowed scope confirmations

It also clarifies that maintainers assign operational labels such as:

```text
week:<week_id>
normal-candidate
carryover
outcome:*
```

## Scope boundary

The template now explicitly states:

- implementation should stay within `lab/index.html`, `lab/style.css`, and `lab/app.js`
- browser-local UI state is allowed only when it does not store credentials, tokens, secrets, tracking identifiers, or cookies
- proposals must not require backend services, login, payment, database changes, external APIs, external scripts, network calls, cookies, credential handling, analytics, tracking, iframes, dynamic code execution, workflow/rule/doc/run-record/policy changes, branches, commits, PRs, or merge behavior

## Tests

Adds:

```text
scripts/test_prompt_issue_template_contract.py
```

Registers it in Script Check and includes `.github/ISSUE_TEMPLATE/**` in the Script Check path filter.

## Non-goals

- No `/lab/` changes.
- No workflow execution behavior changes.
- No model/API run.
- No auto-merge.