### PR TITLE
Allow comparison runs from Issue comments

### DIFF
--- a/.github/workflows/codex-comparison-issue-run.yml
+++ b/.github/workflows/codex-comparison-issue-run.yml
@@ -25,6 +25,8 @@ on:
         required: true
         default: "0"
         type: number
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: write
@@ -32,35 +34,90 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: codex-comparison-${{ inputs.week_id }}-rank-${{ inputs.candidate_rank }}
+  group: codex-comparison-${{ github.event_name == 'workflow_dispatch' && inputs.week_id || github.event.issue.number }}-${{ github.event_name == 'workflow_dispatch' && inputs.candidate_rank || github.event.comment.id }}
   cancel-in-progress: false
 
 jobs:
   codex-comparison-issue-run:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request == null && startsWith(github.event.comment.body, '/run-comparison '))
     runs-on: ubuntu-latest
     env:
       CODEX_MODEL: gpt-5.4-nano
-      RUN_WEEK: ${{ inputs.week_id }}
-      BASE_SHA: ${{ inputs.base_sha }}
-      ISSUE_NUMBER: ${{ inputs.issue_number }}
-      CANDIDATE_RANK: ${{ inputs.candidate_rank }}
-      VOTE_COUNT: ${{ inputs.vote_count }}
-      OUTPUT_ROOT: lab/comparisons/${{ inputs.week_id }}/rank-${{ inputs.candidate_rank }}
     steps:
-      - name: Checkout fixed comparison base
+      - name: Checkout workflow source
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.base_sha }}
           fetch-depth: 0
 
-      - name: Validate comparison inputs
+      - name: Resolve comparison inputs
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_WEEK_ID: ${{ inputs.week_id }}
+          DISPATCH_BASE_SHA: ${{ inputs.base_sha }}
+          DISPATCH_ISSUE_NUMBER: ${{ inputs.issue_number }}
+          DISPATCH_CANDIDATE_RANK: ${{ inputs.candidate_rank }}
+          DISPATCH_VOTE_COUNT: ${{ inputs.vote_count }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           set -euo pipefail
-          case "$CANDIDATE_RANK" in 1|2|3) ;; *) echo "candidate_rank must be 1, 2, or 3"; exit 1 ;; esac
-          case "$VOTE_COUNT" in ''|*[!0-9]*) echo "vote_count must be a non-negative integer"; exit 1 ;; *) ;; esac
-          case "$RUN_WEEK" in *[!A-Za-z0-9._-]*|'') echo "week_id contains unsupported characters"; exit 1 ;; *) ;; esac
-          test -n "$BASE_SHA"
-          case "$OUTPUT_ROOT" in lab/comparisons/*/rank-1|lab/comparisons/*/rank-2|lab/comparisons/*/rank-3) ;; *) echo "invalid output root"; exit 1 ;; esac
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            run_week="$DISPATCH_WEEK_ID"
+            base_sha="$DISPATCH_BASE_SHA"
+            issue_number="$DISPATCH_ISSUE_NUMBER"
+            candidate_rank="$DISPATCH_CANDIDATE_RANK"
+            vote_count="$DISPATCH_VOTE_COUNT"
+          else
+            python - <<'PY' > .tmp-comparison-inputs.env
+          import os
+          import re
+          body = os.environ.get('COMMENT_BODY', '').strip()
+          issue_number = os.environ.get('COMMENT_ISSUE_NUMBER', '').strip()
+          if not body.startswith('/run-comparison '):
+              raise SystemExit('comment is not a comparison run command')
+          pairs = dict(re.findall(r'(week|base|rank|votes)=([^\s]+)', body))
+          required = ['week', 'base', 'rank', 'votes']
+          missing = [key for key in required if key not in pairs]
+          if missing:
+              raise SystemExit(f'missing comparison command keys: {missing}')
+          print(f"RUN_WEEK={pairs['week']}")
+          print(f"BASE_SHA={pairs['base']}")
+          print(f"ISSUE_NUMBER={issue_number}")
+          print(f"CANDIDATE_RANK={pairs['rank']}")
+          print(f"VOTE_COUNT={pairs['votes']}")
+          PY
+            . ./.tmp-comparison-inputs.env
+            run_week="$RUN_WEEK"
+            base_sha="$BASE_SHA"
+            issue_number="$ISSUE_NUMBER"
+            candidate_rank="$CANDIDATE_RANK"
+            vote_count="$VOTE_COUNT"
+          fi
+
+          case "$candidate_rank" in 1|2|3) ;; *) echo "candidate_rank must be 1, 2, or 3"; exit 1 ;; esac
+          case "$vote_count" in ''|*[!0-9]*) echo "vote_count must be a non-negative integer"; exit 1 ;; *) ;; esac
+          case "$run_week" in *[!A-Za-z0-9._-]*|'') echo "week_id contains unsupported characters"; exit 1 ;; *) ;; esac
+          test -n "$base_sha"
+
+          output_root="lab/comparisons/${run_week}/rank-${candidate_rank}"
+          case "$output_root" in lab/comparisons/*/rank-1|lab/comparisons/*/rank-2|lab/comparisons/*/rank-3) ;; *) echo "invalid output root"; exit 1 ;; esac
+
+          {
+            echo "RUN_WEEK=$run_week"
+            echo "BASE_SHA=$base_sha"
+            echo "ISSUE_NUMBER=$issue_number"
+            echo "CANDIDATE_RANK=$candidate_rank"
+            echo "VOTE_COUNT=$vote_count"
+            echo "OUTPUT_ROOT=$output_root"
+          } >> "$GITHUB_ENV"
+
+      - name: Checkout fixed comparison base
+        run: |
+          set -euo pipefail
+          git fetch origin "$BASE_SHA"
+          git checkout "$BASE_SHA"
 
       - name: Fetch Issue and run safety gate
         env:

