### PR TITLE
Test generated comparison dashboards

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -25,6 +25,7 @@ on:
       - "README.md"
       - "data/public-results.json"
       - "data/public-results.md"
+      - "lab/comparisons/**"
       - "docs/codex-runner-contract.md"
       - "docs/canary-log-policy.md"
       - "docs/current-codex-implementation-path.md"
@@ -141,6 +142,9 @@ jobs:
 
       - name: Run comparison dashboard builder test
         run: python scripts/test_build_comparison_dashboard.py
+
+      - name: Run generated comparison dashboard test
+        run: python scripts/test_generated_comparison_dashboards.py
 
       - name: Run weekly Issue finalizer test
         run: python scripts/test_weekly_issue_finalizer.py

--- a/scripts/test_generated_comparison_dashboards.py
+++ b/scripts/test_generated_comparison_dashboards.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPARISONS_DIR = ROOT / "lab" / "comparisons"
+
+RANK_CARD_RE = re.compile(r'<p class="rank-eyebrow">Rank ([123])</p>')
+RANK_TITLE_ID_RE = re.compile(r'id="(rank-[123]-title)"')
+
+REQUIRED_TEXT = [
+    "Prompt Vote Lab comparison:",
+    "Comparison dashboard · generated from public results",
+    "GitHub Issues, PRs, commits, public bundles, and run records remain the source of truth",
+    "default-src 'self'",
+    "connect-src 'none'",
+    "frame-src 'none'",
+    "object-src 'none'",
+    "base-uri 'none'",
+    "form-action 'none'",
+]
+
+FORBIDDEN_TEXT = [
+    "OPENAI_API_KEY",
+    "codex login",
+    "container stderr",
+    "raw stderr",
+    "document.cookie",
+    "eval(",
+    "<iframe",
+    "https://example.com/ping",
+]
+
+
+def _comparison_indexes() -> list[Path]:
+    if not COMPARISONS_DIR.exists():
+        return []
+    return sorted(
+        path
+        for path in COMPARISONS_DIR.glob("*/index.html")
+        if path.parent.name and not path.parent.name.startswith(".")
+    )
+
+
+def _require_unique(values: list[str], label: str, path: Path) -> None:
+    duplicates = sorted({item for item in values if values.count(item) > 1})
+    if duplicates:
+        rel = path.relative_to(ROOT)
+        raise AssertionError(f"{rel}: duplicate {label}: {duplicates}")
+
+
+def test_dashboard(path: Path) -> None:
+    rel = path.relative_to(ROOT)
+    text = path.read_text(encoding="utf-8")
+
+    missing = [item for item in REQUIRED_TEXT if item not in text]
+    if missing:
+        raise AssertionError(f"{rel}: missing required text: {missing}")
+
+    forbidden = [item for item in FORBIDDEN_TEXT if item in text]
+    if forbidden:
+        raise AssertionError(f"{rel}: forbidden text found: {forbidden}")
+
+    ranks = RANK_CARD_RE.findall(text)
+    if not ranks:
+        raise AssertionError(f"{rel}: no rank cards found")
+    _require_unique(ranks, "rank cards", path)
+
+    title_ids = RANK_TITLE_ID_RE.findall(text)
+    _require_unique(title_ids, "rank title ids", path)
+
+    for rank in ranks:
+        expected_root = f"lab/comparisons/{path.parent.name}/rank-{rank}/"
+        if expected_root not in text:
+            raise AssertionError(f"{rel}: missing output root for rank {rank}: {expected_root}")
+
+    if '<section class="rank-grid" aria-label="Comparison candidates">' not in text:
+        raise AssertionError(f"{rel}: missing rank-grid section")
+
+
+def main() -> int:
+    indexes = _comparison_indexes()
+    if not indexes:
+        raise SystemExit("No generated comparison dashboards found")
+
+    for path in indexes:
+        test_dashboard(path)
+
+    print(f"generated comparison dashboard test passed: {len(indexes)} file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a CI self-test for generated comparison dashboard HTML.

## Why

The previous failure mode was not only builder logic. A generated page under `lab/comparisons/2026-W20/index.html` had already drifted into a bad state:

```text
- duplicate Rank 1 cards
- stale PR references in comparison cards
```

Builder tests help, but generated artifacts also need direct invariant checks.

## Change

Adds:

```text
scripts/test_generated_comparison_dashboards.py
```

and wires it into:

```text
.github/workflows/script-check.yml
```

## Checks added

For each `lab/comparisons/*/index.html`:

```text
- comparison dashboard marker exists
- required CSP restrictions exist
- forbidden runtime text is absent
- rank cards are not duplicated
- rank title ids are not duplicated
- each displayed rank has a matching output root
- rank-grid section exists
```

Also adds `lab/comparisons/**` to the Script Check trigger paths so generated dashboard-only PRs get this validation.

## Non-goals

- Does not change generated dashboards.
- Does not change public-results export behavior.
- Does not change model or comparison run workflows.