### PR TITLE
Add comparison run metadata inputs

### DIFF
--- a/.github/workflows/codex-fixed-issue-instruction-canary-run.yml
+++ b/.github/workflows/codex-fixed-issue-instruction-canary-run.yml
@@ -7,6 +7,16 @@ on:
         description: "Fixed GitHub Issue number to convert into a task instruction packet"
         required: true
         type: number
+      candidate_rank:
+        description: "Candidate rank within the comparison set. Use 1 for normal weekly winner, 2/3 for comparison runs."
+        required: true
+        default: "1"
+        type: number
+      vote_count:
+        description: "Vote count recorded for this candidate at selection time."
+        required: true
+        default: "0"
+        type: number
 
 permissions:
   contents: write
@@ -24,11 +34,25 @@ jobs:
       CODEX_MODEL: gpt-5.4-nano
       RUN_WEEK: first-canary-009
       ISSUE_NUMBER: ${{ inputs.issue_number }}
+      CANDIDATE_RANK: ${{ inputs.candidate_rank }}
+      VOTE_COUNT: ${{ inputs.vote_count }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Validate dispatch inputs
+        run: |
+          set -euo pipefail
+          case "$CANDIDATE_RANK" in
+            1|2|3) ;;
+            *) echo "candidate_rank must be 1, 2, or 3"; exit 1 ;;
+          esac
+          case "$VOTE_COUNT" in
+            ''|*[!0-9]*) echo "vote_count must be a non-negative integer"; exit 1 ;;
+            *) ;;
+          esac
 
       - name: Capture diagnostics baseline
         run: |
@@ -191,9 +215,9 @@ jobs:
             --workflow "Codex Fixed Issue Instruction Canary Run" \
             --run-number "${{ github.run_number }}" \
             --week "$RUN_WEEK" \
-            --candidate-rank 1 \
+            --candidate-rank "$CANDIDATE_RANK" \
             --issue-number "$ISSUE_NUMBER" \
-            --vote-count 0 \
+            --vote-count "$VOTE_COUNT" \
             --base-sha "$base_sha" \
             --branch "codex-fixed-issue-canary-009-${{ github.run_number }}" \
             --attempt-count 1 \
@@ -243,8 +267,8 @@ jobs:
           - Week: $RUN_WEEK
           - Issue: #$ISSUE_NUMBER
           - Issue title: $issue_title
-          - Rank: 1
-          - Votes: 0
+          - Rank: $CANDIDATE_RANK
+          - Votes: $VOTE_COUNT
           - Inherited lab base: \`$base_sha\`
           - Provider: \`openai-codex\`
           - Runner: \`codex-cli-fixed-issue-instruction-packet-container\`

--- a/scripts/test_issue_instruction_runner_contract.py
+++ b/scripts/test_issue_instruction_runner_contract.py
@@ -35,6 +35,14 @@ REQUIRED_RUNNER_TEXT = [
 REQUIRED_WORKFLOW_TEXT = [
     "name: Codex Fixed Issue Instruction Canary Run",
     "issue_number:",
+    "candidate_rank:",
+    "vote_count:",
+    "Candidate rank within the comparison set. Use 1 for normal weekly winner, 2/3 for comparison runs.",
+    "Vote count recorded for this candidate at selection time.",
+    "CANDIDATE_RANK: ${{ inputs.candidate_rank }}",
+    "VOTE_COUNT: ${{ inputs.vote_count }}",
+    "candidate_rank must be 1, 2, or 3",
+    "vote_count must be a non-negative integer",
     "issues: write",
     "CODEX_MODEL: gpt-5.4-nano",
     "RUN_WEEK: first-canary-009",
@@ -62,6 +70,10 @@ REQUIRED_WORKFLOW_TEXT = [
     "codex-fixed-issue-instruction-canary-diagnostics-",
     "codex-fixed-issue-instruction-canary-public-log-",
     "codex-fixed-issue-runtime-safety-scan-",
+    "--candidate-rank \"$CANDIDATE_RANK\"",
+    "--vote-count \"$VOTE_COUNT\"",
+    "- Rank: $CANDIDATE_RANK",
+    "- Votes: $VOTE_COUNT",
     "--retry-policy none",
     "--fallback-policy none",
     "--auto-merge-policy disabled",
@@ -71,6 +83,13 @@ FORBIDDEN_RUNNER_TEXT = [
     "-v \"$task:/task:rw\"",
     "cat " + "$" + "OPENAI_API_KEY",
     "echo " + "$" + "OPENAI_API_KEY",
+]
+
+FORBIDDEN_WORKFLOW_TEXT = [
+    "--candidate-rank 1",
+    "--vote-count 0",
+    "- Rank: 1",
+    "- Votes: 0",
 ]
 
 
@@ -93,7 +112,10 @@ def main() -> int:
     require_all(runner_text, REQUIRED_RUNNER_TEXT, "runner")
     reject_all(runner_text, FORBIDDEN_RUNNER_TEXT, "runner")
     require_all(workflow_text, REQUIRED_WORKFLOW_TEXT, "workflow")
+    reject_all(workflow_text, FORBIDDEN_WORKFLOW_TEXT, "workflow")
 
+    if workflow_text.index("Validate dispatch inputs") > workflow_text.index("Capture diagnostics baseline"):
+        raise SystemExit("Dispatch inputs must be validated before diagnostics baseline")
     if workflow_text.index("Check Issue execution gate") > workflow_text.index("Run Codex fixed Issue instruction packet once"):
         raise SystemExit("Issue execution gate must run before Codex execution")
     if workflow_text.index("Collect diagnostics artifact") > workflow_text.index("Build redacted public agent run bundle"):


### PR DESCRIPTION
## Summary

Prepares the fixed-Issue 009 workflow for rank-2/rank-3 comparison runs by making candidate rank and vote count explicit workflow-dispatch inputs.

## Problem

The workflow previously hardcoded comparison metadata as:

```text
candidate_rank: 1
vote_count: 0
```

That is acceptable for a single normal run, but it corrupts evidence for rank-2 and rank-3 comparison runs.

## Changes

Adds workflow inputs:

```text
candidate_rank: 1 | 2 | 3
vote_count: non-negative integer
```

Then threads those values into:

- dispatch input validation
- public run log
- generated implementation PR body

## Tests

Updates the fixed-Issue runner workflow contract test to require dynamic rank/vote metadata and reject the old hardcoded rank/vote values.

## Non-goals

- No `/lab/` changes.
- No model/API run.
- No automatic candidate selection.
- No support/payment logic.
- No auto-merge.