### PR TITLE
Add history page generator

### DIFF
--- a/.github/workflows/public-results-export.yml
+++ b/.github/workflows/public-results-export.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: "100"
       commit_results:
-        description: "Commit data/public-results.json, data/public-results.md, and generated comparison dashboards to the current branch"
+        description: "Commit public results, generated comparison dashboards, and generated history page to the current branch"
         required: false
         default: "true"
   schedule:
@@ -172,6 +172,12 @@ jobs:
               )
           PY
 
+      - name: Build history page
+        run: |
+          python scripts/build_history_page.py \
+            --public-results data/public-results.json \
+            --out-dir lab/history
+
       - name: Upload public results artifact
         uses: actions/upload-artifact@v4
         with:
@@ -180,6 +186,7 @@ jobs:
             data/public-results.json
             data/public-results.md
             lab/comparisons/**
+            lab/history/**
             .tmp/public-results
           if-no-files-found: error
 
@@ -195,9 +202,9 @@ jobs:
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/public-results.json data/public-results.md lab/comparisons
+          git add data/public-results.json data/public-results.md lab/comparisons lab/history
           if git diff --cached --quiet; then
-            echo "No public results or comparison dashboard changes to commit."
+            echo "No public results, comparison dashboard, or history changes to commit."
             exit 0
           fi
           git commit -m "Update public results export"

--- a/docs/public-page-architecture.md
+++ b/docs/public-page-architecture.md
@@ -1,0 +1,273 @@
+# Public page architecture
+
+## Purpose
+
+Prompt Vote Lab has separate public pages for four jobs:
+
+```text
+1. attract people
+2. let people participate
+3. show the current lab state
+4. let people verify the experiment history
+```
+
+GitHub remains the source of truth. The public site is a readable index over that evidence.
+
+## Route map
+
+```text
+/                                      Landing page / public entry
+/lab/                                  Current lab state / latest adopted experiment surface
+/lab/history/                          Cross-week progression and experiment history
+/lab/comparisons/<week_id>/            Weekly rank comparison dashboard
+/lab/comparisons/<week_id>/rank-1/     Rank 1 generated artifact
+/lab/comparisons/<week_id>/rank-2/     Rank 2 generated artifact
+/lab/comparisons/<week_id>/rank-3/     Rank 3 generated artifact
+/docs/                                 Rules, policies, and implementation notes
+```
+
+## Landing page
+
+Canonical route:
+
+```text
+/
+```
+
+The landing page is the public entry point. It explains the game loop and sends visitors to voting, submission, the current lab, and evidence pages.
+
+It must show:
+
+```text
+what Prompt Vote Lab is
+how the weekly loop works
+how to propose a prompt
+how to vote with GitHub reactions
+why the 20-vote baseline exists
+how support expands run capacity without buying outcomes
+link to /lab/
+link to /lab/history/
+link to the latest comparison page when available
+link to GitHub Issues
+link to public results
+```
+
+It must not include:
+
+```text
+login inside the static site
+payment handling inside the static site
+external scripts
+analytics or tracking
+network calls
+cookies
+```
+
+## Current lab page
+
+Canonical route:
+
+```text
+/lab/
+```
+
+This is not the landing page. It is the current visible lab state and latest adopted experiment surface.
+
+It should show:
+
+```text
+current experiment state
+latest adopted Issue or PR when available
+next action for participants
+links to history and latest comparison
+short note that results are publicly recorded
+```
+
+It must not become:
+
+```text
+marketing-heavy landing page
+payment page
+login surface
+external-service UI
+```
+
+## History page
+
+Canonical route:
+
+```text
+/lab/history/
+```
+
+The history page shows how the experiment moved across weeks.
+
+It should show, per week:
+
+```text
+week_id
+candidate Issue count
+eligible clear count
+blocked count
+review count
+executed rank count
+adopted rank when known
+comparison page link
+public results snapshot time
+```
+
+Candidate state flow:
+
+```text
+Issue posted
+→ submission safety scan
+→ clear / review / blocked
+→ eligible candidate
+→ rank selected
+→ comparison run
+→ PR created
+→ merged / not selected / blocked
+→ finalizer close
+```
+
+## Weekly comparison page
+
+Canonical route:
+
+```text
+/lab/comparisons/<week_id>/
+```
+
+The weekly comparison page compares rank candidates from the same weekly selection set.
+
+It should show, per rank:
+
+```text
+rank
+Issue number
+Issue title
+vote count
+safety scan status
+runtime scan status
+implementation PR
+changed files
+output root
+run record path
+public bundle link when available
+decision
+```
+
+Critical comparison rule:
+
+```text
+Do not let rank2 inherit rank1's merged root lab output.
+```
+
+Use rank-specific roots:
+
+```text
+lab/comparisons/<week_id>/rank-1/
+lab/comparisons/<week_id>/rank-2/
+lab/comparisons/<week_id>/rank-3/
+```
+
+## Rank output pages
+
+Canonical routes:
+
+```text
+/lab/comparisons/<week_id>/rank-1/
+/lab/comparisons/<week_id>/rank-2/
+/lab/comparisons/<week_id>/rank-3/
+```
+
+Each rank root should contain only:
+
+```text
+index.html
+style.css
+app.js
+```
+
+Rank pages must not contain:
+
+```text
+external scripts
+external network calls
+cookies
+tracking
+credential handling
+iframes
+dynamic code execution
+```
+
+## Source evidence
+
+Canonical sources:
+
+```text
+data/public-results.json
+data/public-results.md
+runs/*.md
+GitHub Issues
+GitHub PRs
+GitHub commits
+redacted public Actions artifacts when intentionally published
+```
+
+The public pages index these sources. They do not replace them.
+
+## Support relation
+
+Support affects only run capacity.
+
+```text
+votes decide ranking
+safety scan decides eligibility
+support amount decides how many ranks can run
+maintainer review decides what is adopted
+```
+
+Bad design:
+
+```text
+supporter buys a specific outcome
+```
+
+Good design:
+
+```text
+support expands total experiment capacity
+```
+
+## Minimum implementation sequence
+
+```text
+1. keep / as the landing page
+2. keep /lab/ as the current lab state
+3. auto-generate /lab/comparisons/<week_id>/ from public results
+4. run comparison candidates into rank-specific roots
+5. auto-generate /lab/history/ from public results
+6. update / and /lab/ to link history and latest comparison
+```
+
+## Security posture
+
+All generated public pages must remain static.
+
+```text
+connect-src 'none'
+frame-src 'none'
+object-src 'none'
+form-action 'none'
+```
+
+No page should publish raw private diagnostics or sensitive operational data.
+
+## Evaluation question
+
+A participant should be able to answer this within one minute:
+
+```text
+What happened this week, which rank was adopted, and what evidence supports that decision?
+```

--- a/scripts/build_history_page.py
+++ b/scripts/build_history_page.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+SAFE_CSP = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'none'; frame-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none';"
+
+
+@dataclass(frozen=True)
+class WeekSummary:
+    week_id: str
+    total_issues: int
+    clear_count: int
+    blocked_count: int
+    review_count: int
+    runtime_count: int
+    implemented_count: int
+    not_selected_count: int
+    open_count: int
+    adopted_rank: str
+    comparison_href: str
+
+
+def _labels(item: dict[str, Any]) -> set[str]:
+    return {str(label) for label in item.get("labels", [])}
+
+
+def _week_labels(issue: dict[str, Any]) -> set[str]:
+    return {label.split(":", 1)[1] for label in _labels(issue) if label.startswith("week:")}
+
+
+def _rank_from_text(issue: dict[str, Any]) -> int | None:
+    text = f"{issue.get('title', '')}\n{issue.get('body', '')}".lower()
+    for rank in (1, 2, 3):
+        if f"rank {rank}" in text or f"rank-{rank}" in text or f"rank:{rank}" in text:
+            return rank
+    return None
+
+
+def build_week_summaries(public_results: dict[str, Any]) -> list[WeekSummary]:
+    issues = list(public_results.get("issues", []))
+    week_ids = sorted({week for issue in issues for week in _week_labels(issue)}, reverse=True)
+    summaries: list[WeekSummary] = []
+
+    for week_id in week_ids:
+        week_issues = [issue for issue in issues if week_id in _week_labels(issue)]
+        clear_count = 0
+        blocked_count = 0
+        review_count = 0
+        runtime_count = 0
+        implemented_count = 0
+        not_selected_count = 0
+        open_count = 0
+        adopted_rank: str | None = None
+
+        for issue in week_issues:
+            labels = _labels(issue)
+            safety = issue.get("safety") or {}
+            if safety.get("clear") or "issue-safety:clear" in labels:
+                clear_count += 1
+            if safety.get("blocked") or "issue-safety:blocked" in labels:
+                blocked_count += 1
+            if safety.get("review") or "issue-safety:review" in labels:
+                review_count += 1
+            if safety.get("runtime_detected") or "issue-safety:runtime-detected" in labels:
+                runtime_count += 1
+            if "outcome:implemented" in labels:
+                implemented_count += 1
+                rank = _rank_from_text(issue)
+                if rank is not None:
+                    adopted_rank = f"rank {rank}"
+            if "outcome:not-selected" in labels:
+                not_selected_count += 1
+            if str(issue.get("state", "")).upper() == "OPEN":
+                open_count += 1
+
+        summaries.append(
+            WeekSummary(
+                week_id=week_id,
+                total_issues=len(week_issues),
+                clear_count=clear_count,
+                blocked_count=blocked_count,
+                review_count=review_count,
+                runtime_count=runtime_count,
+                implemented_count=implemented_count,
+                not_selected_count=not_selected_count,
+                open_count=open_count,
+                adopted_rank=adopted_rank or "not decided",
+                comparison_href=f"../comparisons/{week_id}/",
+            )
+        )
+    return summaries
+
+
+def render_history(public_results: dict[str, Any]) -> str:
+    summaries = build_week_summaries(public_results)
+    generated_at = html.escape(str(public_results.get("generated_at", "unknown")))
+    cards: list[str] = []
+    for summary in summaries:
+        cards.append(
+            f"""
+      <article class="week-card" aria-labelledby="week-{html.escape(summary.week_id)}">
+        <div class="week-card-head">
+          <p class="week-kicker">Week</p>
+          <h2 id="week-{html.escape(summary.week_id)}">{html.escape(summary.week_id)}</h2>
+        </div>
+        <dl class="facts">
+          <div><dt>Candidates</dt><dd>{summary.total_issues}</dd></div>
+          <div><dt>Clear</dt><dd>{summary.clear_count}</dd></div>
+          <div><dt>Runtime scans</dt><dd>{summary.runtime_count}</dd></div>
+          <div><dt>Blocked</dt><dd>{summary.blocked_count}</dd></div>
+          <div><dt>Review</dt><dd>{summary.review_count}</dd></div>
+          <div><dt>Implemented</dt><dd>{summary.implemented_count}</dd></div>
+          <div><dt>Not selected</dt><dd>{summary.not_selected_count}</dd></div>
+          <div><dt>Open</dt><dd>{summary.open_count}</dd></div>
+          <div><dt>Adopted</dt><dd>{html.escape(summary.adopted_rank)}</dd></div>
+        </dl>
+        <p class="week-link"><a href="{html.escape(summary.comparison_href, quote=True)}">Open weekly comparison</a></p>
+      </article>"""
+        )
+    cards_html = "\n".join(cards) if cards else "<p>No week records found yet.</p>"
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Prompt Vote Lab history</title>
+  <link rel="stylesheet" href="./style.css">
+  <meta http-equiv="Content-Security-Policy" content="{SAFE_CSP}">
+</head>
+<body>
+  <main class="history-root" aria-labelledby="history-title">
+    <p class="status">History · generated from public results</p>
+    <h1 id="history-title">Prompt Vote Lab history</h1>
+    <p class="note">This page summarizes weekly progression. GitHub Issues, PRs, commits, public bundles, and run records remain the source of truth.</p>
+    <section class="method" aria-labelledby="flow-title">
+      <h2 id="flow-title">Candidate state flow</h2>
+      <ol class="flow">
+        <li>Issue posted</li>
+        <li>submission safety scan</li>
+        <li>clear / review / blocked</li>
+        <li>rank selected</li>
+        <li>comparison run</li>
+        <li>PR created</li>
+        <li>merged / not selected / blocked</li>
+        <li>finalizer close</li>
+      </ol>
+      <p>Generated from <code>data/public-results.json</code> at <code>{generated_at}</code>.</p>
+    </section>
+    <section class="week-grid" aria-label="Weekly experiment history">
+{cards_html}
+    </section>
+  </main>
+</body>
+</html>
+"""
+
+
+def render_css() -> str:
+    return """:root {
+  color-scheme: light;
+  --bg: #f7f5ef;
+  --text: #171717;
+  --muted: #62615c;
+  --line: #d9d3c5;
+  --card: #fffdf7;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+}
+.history-root {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 40px 0;
+}
+.status {
+  color: var(--muted);
+  font-size: 0.95rem;
+  margin: 0 0 8px;
+}
+h1 { margin: 0 0 12px; font-size: clamp(2.2rem, 5vw, 4.5rem); line-height: 1; }
+.note, .method { color: var(--muted); max-width: 820px; }
+.method {
+  border: 1px solid var(--line);
+  background: var(--card);
+  padding: 16px;
+  border-radius: 18px;
+  margin: 24px 0;
+}
+.flow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 0;
+  list-style: none;
+}
+.flow li {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 8px 10px;
+  background: #fff;
+}
+.week-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+.week-card {
+  border: 1px solid var(--line);
+  background: var(--card);
+  border-radius: 20px;
+  padding: 18px;
+}
+.week-kicker { color: var(--muted); font-weight: 700; margin: 0 0 4px; }
+.week-card h2 { margin: 0 0 14px; font-size: 1.8rem; }
+.facts { display: grid; gap: 10px; margin: 0; }
+.facts div { border-top: 1px solid var(--line); padding-top: 8px; }
+dt { font-weight: 700; }
+dd { margin: 2px 0 0; color: var(--muted); }
+.week-link { margin: 16px 0 0; font-weight: 700; }
+a { color: inherit; text-underline-offset: 0.18em; }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.9em; }
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--public-results", default="data/public-results.json")
+    parser.add_argument("--out-dir", required=True)
+    args = parser.parse_args()
+
+    public_results = json.loads(Path(args.public_results).read_text(encoding="utf-8"))
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "index.html").write_text(render_history(public_results), encoding="utf-8")
+    (out_dir / "style.css").write_text(render_css(), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_build_history_page.py
+++ b/scripts/test_build_history_page.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build_history_page.py"
+
+
+def test_history_builder() -> None:
+    data = {
+        "generated_at": "2026-05-08T00:00:00+00:00",
+        "issues": [
+            {
+                "number": 195,
+                "title": "[Prompt][Rank 2]: Add an evidence map",
+                "url": "https://example.test/issues/195",
+                "state": "OPEN",
+                "labels": ["week:2026-W20", "prompt-proposal", "normal-candidate", "issue-safety:clear", "issue-safety:submission-detected"],
+                "safety": {"clear": True, "blocked": False, "review": False, "runtime_detected": True},
+                "body": "## Comparison metadata\n\n- Intended comparison rank: 2",
+            },
+            {
+                "number": 196,
+                "title": "[Prompt][Rank 3]: Add a decision card",
+                "url": "https://example.test/issues/196",
+                "state": "OPEN",
+                "labels": ["week:2026-W20", "prompt-proposal", "normal-candidate", "issue-safety:review"],
+                "safety": {"clear": False, "blocked": False, "review": True, "runtime_detected": False},
+                "body": "## Comparison metadata\n\n- Intended comparison rank: 3",
+            },
+            {
+                "number": 191,
+                "title": "[Prompt]: Add a static reviewer orientation panel",
+                "url": "https://example.test/issues/191",
+                "state": "CLOSED",
+                "labels": ["week:2026-W19", "prompt-proposal", "normal-candidate", "issue-safety:clear", "issue-safety:runtime-detected", "outcome:implemented"],
+                "safety": {"clear": True, "blocked": False, "review": False, "runtime_detected": True},
+                "body": "normal candidate",
+            },
+        ],
+    }
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        source = tmp_path / "public-results.json"
+        out_dir = tmp_path / "history"
+        source.write_text(json.dumps(data), encoding="utf-8")
+        subprocess.run(
+            [sys.executable, str(SCRIPT), "--public-results", str(source), "--out-dir", str(out_dir)],
+            check=True,
+            cwd=ROOT,
+        )
+        html = (out_dir / "index.html").read_text(encoding="utf-8")
+        css = (out_dir / "style.css").read_text(encoding="utf-8")
+
+    required = [
+        "Prompt Vote Lab history",
+        "2026-W20",
+        "2026-W19",
+        "Candidate state flow",
+        "submission safety scan",
+        "comparison run",
+        "finalizer close",
+        "Open weekly comparison",
+        "../comparisons/2026-W20/",
+        "Generated from <code>data/public-results.json</code>",
+        "connect-src 'none'",
+    ]
+    missing = [item for item in required if item not in html]
+    if missing:
+        raise AssertionError(f"history page missing expected text: {missing}")
+
+    forbidden = [
+        "OPENAI_API_KEY",
+        "codex login",
+        "container stderr",
+        "raw stderr",
+        "document.cookie",
+        "eval(",
+        "<iframe",
+        "https://example.com/ping",
+    ]
+    found = [item for item in forbidden if item in html]
+    if found:
+        raise AssertionError(f"history page leaked forbidden text: {found}")
+
+    if "week-grid" not in css or "week-card" not in css:
+        raise AssertionError("history CSS should define week grid/cards")
+
+
+def main() -> int:
+    test_history_builder()
+    print("history page builder test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_public_results_export_workflow_contract.py
+++ b/scripts/test_public_results_export_workflow_contract.py
@@ -23,9 +23,13 @@ REQUIRED_WORKFLOW_TEXT = [
     "python scripts/build_public_results_export.py",
     "Build comparison dashboards",
     "scripts/build_comparison_dashboard.py",
+    "Build history page",
+    "scripts/build_history_page.py",
+    "--out-dir lab/history",
     "lab/comparisons",
     "lab/comparisons/**",
-    "git add data/public-results.json data/public-results.md lab/comparisons",
+    "lab/history/**",
+    "git add data/public-results.json data/public-results.md lab/comparisons lab/history",
     "data/public-results.json",
     "data/public-results.md",
     "public-results-export-${{ github.run_number }}",
@@ -84,8 +88,10 @@ def main() -> int:
 
     if workflow_text.index("Build public results export") > workflow_text.index("Build comparison dashboards"):
         raise SystemExit("Comparison dashboards must be built after public results export")
-    if workflow_text.index("Build comparison dashboards") > workflow_text.index("Upload public results artifact"):
-        raise SystemExit("Comparison dashboards must be built before artifact upload")
+    if workflow_text.index("Build comparison dashboards") > workflow_text.index("Build history page"):
+        raise SystemExit("History page must be built after comparison dashboards")
+    if workflow_text.index("Build history page") > workflow_text.index("Upload public results artifact"):
+        raise SystemExit("History page must be built before artifact upload")
     if workflow_text.index("Upload public results artifact") > workflow_text.index("Commit public results snapshot"):
         raise SystemExit("Artifacts should be uploaded before the commit step")
 


### PR DESCRIPTION
## Summary

Adds a generated history page for cross-week Prompt Vote Lab progression.

## Added

```text
docs/public-page-architecture.md
scripts/build_history_page.py
scripts/test_build_history_page.py
```

## Updated

```text
.github/workflows/public-results-export.yml
scripts/test_public_results_export_workflow_contract.py
```

## Page architecture

The documented page responsibilities are:

```text
/                                      Landing page / public entry
/lab/                                  Current lab state
/lab/history/                          Cross-week progression
/lab/comparisons/<week_id>/            Weekly rank comparison
/lab/comparisons/<week_id>/rank-*      Rank-specific generated artifacts
```

## History page

The new generator reads:

```text
data/public-results.json
```

and writes:

```text
lab/history/index.html
lab/history/style.css
```

It summarizes per week:

- candidate Issue count
- clear count
- runtime scan count
- blocked count
- review count
- implemented count
- not-selected count
- open count
- adopted rank when known
- comparison page link

## Public Results Export

Public Results Export now builds:

```text
data/public-results.json
data/public-results.md
lab/comparisons/**
lab/history/**
```

in that order.

## Non-goals

- No model/API run.
- No rank run.
- No auto-merge.
- No raw private diagnostics publication.