### PR TITLE
Auto-build comparison dashboards during public export

### DIFF
--- a/.github/workflows/public-results-export.yml
+++ b/.github/workflows/public-results-export.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: "100"
       commit_results:
-        description: "Commit data/public-results.json and data/public-results.md to the current branch"
+        description: "Commit data/public-results.json, data/public-results.md, and generated comparison dashboards to the current branch"
         required: false
         default: "true"
   schedule:
@@ -135,6 +135,43 @@ jobs:
             --out-json data/public-results.json \
             --out-md data/public-results.md
 
+      - name: Build comparison dashboards
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from __future__ import annotations
+          import json
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          data = json.loads(Path('data/public-results.json').read_text(encoding='utf-8'))
+          weeks = sorted({
+              label.split(':', 1)[1]
+              for issue in data.get('issues', [])
+              for label in issue.get('labels', [])
+              if isinstance(label, str) and label.startswith('week:')
+          })
+          if not weeks:
+              print('No week labels found; skipping comparison dashboard generation.')
+          for week_id in weeks:
+              out_dir = Path('lab') / 'comparisons' / week_id
+              print(f'Building comparison dashboard for {week_id} -> {out_dir}')
+              subprocess.run(
+                  [
+                      sys.executable,
+                      'scripts/build_comparison_dashboard.py',
+                      '--public-results',
+                      'data/public-results.json',
+                      '--week-id',
+                      week_id,
+                      '--out-dir',
+                      str(out_dir),
+                  ],
+                  check=True,
+              )
+          PY
+
       - name: Upload public results artifact
         uses: actions/upload-artifact@v4
         with:
@@ -142,6 +179,7 @@ jobs:
           path: |
             data/public-results.json
             data/public-results.md
+            lab/comparisons/**
             .tmp/public-results
           if-no-files-found: error
 
@@ -157,9 +195,9 @@ jobs:
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/public-results.json data/public-results.md
+          git add data/public-results.json data/public-results.md lab/comparisons
           if git diff --cached --quiet; then
-            echo "No public results changes to commit."
+            echo "No public results or comparison dashboard changes to commit."
             exit 0
           fi
           git commit -m "Update public results export"

--- a/scripts/test_public_results_export_workflow_contract.py
+++ b/scripts/test_public_results_export_workflow_contract.py
@@ -21,6 +21,11 @@ REQUIRED_WORKFLOW_TEXT = [
     "gh run list",
     "gh label list",
     "python scripts/build_public_results_export.py",
+    "Build comparison dashboards",
+    "scripts/build_comparison_dashboard.py",
+    "lab/comparisons",
+    "lab/comparisons/**",
+    "git add data/public-results.json data/public-results.md lab/comparisons",
     "data/public-results.json",
     "data/public-results.md",
     "public-results-export-${{ github.run_number }}",
@@ -32,6 +37,7 @@ FORBIDDEN_WORKFLOW_TEXT = [
     "run_codex_issue_instruction_canary",
     "codex exec",
     "gh pr merge",
+    "raw diagnostics",
 ]
 
 REQUIRED_DOC_TEXT = [
@@ -75,6 +81,13 @@ def main() -> int:
     require_all(doc_text, REQUIRED_DOC_TEXT, "public results doc")
     require_all(data_json_text, REQUIRED_DATA_TEXT, "public results json")
     require_all(data_md_text, ["raw results surface", "See `public-results.json`"], "public results markdown")
+
+    if workflow_text.index("Build public results export") > workflow_text.index("Build comparison dashboards"):
+        raise SystemExit("Comparison dashboards must be built after public results export")
+    if workflow_text.index("Build comparison dashboards") > workflow_text.index("Upload public results artifact"):
+        raise SystemExit("Comparison dashboards must be built before artifact upload")
+    if workflow_text.index("Upload public results artifact") > workflow_text.index("Commit public results snapshot"):
+        raise SystemExit("Artifacts should be uploaded before the commit step")
 
     print("public results export workflow contract test passed")
     return 0


### PR DESCRIPTION
## Summary

Makes comparison dashboards automatic during Public Results Export.

## Changes

Updates `.github/workflows/public-results-export.yml` so that after `data/public-results.json` and `data/public-results.md` are generated, the workflow extracts every `week:*` label from the public results and builds:

```text
lab/comparisons/<week_id>/index.html
lab/comparisons/<week_id>/style.css
```

using:

```text
scripts/build_comparison_dashboard.py
```

The generated dashboards are included in the uploaded artifact and committed together with the public results snapshot when `commit_results=true`.

## Contract test

Updates:

```text
scripts/test_public_results_export_workflow_contract.py
```

to require:

- `Build comparison dashboards`
- `scripts/build_comparison_dashboard.py`
- `lab/comparisons/**` in the artifact
- `git add data/public-results.json data/public-results.md lab/comparisons`
- ordering: public results export → comparison dashboards → artifact upload → commit

## Non-goals

- No model/API run.
- No rank-specific implementation workflow yet.
- No auto-merge.
- No raw diagnostics publication.