### PR TITLE
Dedupe comparison dashboard rows by rank

### DIFF
--- a/scripts/build_comparison_dashboard.py
+++ b/scripts/build_comparison_dashboard.py
@@ -87,19 +87,23 @@ def _pr_number(item: dict[str, Any]) -> int:
         return 0
 
 
-def _pr_state_score(item: dict[str, Any]) -> int:
-    state = str(item.get("state", "")).upper()
-    if state == "MERGED":
+def _state_score(state: str) -> int:
+    normalized = state.upper()
+    if normalized == "MERGED":
         return 3
-    if state == "OPEN":
+    if normalized == "OPEN":
         return 2
-    if state == "CLOSED":
+    if normalized == "CLOSED":
         return 1
     return 0
 
 
 def _pr_selection_key(item: dict[str, Any]) -> tuple[int, int]:
-    return (_pr_state_score(item), _pr_number(item))
+    return (_state_score(str(item.get("state", ""))), _pr_number(item))
+
+
+def _row_selection_key(row: ComparisonRow) -> tuple[int, int, int]:
+    return (_state_score(row.pr_state), row.pr_number or 0, row.issue_number)
 
 
 def _best_pr_by_issue(prs: list[dict[str, Any]]) -> dict[int, dict[str, Any]]:
@@ -136,6 +140,15 @@ def _changed_files(pr: dict[str, Any] | None) -> tuple[str, ...]:
         return ()
     files = pr.get("files") or []
     return tuple(str(item.get("path", "")) for item in files if item.get("path"))
+
+
+def _dedupe_rows_by_rank(rows: list[ComparisonRow]) -> list[ComparisonRow]:
+    best_by_rank: dict[int, ComparisonRow] = {}
+    for row in rows:
+        current = best_by_rank.get(row.rank)
+        if current is None or _row_selection_key(row) > _row_selection_key(current):
+            best_by_rank[row.rank] = row
+    return sorted(best_by_rank.values(), key=lambda row: row.rank)
 
 
 def build_rows(public_results: dict[str, Any], week_id: str) -> list[ComparisonRow]:
@@ -180,7 +193,7 @@ def build_rows(public_results: dict[str, Any], week_id: str) -> list[ComparisonR
                 decision=decision,
             )
         )
-    return sorted(rows, key=lambda row: row.rank)
+    return _dedupe_rows_by_rank(rows)
 
 
 def _link(url: str, label: str) -> str:

