### PR TITLE
Regenerate 2026-W20 comparison dashboard

### DIFF
--- a/lab/comparisons/2026-W20/index.html
+++ b/lab/comparisons/2026-W20/index.html
@@ -36,23 +36,6 @@
         <ul class="changed-files"><li><code>lab/app.js</code></li><li><code>lab/index.html</code></li><li><code>lab/style.css</code></li></ul>
       </article>
 
-      <article class="rank-card" aria-labelledby="rank-1-title">
-        <p class="rank-eyebrow">Rank 1</p>
-        <h2 id="rank-1-title">Add a static checklist showing how participants review a run result</h2>
-        <dl class="facts">
-          <div><dt>Issue</dt><dd><a href="https://github.com/Unjuno/prompt-vote-lab/issues/183">Issue #183</a> · CLOSED</dd></div>
-          <div><dt>Votes</dt><dd>0</dd></div>
-          <div><dt>Safety</dt><dd>clear</dd></div>
-          <div><dt>Runtime scan</dt><dd>detected</dd></div>
-          <div><dt>Implementation PR</dt><dd><a href="https://github.com/Unjuno/prompt-vote-lab/pull/184">PR #184</a> · MERGED</dd></div>
-          <div><dt>Output root</dt><dd><code>lab/comparisons/2026-W20/rank-1/</code></dd></div>
-          <div><dt>Run record</dt><dd><code>runs/2026-W20-rank-1-issue-183.md</code></dd></div>
-          <div><dt>Decision</dt><dd>implemented</dd></div>
-        </dl>
-        <h3>Changed files</h3>
-        <ul class="changed-files"><li><code>lab/app.js</code></li><li><code>lab/index.html</code></li><li><code>lab/style.css</code></li></ul>
-      </article>
-
       <article class="rank-card" aria-labelledby="rank-2-title">
         <p class="rank-eyebrow">Rank 2</p>
         <h2 id="rank-2-title">[Prompt][Rank 2]: Add an evidence map for reviewing weekly runs</h2>


### PR DESCRIPTION
## Summary

Regenerates the 2026-W20 comparison dashboard after the comparison dashboard selection fixes.

## Change

Updates:

```text
lab/comparisons/2026-W20/index.html
```

by removing the duplicate Rank 1 card.

## Resulting dashboard rows

```text
Rank 1: Issue #191 / PR #192
Rank 2: Issue #195 / PR #214
Rank 3: Issue #196 / PR #224
```

## Why

The dashboard previously rendered two Rank 1 cards:

```text
Issue #191 / PR #192
Issue #183 / PR #184
```

After the builder fix, one rank should produce one comparison card.

## Scope

Generated comparison dashboard only.

## Non-goals

- No workflow changes.
- No rank artifact changes.
- No public-results schema changes.