--- a/scripts/test_comparison_issue_run_workflow_contract.py
+++ b/scripts/test_comparison_issue_run_workflow_contract.py
@@ -9,15 +9,30 @@ WORKFLOW = ROOT / ".github" / "workflows" / "codex-comparison-issue-run.yml"
 REQUIRED_TEXT = [
     "name: Codex Comparison Issue Run",
     "workflow_dispatch:",
+    "issue_comment:",
+    "types: [created]",
     "week_id:",
     "base_sha:",
     "issue_number:",
     "candidate_rank:",
     "vote_count:",
-    "ref: ${{ inputs.base_sha }}",
+    "startsWith(github.event.comment.body, '/run-comparison ')",
+    "Checkout workflow source",
+    "Resolve comparison inputs",
+    "COMMENT_BODY: ${{ github.event.comment.body }}",
+    "COMMENT_ISSUE_NUMBER: ${{ github.event.issue.number }}",
+    "week|base|rank|votes",
+    "missing comparison command keys",
+    "RUN_WEEK=",
+    "BASE_SHA=",
+    "ISSUE_NUMBER=",
+    "CANDIDATE_RANK=",
+    "VOTE_COUNT=",
+    "OUTPUT_ROOT=",
+    "Checkout fixed comparison base",
+    "git fetch origin \"$BASE_SHA\"",
+    "git checkout \"$BASE_SHA\"",
     "CODEX_MODEL: gpt-5.4-nano",
-    "OUTPUT_ROOT: lab/comparisons/${{ inputs.week_id }}/rank-${{ inputs.candidate_rank }}",
-    "codex-comparison-${{ inputs.week_id }}-rank-${{ inputs.candidate_rank }}",
     "candidate_rank must be 1, 2, or 3",
     "week_id contains unsupported characters",
     "Fetch Issue and run safety gate",
@@ -69,8 +84,10 @@ def main() -> int:
     require_all(text, REQUIRED_TEXT)
     reject_all(text, FORBIDDEN_TEXT)
 
-    if text.index("Validate comparison inputs") > text.index("Fetch Issue and run safety gate"):
-        raise SystemExit("Inputs must be validated before fetching the Issue")
+    if text.index("Resolve comparison inputs") > text.index("Checkout fixed comparison base"):
+        raise SystemExit("Inputs must be resolved before fixed-base checkout")
+    if text.index("Checkout fixed comparison base") > text.index("Fetch Issue and run safety gate"):
+        raise SystemExit("Fixed base must be checked out before fetching the Issue")
     if text.index("Fetch Issue and run safety gate") > text.index("Run existing fixed-Issue runner"):
         raise SystemExit("Issue safety gate must run before the model runner")
     if text.index("Run existing fixed-Issue runner") > text.index("Move root lab result into comparison output root"):


### PR DESCRIPTION
## Summary

Adds an `issue_comment` trigger to `Codex Comparison Issue Run` so comparison runs can be started by commenting on a candidate Issue.

## Why

This environment cannot invoke `workflow_dispatch` directly, but it can create Issue comments. The comment trigger lets maintainers and connected tools start comparison runs without pressing the GitHub UI button.

## Command

Comment on a candidate Issue:

```text
/run-comparison week=2026-W20 base=<base_sha> rank=2 votes=0
```

The Issue number is taken from the commented Issue.

## Preserved behavior

`workflow_dispatch` remains supported.

## Safety boundary

The job only runs for comments that:

```text
start with /run-comparison
are on Issues, not PRs
```

The existing runtime Issue safety scan and execution gate still run before the model runner.

## Output root

Comparison output is still constrained to:

```text
lab/comparisons/<week>/rank-<rank>/index.html
lab/comparisons/<week>/rank-<rank>/style.css
lab/comparisons/<week>/rank-<rank>/app.js
```

Root `lab/` is restored before PR creation.

## Tests

Updates `scripts/test_comparison_issue_run_workflow_contract.py` to require the comment trigger and command parser contract.