### PR TITLE
Allow generated lab evidence paths in scope guard

### DIFF
--- a/scripts/check-lab-pr-scope.sh
+++ b/scripts/check-lab-pr-scope.sh
@@ -19,17 +19,20 @@ fi
 echo "Changed files:"
 printf '  - %s\n' "${changed_files[@]}"
 
-lab_changed=false
+root_lab_changed=false
+generated_evidence_changed=false
 non_lab_changes=()
 invalid_lab_changes=()
 
 for file in "${changed_files[@]}"; do
   case "$file" in
     lab/index.html|lab/style.css|lab/app.js)
-      lab_changed=true
+      root_lab_changed=true
+      ;;
+    lab/comparisons/*|lab/history/*)
+      generated_evidence_changed=true
       ;;
     lab/*)
-      lab_changed=true
       invalid_lab_changes+=("$file")
       ;;
     *)
@@ -38,28 +41,38 @@ for file in "${changed_files[@]}"; do
   esac
 done
 
-if [ "$lab_changed" != "true" ]; then
+if [ "$root_lab_changed" != "true" ] && [ "$generated_evidence_changed" != "true" ]; then
   echo "No lab files changed. Lab PR scope guard passes."
   exit 0
 fi
 
 if [ "${#invalid_lab_changes[@]}" -gt 0 ]; then
-  echo "ERROR: lab implementation PRs may only change these files:"
+  echo "ERROR: invalid lab path changes detected."
+  echo "Allowed root lab implementation files:"
   echo "  - lab/index.html"
   echo "  - lab/style.css"
   echo "  - lab/app.js"
+  echo "Allowed generated evidence paths:"
+  echo "  - lab/comparisons/**"
+  echo "  - lab/history/**"
   echo "Invalid lab path changes:"
   printf '  - %s\n' "${invalid_lab_changes[@]}"
   exit 1
 fi
 
-if [ "${#non_lab_changes[@]}" -gt 0 ]; then
-  echo "ERROR: PR changes lab files and non-lab files together."
-  echo "Codex/agent implementation PRs must keep evidence, workflow, docs, and policy files untouched."
+if [ "$root_lab_changed" = "true" ] && [ "${#non_lab_changes[@]}" -gt 0 ]; then
+  echo "ERROR: PR changes root lab implementation files and non-lab files together."
+  echo "Codex/agent root lab implementation PRs must keep evidence, workflow, docs, and policy files untouched."
   echo "Move non-lab changes to a separate human-reviewed PR."
   echo "Non-lab changes detected:"
   printf '  - %s\n' "${non_lab_changes[@]}"
   exit 1
 fi
 
-echo "Lab PR scope guard passes: only approved lab files changed."
+if [ "$root_lab_changed" = "true" ] && [ "$generated_evidence_changed" = "true" ]; then
+  echo "ERROR: PR changes root lab implementation files and generated evidence paths together."
+  echo "Keep accepted root lab changes separate from comparison/history evidence updates."
+  exit 1
+fi
+
+echo "Lab PR scope guard passes."

--- a/scripts/check-lab-pr-scope.sh
+++ b/scripts/check-lab-pr-scope.sh
@@ -41,11 +41,6 @@ for file in "${changed_files[@]}"; do
   esac
 done
 
-if [ "$root_lab_changed" != "true" ] && [ "$generated_evidence_changed" != "true" ]; then
-  echo "No lab files changed. Lab PR scope guard passes."
-  exit 0
-fi
-
 if [ "${#invalid_lab_changes[@]}" -gt 0 ]; then
   echo "ERROR: invalid lab path changes detected."
   echo "Allowed root lab implementation files:"
@@ -58,6 +53,11 @@ if [ "${#invalid_lab_changes[@]}" -gt 0 ]; then
   echo "Invalid lab path changes:"
   printf '  - %s\n' "${invalid_lab_changes[@]}"
   exit 1
+fi
+
+if [ "$root_lab_changed" != "true" ] && [ "$generated_evidence_changed" != "true" ]; then
+  echo "No lab files changed. Lab PR scope guard passes."
+  exit 0
 fi
 
 if [ "$root_lab_changed" = "true" ] && [ "${#non_lab_changes[@]}" -gt 0 ]; then

--- a/scripts/test-lab-pr-scope.sh
+++ b/scripts/test-lab-pr-scope.sh
@@ -62,11 +62,11 @@ run_case() {
   echo "CASE OK: $name"
 }
 
-mutate_lab_only() {
+mutate_root_lab_only() {
   local repo_dir="$1"
-  printf '\n<!-- scope test lab only -->\n' >> "$repo_dir/lab/index.html"
+  printf '\n<!-- scope test root lab only -->\n' >> "$repo_dir/lab/index.html"
   git -C "$repo_dir" add lab/index.html
-  git -C "$repo_dir" commit -q -m "change lab only"
+  git -C "$repo_dir" commit -q -m "change root lab only"
 }
 
 mutate_docs_only() {
@@ -76,12 +76,37 @@ mutate_docs_only() {
   git -C "$repo_dir" commit -q -m "change docs only"
 }
 
-mutate_lab_and_docs() {
+mutate_generated_comparison_only() {
+  local repo_dir="$1"
+  mkdir -p "$repo_dir/lab/comparisons/2099-W01/rank-2"
+  printf '<!doctype html>\n<title>scope test</title>\n' > "$repo_dir/lab/comparisons/2099-W01/rank-2/index.html"
+  git -C "$repo_dir" add lab/comparisons/2099-W01/rank-2/index.html
+  git -C "$repo_dir" commit -q -m "change generated comparison only"
+}
+
+mutate_generated_history_only() {
+  local repo_dir="$1"
+  mkdir -p "$repo_dir/lab/history"
+  printf '<!doctype html>\n<title>history scope test</title>\n' > "$repo_dir/lab/history/index.html"
+  git -C "$repo_dir" add lab/history/index.html
+  git -C "$repo_dir" commit -q -m "change generated history only"
+}
+
+mutate_root_lab_and_docs() {
   local repo_dir="$1"
   printf '\n<!-- scope test mixed -->\n' >> "$repo_dir/lab/index.html"
   printf '\nScope test mixed docs.\n' >> "$repo_dir/docs/README.md"
   git -C "$repo_dir" add lab/index.html docs/README.md
-  git -C "$repo_dir" commit -q -m "change lab and docs"
+  git -C "$repo_dir" commit -q -m "change root lab and docs"
+}
+
+mutate_root_lab_and_generated_evidence() {
+  local repo_dir="$1"
+  mkdir -p "$repo_dir/lab/comparisons/2099-W01/rank-1"
+  printf '\n<!-- scope test root lab plus evidence -->\n' >> "$repo_dir/lab/index.html"
+  printf '<!doctype html>\n<title>mixed evidence</title>\n' > "$repo_dir/lab/comparisons/2099-W01/rank-1/index.html"
+  git -C "$repo_dir" add lab/index.html lab/comparisons/2099-W01/rank-1/index.html
+  git -C "$repo_dir" commit -q -m "change root lab and generated evidence"
 }
 
 mutate_extra_lab_file() {
@@ -91,9 +116,12 @@ mutate_extra_lab_file() {
   git -C "$repo_dir" commit -q -m "add extra lab file"
 }
 
-run_case "lab-only" "pass" mutate_lab_only
+run_case "root-lab-only" "pass" mutate_root_lab_only
 run_case "docs-only" "pass" mutate_docs_only
-run_case "lab-and-docs" "fail" mutate_lab_and_docs
+run_case "generated-comparison-only" "pass" mutate_generated_comparison_only
+run_case "generated-history-only" "pass" mutate_generated_history_only
+run_case "root-lab-and-docs" "fail" mutate_root_lab_and_docs
+run_case "root-lab-and-generated-evidence" "fail" mutate_root_lab_and_generated_evidence
 run_case "extra-lab-file" "fail" mutate_extra_lab_file
 
 echo "Lab PR scope guard self-test passed."


### PR DESCRIPTION
## Summary

Updates the lab PR scope guard so generated public evidence pages are allowed under `lab/comparisons/**` and `lab/history/**`.

## Problem

The current scope guard only allows root lab implementation files:

```text
lab/index.html
lab/style.css
lab/app.js
```

That was correct before generated public evidence pages existed, but now the project intentionally generates and updates:

```text
lab/comparisons/**
lab/history/**
```

As a result, valid evidence-page fixes such as #220 fail `Lab PR Scope Check`.

## Change

Allows generated evidence paths:

```text
lab/comparisons/**
lab/history/**
```

while preserving these restrictions:

- unknown `lab/*` paths still fail
- root lab implementation changes cannot be mixed with docs/workflows/policy changes
- root lab implementation changes cannot be mixed with generated evidence updates

## Tests

Updates `scripts/test-lab-pr-scope.sh` to cover:

- root lab only: pass
- docs only: pass
- generated comparison only: pass
- generated history only: pass
- root lab + docs: fail
- root lab + generated evidence: fail
- unknown lab file: fail

## Non-goals

- No generated evidence output is changed in this PR.
- No root `/lab/` implementation output is changed.