### PR TITLE
Allow comparison runs from request PRs

### DIFF
--- a/.github/workflows/codex-comparison-issue-run.yml
+++ b/.github/workflows/codex-comparison-issue-run.yml
@@ -32,6 +32,11 @@ on:
       - main
     paths:
       - "run-requests/comparison/*.json"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "run-requests/comparison/*.json"
 
 permissions:
   contents: write
@@ -47,6 +52,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request == null && startsWith(github.event.comment.body, '/run-comparison '))
     runs-on: ubuntu-latest
     env:
@@ -69,6 +75,8 @@ jobs:
           COMMENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
           PUSH_BEFORE: ${{ github.event.before }}
           PUSH_SHA: ${{ github.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
@@ -112,6 +120,37 @@ jobs:
           after = os.environ.get('PUSH_SHA', '')
           files = subprocess.check_output([
               'git', 'diff', '--name-only', before, after, '--', 'run-requests/comparison/*.json'
+          ], text=True).splitlines()
+          files = [name for name in files if name.startswith('run-requests/comparison/') and name.endswith('.json')]
+          if len(files) != 1:
+              raise SystemExit(f'exactly one comparison request JSON is required, got {files}')
+          data = json.loads(Path(files[0]).read_text(encoding='utf-8'))
+          required = ['week_id', 'base_sha', 'issue_number', 'candidate_rank', 'vote_count']
+          missing = [key for key in required if key not in data]
+          if missing:
+              raise SystemExit(f'missing comparison request keys: {missing}')
+          print(f"RUN_WEEK={data['week_id']}")
+          print(f"BASE_SHA={data['base_sha']}")
+          print(f"ISSUE_NUMBER={data['issue_number']}")
+          print(f"CANDIDATE_RANK={data['candidate_rank']}")
+          print(f"VOTE_COUNT={data['vote_count']}")
+          PY
+            . ./.tmp-comparison-inputs.env
+            run_week="$RUN_WEEK"
+            base_sha="$BASE_SHA"
+            issue_number="$ISSUE_NUMBER"
+            candidate_rank="$CANDIDATE_RANK"
+            vote_count="$VOTE_COUNT"
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
+            python - <<'PY' > .tmp-comparison-inputs.env
+          import json
+          import os
+          import subprocess
+          from pathlib import Path
+          base = os.environ.get('PR_BASE_SHA', '')
+          head = os.environ.get('PR_HEAD_SHA', '')
+          files = subprocess.check_output([
+              'git', 'diff', '--name-only', base, head, '--', 'run-requests/comparison/*.json'
           ], text=True).splitlines()
           files = [name for name in files if name.startswith('run-requests/comparison/') and name.endswith('.json')]
           if len(files) != 1:

--- a/scripts/test_comparison_issue_run_workflow_contract.py
+++ b/scripts/test_comparison_issue_run_workflow_contract.py
@@ -12,6 +12,7 @@ REQUIRED_TEXT = [
     "issue_comment:",
     "types: [created]",
     "push:",
+    "pull_request:",
     "branches:",
     "- main",
     "paths:",
@@ -23,15 +24,20 @@ REQUIRED_TEXT = [
     "vote_count:",
     "startsWith(github.event.comment.body, '/run-comparison ')",
     "github.event_name == 'push'",
+    "github.event_name == 'pull_request'",
+    "github.event.pull_request.head.repo.full_name == github.repository",
     "Checkout workflow source",
     "Resolve comparison inputs",
     "COMMENT_BODY: ${{ github.event.comment.body }}",
     "COMMENT_ISSUE_NUMBER: ${{ github.event.issue.number }}",
     "PUSH_BEFORE: ${{ github.event.before }}",
     "PUSH_SHA: ${{ github.sha }}",
+    "PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}",
+    "PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}",
     "week|base|rank|votes",
     "missing comparison command keys",
     "git', 'diff', '--name-only', before, after, '--', 'run-requests/comparison/*.json'",
+    "git', 'diff', '--name-only', base, head, '--', 'run-requests/comparison/*.json'",
     "exactly one comparison request JSON is required",
     "missing comparison request keys",
     "week_id",
@@ -106,6 +112,8 @@ def main() -> int:
         raise SystemExit("workflow_dispatch should appear before issue_comment")
     if text.index("issue_comment:") > text.index("push:"):
         raise SystemExit("issue_comment should appear before request-file push trigger")
+    if text.index("push:") > text.index("pull_request:"):
+        raise SystemExit("push trigger should appear before request-file pull_request trigger")
     if text.index("Resolve comparison inputs") > text.index("Checkout fixed comparison base"):
         raise SystemExit("Inputs must be resolved before fixed-base checkout")
     if text.index("Checkout fixed comparison base") > text.index("Fetch Issue and run safety gate"):


### PR DESCRIPTION
## Summary

Adds a `pull_request` trigger to `Codex Comparison Issue Run` for PRs that add a comparison request file.

## Why

In this connected environment, `issue_comment` and direct `push` request-file events are not reliably starting the comparison workflow. Pull-request-triggered workflows are known to run here, so request files should be executable before merge.

## Trigger

A PR changing exactly one file under:

```text
run-requests/comparison/*.json
```

can trigger the comparison run.

## Safety boundary

The workflow only allows request PR execution when:

```text
github.event.pull_request.head.repo.full_name == github.repository
```

So this does not run write-capable comparison jobs for forked PRs.

## Request JSON

```json
{
  "week_id": "2026-W20",
  "base_sha": "<fixed_base_sha>",
  "issue_number": 195,
  "candidate_rank": 2,
  "vote_count": 0
}
```

The existing runtime Issue safety scan, execution gate, fixed-base checkout, rank-specific output root, and manual-review PR policy remain unchanged.

## Tests

Updates `scripts/test_comparison_issue_run_workflow_contract.py` to require the request PR trigger and parser contract.