### PR TITLE
Fix comparison safety check base

### DIFF
--- a/.github/workflows/codex-comparison-issue-run.yml
+++ b/.github/workflows/codex-comparison-issue-run.yml
@@ -203,7 +203,7 @@ jobs:
           echo "$changed_files" | while read -r file; do
             case "$file" in "$OUTPUT_ROOT/index.html"|"$OUTPUT_ROOT/style.css"|"$OUTPUT_ROOT/app.js") ;; *) echo "Forbidden changed file: $file"; exit 1 ;; esac
           done
-          bash scripts/safety-check.sh origin/main HEAD
+          bash scripts/safety-check.sh "$BASE_SHA" HEAD
           bash scripts/static-site-check.sh
 
       - name: Upload comparison diagnostics

--- a/scripts/test_comparison_issue_run_workflow_contract.py
+++ b/scripts/test_comparison_issue_run_workflow_contract.py
@@ -66,7 +66,7 @@ REQUIRED_TEXT = [
     "git checkout -- lab/index.html lab/style.css lab/app.js",
     "Validate comparison output scope",
     "\"$OUTPUT_ROOT/index.html\"|\"$OUTPUT_ROOT/style.css\"|\"$OUTPUT_ROOT/app.js\"",
-    "bash scripts/safety-check.sh origin/main HEAD",
+    "bash scripts/safety-check.sh \"$BASE_SHA\" HEAD",
     "bash scripts/static-site-check.sh",
     "Upload comparison diagnostics",
     "Commit comparison output and create PR",
@@ -81,6 +81,7 @@ FORBIDDEN_TEXT = [
     "gh pr merge",
     "enable_auto_merge",
     "schedule:",
+    "bash scripts/safety-check.sh origin/main HEAD",
 ]
 
 


### PR DESCRIPTION
## Summary

Fixes the comparison workflow safety check to compare against the fixed comparison base instead of `origin/main`.

## Problem

Request-file triggered runs add a JSON file under:

```text
run-requests/comparison/*.json
```

If the comparison job validates against `origin/main`, that request file can appear as a non-lab change and make the safety check fail for the wrong reason.

## Change

```text
bash scripts/safety-check.sh origin/main HEAD
```

becomes:

```text
bash scripts/safety-check.sh "$BASE_SHA" HEAD
```

## Why this is correct

The comparison experiment must measure only the generated rank artifact against the fixed comparison base. The request file is a trigger, not part of the generated artifact.

## Tests

Updates the comparison workflow contract test to require the fixed-base safety check and reject the old `origin/main` comparison.