### PR TITLE
Normalize rank 2 comparison metadata v2

### DIFF
--- a/lab/comparisons/2026-W20/rank-2/index.html
+++ b/lab/comparisons/2026-W20/rank-2/index.html
@@ -31,7 +31,7 @@
       <div class="hostile-card-meta" role="status" aria-live="polite">
         <p class="meta-row">
           <span class="meta-label">current experiment state:</span>
-          <span class="meta-value">first-canary-009 • Candidate #1 • Issue #195</span>
+          <span class="meta-value">first-canary-009 • Candidate #2 • Issue #195</span>
         </p>
         <p class="meta-row">
           <span class="meta-label">next action for participants:</span>


### PR DESCRIPTION
## Summary

Fixes stale candidate metadata in the existing rank-2 comparison artifact.

## Why

The current rank-2 artifact already has the correct Issue number:

```text
Issue #195
```

but still contains stale copied candidate metadata:

```text
Candidate #1
```

Rank 2 should display:

```text
Candidate #2
```

## Change

```text
lab/comparisons/2026-W20/rank-2/index.html
Candidate #1 -> Candidate #2
```

## Scope

Only one generated comparison evidence file is changed.

## Non-goals

- No model run.
- No rank-3 changes.
- No root `/lab/` changes.
- No workflow changes.