### PR TITLE
Normalize rank 2 comparison metadata

### DIFF
--- a/lab/comparisons/2026-W20/rank-2/index.html
+++ b/lab/comparisons/2026-W20/rank-2/index.html
@@ -31,7 +31,7 @@
       <div class="hostile-card-meta" role="status" aria-live="polite">
         <p class="meta-row">
           <span class="meta-label">current experiment state:</span>
-          <span class="meta-value">first-canary-009 • Candidate #1 • Issue #195</span>
+          <span class="meta-value">first-canary-009 • Candidate #2 • Issue #195</span>
         </p>
         <p class="meta-row">
           <span class="meta-label">next action for participants:</span>


### PR DESCRIPTION
## Summary

Fixes stale rank metadata in the existing rank-2 comparison artifact.

## Why

#219 generated a correct metadata-normalized rank-2 artifact, but it cannot be merged directly because `lab/comparisons/2026-W20/rank-2/` already exists on `main` from #214.

This PR applies the necessary minimal fix directly on top of current `main`.

## Change

```text
lab/comparisons/2026-W20/rank-2/index.html
Candidate #1 -> Candidate #2
```

## Scope

Only one existing rank-2 HTML file is changed.

## Non-goals

- No model run.
- No rank-3 changes.
- No root `/lab/` changes.