### PR TITLE
Prefer merged latest PRs in comparison dashboard

### DIFF
--- a/scripts/build_comparison_dashboard.py
+++ b/scripts/build_comparison_dashboard.py
@@ -80,6 +80,40 @@ def _pr_issue_number(item: dict[str, Any]) -> int | None:
     return None
 
 
+def _pr_number(item: dict[str, Any]) -> int:
+    try:
+        return int(item.get("number") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _pr_state_score(item: dict[str, Any]) -> int:
+    state = str(item.get("state", "")).upper()
+    if state == "MERGED":
+        return 3
+    if state == "OPEN":
+        return 2
+    if state == "CLOSED":
+        return 1
+    return 0
+
+
+def _pr_selection_key(item: dict[str, Any]) -> tuple[int, int]:
+    return (_pr_state_score(item), _pr_number(item))
+
+
+def _best_pr_by_issue(prs: list[dict[str, Any]]) -> dict[int, dict[str, Any]]:
+    prs_by_issue: dict[int, dict[str, Any]] = {}
+    for pr in prs:
+        issue_number = _pr_issue_number(pr)
+        if issue_number is None:
+            continue
+        current = prs_by_issue.get(issue_number)
+        if current is None or _pr_selection_key(pr) > _pr_selection_key(current):
+            prs_by_issue[issue_number] = pr
+    return prs_by_issue
+
+
 def _vote_count(issue: dict[str, Any], pr: dict[str, Any] | None) -> int:
     if pr:
         body = str(pr.get("body", ""))
@@ -107,11 +141,7 @@ def _changed_files(pr: dict[str, Any] | None) -> tuple[str, ...]:
 def build_rows(public_results: dict[str, Any], week_id: str) -> list[ComparisonRow]:
     issues = [item for item in public_results.get("issues", []) if f"week:{week_id}" in _labels(item)]
     prs = list(public_results.get("pull_requests", []))
-    prs_by_issue: dict[int, dict[str, Any]] = {}
-    for pr in prs:
-        issue_number = _pr_issue_number(pr)
-        if issue_number is not None:
-            prs_by_issue[issue_number] = pr
+    prs_by_issue = _best_pr_by_issue(prs)
 
     rows: list[ComparisonRow] = []
     for issue in issues:

--- a/scripts/test_build_comparison_dashboard.py
+++ b/scripts/test_build_comparison_dashboard.py
@@ -38,13 +38,21 @@ def test_dashboard_builder() -> None:
         ],
         "pull_requests": [
             {
+                "number": 199,
+                "title": "Closed stale comparison output",
+                "url": "https://example.test/pulls/199",
+                "state": "CLOSED",
+                "body": "- Issue: #195\n- Rank: 2\n- Votes: 4",
+                "files": [{"path": "lab/comparisons/2026-W20/rank-2/stale.html"}],
+            },
+            {
                 "number": 201,
-                "title": "Run Codex fixed Issue instruction canary",
+                "title": "Merged comparison output",
                 "url": "https://example.test/pulls/201",
-                "state": "OPEN",
+                "state": "MERGED",
                 "body": "- Issue: #195\n- Rank: 2\n- Votes: 4",
                 "files": [{"path": "lab/comparisons/2026-W20/rank-2/index.html"}],
-            }
+            },
         ],
     }
     with tempfile.TemporaryDirectory() as tmp:
@@ -67,6 +75,7 @@ def test_dashboard_builder() -> None:
         "Issue #195",
         "Issue #196",
         "PR #201",
+        "MERGED",
         "lab/comparisons/2026-W20/rank-2/",
         "runs/2026-W20-rank-2-issue-195.md",
         "participant evidence comprehension",
@@ -78,6 +87,8 @@ def test_dashboard_builder() -> None:
         raise AssertionError(f"dashboard missing expected text: {missing}")
 
     forbidden = [
+        "PR #199",
+        "stale.html",
         "OPENAI_API_KEY",
         "codex login",
         "container stderr",


### PR DESCRIPTION
## Summary

Fixes comparison dashboard PR selection when the same Issue has multiple generated or corrective PRs.

## Problem

The dashboard currently builds `prs_by_issue` with a simple assignment:

```python
prs_by_issue[issue_number] = pr
```

That makes the selected PR depend on public-results ordering. In rerun flows, an Issue can have stale closed PRs and later merged PRs, for example:

```text
Issue #195: #211 CLOSED, #214 MERGED, #222 MERGED metadata fix
Issue #196: #216 CLOSED, #224 MERGED
```

The dashboard can therefore show closed stale PRs even after corrected artifacts are merged.

## Change

Adds PR selection logic:

```text
MERGED > OPEN > CLOSED > unknown
then higher PR number wins
```

## Tests

Updates `scripts/test_build_comparison_dashboard.py` with a regression case where Issue #195 has:

```text
PR #199 CLOSED
PR #201 MERGED
```

and verifies the dashboard selects #201 and does not show #199 or stale changed files.

## Non-goals

- Does not regenerate public results in this PR.
- Does not modify generated comparison HTML in this PR.
- Does not change rank artifacts.