### PR TITLE
Add lab evidence navigation

### DIFF
--- a/lab/index.html
+++ b/lab/index.html
@@ -17,6 +17,14 @@
     <p class="note">
       This area is the constrained implementation target. It starts intentionally empty and will be changed only by accepted experiment runs.
     </p>
+
+    <nav class="evidence-nav" aria-label="Public evidence navigation">
+      <a href="./history/">History</a>
+      <a href="./comparisons/2026-W20/">Latest comparison</a>
+      <a href="../data/public-results.json">Public results JSON</a>
+      <a href="https://github.com/Unjuno/prompt-vote-lab/issues?q=is%3Aissue+label%3Aprompt-proposal">Prompt Issues</a>
+    </nav>
+
     <section class="hostile-card" role="note" aria-label="Experiment status and next action for participants.">
       <p class="hostile-card-text">Experiment status</p>
 

--- a/lab/style.css
+++ b/lab/style.css
@@ -56,6 +56,32 @@ noscript {
   margin-top: 16px;
 }
 
+.evidence-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 18px 0 0;
+}
+
+.evidence-nav a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 38px;
+  padding: 0 12px;
+  border: 1px solid rgba(25, 25, 25, 0.14);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.66);
+  color: var(--fg);
+  font-size: 0.86rem;
+  font-weight: 800;
+  line-height: 1.2;
+  text-decoration: none;
+}
+
+.evidence-nav a:hover {
+  border-color: rgba(25, 25, 25, 0.34);
+}
+
 .hostile-card {
   margin: 16px 0 0;
   padding: 14px 16px;
@@ -235,4 +261,17 @@ noscript {
 
 .review-link:hover {
   border-bottom-color: rgba(25, 25, 25, 0.6);
+}
+
+@media (max-width: 520px) {
+  .lab-root {
+    width: min(100% - 20px, 640px);
+    padding: 28px 18px;
+    border-radius: 20px;
+  }
+
+  .evidence-nav a {
+    width: 100%;
+    justify-content: center;
+  }
 }


### PR DESCRIPTION
## Summary

Adds a compact evidence navigation row to `/lab/` so participants can move from the current lab state to the public history, latest comparison, public results JSON, and prompt Issues.

## Changes

Updates:

```text
lab/index.html
lab/style.css
```

Adds links to:

```text
./history/
./comparisons/2026-W20/
../data/public-results.json
GitHub prompt Issues
```

## Why

`/lab/` is the current experiment surface, not the landing page. It still needs evidence links so participants can inspect how the current state was produced.

## Safety boundary

- Static links only.
- No external scripts.
- No network calls from JavaScript.
- No cookies.
- No tracking.
- No generated history/comparison files modified in this PR.

## Responsive check

The evidence links wrap, and on narrow screens they become full-width buttons.