--- a/scripts/test_build_comparison_dashboard.py
+++ b/scripts/test_build_comparison_dashboard.py
@@ -16,6 +16,26 @@ def test_dashboard_builder() -> None:
         "generated_at": "2026-05-08T00:00:00+00:00",
         "issues": [
             {
+                "number": 183,
+                "title": "Old Rank 1 candidate",
+                "url": "https://example.test/issues/183",
+                "state": "CLOSED",
+                "labels": ["week:2026-W20", "prompt-proposal", "normal-candidate", "issue-safety:clear"],
+                "reaction_plus_one_count": 0,
+                "safety": {"clear": True, "blocked": False, "review": False, "runtime_detected": True},
+                "body": "## Comparison metadata\n\n- Intended comparison rank: 1",
+            },
+            {
+                "number": 191,
+                "title": "Preferred Rank 1 candidate",
+                "url": "https://example.test/issues/191",
+                "state": "CLOSED",
+                "labels": ["week:2026-W20", "prompt-proposal", "normal-candidate", "issue-safety:clear"],
+                "reaction_plus_one_count": 0,
+                "safety": {"clear": True, "blocked": False, "review": False, "runtime_detected": True},
+                "body": "## Comparison metadata\n\n- Intended comparison rank: 1",
+            },
+            {
                 "number": 195,
                 "title": "[Prompt][Rank 2]: Add an evidence map",
                 "url": "https://example.test/issues/195",
@@ -37,6 +57,22 @@ def test_dashboard_builder() -> None:
             },
         ],
         "pull_requests": [
+            {
+                "number": 184,
+                "title": "Older merged rank 1 output",
+                "url": "https://example.test/pulls/184",
+                "state": "MERGED",
+                "body": "- Issue: #183\n- Rank: 1\n- Votes: 0",
+                "files": [{"path": "lab/comparisons/2026-W20/rank-1/old.html"}],
+            },
+            {
+                "number": 192,
+                "title": "Preferred merged rank 1 output",
+                "url": "https://example.test/pulls/192",
+                "state": "MERGED",
+                "body": "- Issue: #191\n- Rank: 1\n- Votes: 0",
+                "files": [{"path": "lab/comparisons/2026-W20/rank-1/index.html"}],
+            },
             {
                 "number": 199,
                 "title": "Closed stale comparison output",
@@ -70,12 +106,16 @@ def test_dashboard_builder() -> None:
 
     required = [
         "Prompt Vote Lab comparison: 2026-W20",
+        "Rank 1",
         "Rank 2",
         "Rank 3",
+        "Issue #191",
         "Issue #195",
         "Issue #196",
+        "PR #192",
         "PR #201",
         "MERGED",
+        "lab/comparisons/2026-W20/rank-1/",
         "lab/comparisons/2026-W20/rank-2/",
         "runs/2026-W20-rank-2-issue-195.md",
         "participant evidence comprehension",
@@ -87,6 +127,10 @@ def test_dashboard_builder() -> None:
         raise AssertionError(f"dashboard missing expected text: {missing}")
 
     forbidden = [
+        "Old Rank 1 candidate",
+        "Issue #183",
+        "PR #184",
+        "old.html",
         "PR #199",
         "stale.html",
         "OPENAI_API_KEY",
@@ -101,6 +145,9 @@ def test_dashboard_builder() -> None:
     found = [item for item in forbidden if item in html]
     if found:
         raise AssertionError(f"dashboard leaked forbidden text: {found}")
+
+    if html.count("Rank 1") != 1:
+        raise AssertionError("dashboard should render exactly one Rank 1 card")
 
     if "rank-grid" not in css or "rank-card" not in css:
         raise AssertionError("dashboard CSS should define rank grid/cards")

--- a/scripts/test_build_comparison_dashboard.py
+++ b/scripts/test_build_comparison_dashboard.py
@@ -146,7 +146,7 @@ def test_dashboard_builder() -> None:
     if found:
         raise AssertionError(f"dashboard leaked forbidden text: {found}")
 
-    if html.count("Rank 1") != 1:
+    if html.count('<p class="rank-eyebrow">Rank 1</p>') != 1:
         raise AssertionError("dashboard should render exactly one Rank 1 card")
 
     if "rank-grid" not in css or "rank-card" not in css:


### PR DESCRIPTION
## Summary

Fixes the comparison dashboard so it does not show stale PRs or duplicate rank cards.

## Problem

The comparison dashboard had two related issues:

```text
1. Same Issue with multiple PRs could select a stale closed PR.
2. Same rank could render multiple cards, for example two Rank 1 cards.
```

Observed examples:

```text
Rank 2: stale PR #211 instead of the corrected/merged rank-2 output
Rank 3: stale PR #216 instead of merged PR #224
Rank 1: duplicate cards from Issue #183 and Issue #191
```

## Change

Selection is now deterministic:

```text
PR state: MERGED > OPEN > CLOSED > unknown
Tie-break: larger PR number
Rank dedupe tie-break: PR selection key, then larger Issue number
```

## Tests

Adds regression coverage for:

```text
Issue #195: choose MERGED PR #201 over CLOSED PR #199
Rank 1: choose the preferred/newer merged row and render exactly one Rank 1 card
```

## Non-goals

- Does not directly edit generated comparison HTML in this PR.
- Does not modify rank artifacts.
- Does not change model execution workflow.