### PR TITLE
Add Script Check workflow contract test

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -137,6 +137,9 @@ jobs:
       - name: Run public results export workflow contract test
         run: python scripts/test_public_results_export_workflow_contract.py
 
+      - name: Run script-check workflow contract test
+        run: python scripts/test_script_check_workflow_contract.py
+
       - name: Run public agent run bundle builder test
         run: python scripts/test_build_public_agent_run_bundle.py
 

--- a/scripts/test_script_check_workflow_contract.py
+++ b/scripts/test_script_check_workflow_contract.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "script-check.yml"
+
+REQUIRED_TEXT = [
+    "name: Script Check",
+    "pull_request:",
+    "paths:",
+    "lab/comparisons/**",
+    "workflow_dispatch:",
+    "contents: read",
+    "Run comparison dashboard builder test",
+    "python scripts/test_build_comparison_dashboard.py",
+    "Run generated comparison dashboard test",
+    "python scripts/test_generated_comparison_dashboards.py",
+    "Run public results export workflow contract test",
+    "python scripts/test_public_results_export_workflow_contract.py",
+    "Run lab PR scope guard self-test",
+    "bash scripts/test-lab-pr-scope.sh",
+]
+
+FORBIDDEN_TEXT = [
+    "contents: write",
+    "pull-requests: write",
+    "issues: write",
+    "secrets.OPENAI",
+    "OPENAI_API_KEY",
+    "codex exec",
+    "gh pr merge",
+]
+
+
+def require_all(text: str, required: list[str]) -> None:
+    missing = [item for item in required if item not in text]
+    if missing:
+        raise SystemExit(f"Missing script-check workflow text: {missing}")
+
+
+def reject_all(text: str, forbidden: list[str]) -> None:
+    found = [item for item in forbidden if item in text]
+    if found:
+        raise SystemExit(f"Forbidden script-check workflow text found: {found}")
+
+
+def main() -> int:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    require_all(text, REQUIRED_TEXT)
+    reject_all(text, FORBIDDEN_TEXT)
+
+    if text.index("Run comparison dashboard builder test") > text.index("Run generated comparison dashboard test"):
+        raise SystemExit("Generated comparison dashboard test should run after the builder test")
+
+    if text.index("Run generated comparison dashboard test") > text.index("Run weekly Issue finalizer test"):
+        raise SystemExit("Generated dashboard test should run before later weekly finalizer tests")
+
+    print("script-check workflow contract test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a contract test for `.github/workflows/script-check.yml`.

## Why

#230 added generated comparison dashboard validation, but the workflow wiring itself was not protected by a contract test. If the generated dashboard test or `lab/comparisons/**` trigger path is later removed from `Script Check`, generated dashboard regressions can slip through again.

## Change

Adds:

```text
scripts/test_script_check_workflow_contract.py
```

and runs it from:

```text
.github/workflows/script-check.yml
```

## Contract fixed

The test requires:

```text
- pull_request.paths includes lab/comparisons/**
- Script Check runs scripts/test_generated_comparison_dashboards.py
- Script Check runs comparison dashboard builder tests
- Script Check keeps contents: read
```

The test forbids:

```text
- contents: write
- pull-requests: write
- issues: write
- OpenAI secrets/API keys
- Codex execution
- PR merge commands
```

## Non-goals

- No generated dashboard changes.
- No public-results export behavior changes.
- No model workflow changes.