### PR TITLE
Automate support unlocks for comparison runs

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -10,6 +10,7 @@ on:
       - ".github/ISSUE_TEMPLATE/**"
       - ".github/workflows/script-check.yml"
       - ".github/workflows/support-unlock-export.yml"
+      - ".github/workflows/weekly-auto-run.yml"
       - ".github/workflows/issue-safety-scan.yml"
       - ".github/workflows/public-results-export.yml"
       - ".github/workflows/weekly-issue-finalizer.yml"
@@ -36,6 +37,7 @@ on:
       - "docs/issue-lifecycle.md"
       - "docs/comparison-dashboard.md"
       - "docs/support-policy.md"
+      - "docs/support-unlock-automation.md"
       - "docs/canary-007-policy-enforced-agent.md"
       - "docs/canary-008-selected-prompt-task-packet.md"
       - "docs/canary-009-selected-issue-instructions.md"
@@ -145,6 +147,15 @@ jobs:
 
       - name: Run support unlock builder test
         run: python scripts/test_build_support_unlocks.py
+
+      - name: Run support unlock resolver test
+        run: python scripts/test_resolve_support_unlock.py
+
+      - name: Run eligible selector support unlock test
+        run: python scripts/test_select_eligible_support_unlock.py
+
+      - name: Run support unlock workflow contract test
+        run: python scripts/test_support_unlock_workflow_contract.py
 
       - name: Run support unlock smoke test
         run: python scripts/test_unlock_export_public.py

--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -9,6 +9,7 @@ on:
       - "tests/fixtures/**"
       - ".github/ISSUE_TEMPLATE/**"
       - ".github/workflows/script-check.yml"
+      - ".github/workflows/support-unlock-export.yml"
       - ".github/workflows/issue-safety-scan.yml"
       - ".github/workflows/public-results-export.yml"
       - ".github/workflows/weekly-issue-finalizer.yml"
@@ -25,6 +26,7 @@ on:
       - "README.md"
       - "data/public-results.json"
       - "data/public-results.md"
+      - "data/support-unlocks/**"
       - "lab/comparisons/**"
       - "docs/codex-runner-contract.md"
       - "docs/canary-log-policy.md"
@@ -33,6 +35,7 @@ on:
       - "docs/public-agent-run-bundle.md"
       - "docs/issue-lifecycle.md"
       - "docs/comparison-dashboard.md"
+      - "docs/support-policy.md"
       - "docs/canary-007-policy-enforced-agent.md"
       - "docs/canary-008-selected-prompt-task-packet.md"
       - "docs/canary-009-selected-issue-instructions.md"
@@ -139,6 +142,12 @@ jobs:
 
       - name: Run script-check workflow contract test
         run: python scripts/test_script_check_workflow_contract.py
+
+      - name: Run support unlock builder test
+        run: python scripts/test_build_support_unlocks.py
+
+      - name: Run support unlock smoke test
+        run: python scripts/test_unlock_export_public.py
 
       - name: Run public agent run bundle builder test
         run: python scripts/test_build_public_agent_run_bundle.py

--- a/.github/workflows/support-unlock-export.yml
+++ b/.github/workflows/support-unlock-export.yml
@@ -1,0 +1,20 @@
+name: Support Unlock Export
+
+on:
+  schedule:
+    - cron: "17 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  export:
+    if: github.repository == 'Unjuno/prompt-vote-lab'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify support unlock tooling
+        run: python scripts/test_build_support_unlocks.py

--- a/.github/workflows/support-unlock-export.yml
+++ b/.github/workflows/support-unlock-export.yml
@@ -6,15 +6,68 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   export:
     if: github.repository == 'Unjuno/prompt-vote-lab'
     runs-on: ubuntu-latest
+    env:
+      SPONSORS_LOGIN: Unjuno
+      GH_TOKEN: ${{ secrets.SPONSORS_GRAPHQL_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve support window
+        id: window
+        shell: python
+        run: |
+          from datetime import datetime, timedelta, timezone
+          import os
+          current = datetime.now(timezone.utc)
+          iso = current.isocalendar()
+          start = current - timedelta(days=iso.weekday - 1)
+          start = start.replace(hour=0, minute=0, second=0, microsecond=0)
+          end = start + timedelta(days=7)
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as handle:
+              handle.write(f"week_id={iso.year}-W{iso.week:02d}\n")
+              handle.write(f"since={start.isoformat(timespec='seconds').replace('+00:00', 'Z')}\n")
+              handle.write(f"until={end.isoformat(timespec='seconds').replace('+00:00', 'Z')}\n")
+
+      - name: Fetch support activity
+        run: |
+          test -n "$GH_TOKEN"
+          python scripts/fetch_support_activities.py \
+            --login "$SPONSORS_LOGIN" \
+            --since "${{ steps.window.outputs.since }}" \
+            --until "${{ steps.window.outputs.until }}" \
+            --out tmp/support-activities.json
+
+      - name: Build support unlocks
+        run: |
+          python scripts/build_support_unlocks.py \
+            --input tmp/support-activities.json \
+            --week-id "${{ steps.window.outputs.week_id }}" \
+            --since "${{ steps.window.outputs.since }}" \
+            --until "${{ steps.window.outputs.until }}" \
+            --out-dir data/support-unlocks
 
       - name: Verify support unlock tooling
         run: python scripts/test_build_support_unlocks.py
+
+      - name: Commit support unlocks
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/support-unlocks/
+          if git diff --cached --quiet; then
+            echo "No support unlock changes."
+            exit 0
+          fi
+          git commit -m "Update support unlocks for ${{ steps.window.outputs.week_id }}"
+          git push

--- a/.github/workflows/weekly-auto-run.yml
+++ b/.github/workflows/weekly-auto-run.yml
@@ -37,6 +37,11 @@ jobs:
           PROMPT_VOTE_LAB_NO_CHANGE_BASELINE: ${{ vars.PROMPT_VOTE_LAB_NO_CHANGE_BASELINE }}
           PROMPT_VOTE_LAB_SUPPORT_USD: ${{ vars.PROMPT_VOTE_LAB_SUPPORT_USD }}
 
+      - name: Resolve automated support unlocks
+        run: |
+          python scripts/resolve_support_unlock.py --week "$RUN_WEEK" --out .tmp/support-unlock-env.txt
+          cat .tmp/support-unlock-env.txt >> "$GITHUB_ENV"
+
       - name: Collect prompt proposal votes
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -52,6 +57,7 @@ jobs:
           python scripts/select_eligible.py \
             --candidates .tmp/weekly-candidates.json \
             --support-usd "$SUPPORT_USD" \
+            --week "$RUN_WEEK" \
             --out .tmp/eligible-candidates.json \
             --flag .tmp/has-eligible.txt \
             --meta .tmp/selection-meta.json
@@ -72,6 +78,10 @@ jobs:
             echo "## Weekly support total"
             echo ""
             echo "${SUPPORT_USD} USD"
+            echo ""
+            echo "## Support unlock source"
+            echo ""
+            echo "${SUPPORT_UNLOCK_WEEK:-unrecorded} / rank2=${RANK_2_UNLOCKED:-false} / rank3=${RANK_3_UNLOCKED:-false}"
             echo ""
             echo "## No-change baseline"
             echo ""

--- a/docs/support-unlock-automation.md
+++ b/docs/support-unlock-automation.md
@@ -1,0 +1,76 @@
+# Support unlock automation
+
+Prompt Vote Lab support unlocks are automated as an anonymized weekly aggregate.
+
+## Purpose
+
+Support can unlock extra comparison runs for the current weekly vote:
+
+- rank 2 unlock: 5 USD total weekly one-time support
+- rank 3 unlock: 10 USD total weekly one-time support
+
+Support does not buy votes, merge rights, success, adoption, maintenance, review, support work, delivery, or specification control.
+
+## Privacy boundary
+
+The public output must contain only aggregate unlock data.
+
+Allowed public fields include:
+
+- week id
+- support total in cents/USD
+- counted event count
+- ignored event count
+- rank 2 unlocked boolean
+- rank 3 unlocked boolean
+- threshold values
+- source label
+- generated timestamp
+
+The public output must not contain sponsor names, sponsor logins, sponsor emails, individual payment events, or per-supporter amounts.
+
+## Data source
+
+The automation polls GitHub Sponsors activity through GitHub GraphQL.
+
+The fetch step writes a temporary local payload under `tmp/`. The temporary payload is not committed.
+
+The build step converts that temporary payload into:
+
+```text
+data/support-unlocks/<week-id>.json
+```
+
+Only the anonymized aggregate file is allowed to be committed.
+
+## Operational token
+
+The workflow needs a repository secret that can read the maintainer's GitHub Sponsors activity.
+
+Expected secret name:
+
+```text
+SPONSORS_GRAPHQL_TOKEN
+```
+
+The token should use the least permissions that can read sponsorship activity for the maintainer account. Do not use a token with repository administration permissions.
+
+## CI contract
+
+Script Check must run:
+
+```text
+python scripts/test_build_support_unlocks.py
+```
+
+That test verifies:
+
+- weekly totals are computed from fixture activity
+- rank 2 unlocks at 5 USD
+- rank 3 unlocks at 10 USD
+- non-new, old, and recurring support events are ignored
+- sponsor identities from the raw fixture are not present in the public output
+
+## Failure mode
+
+If the fetch step fails because the token is missing or lacks access, the workflow must fail visibly. It must not guess support totals and must not unlock comparison runs from stale data.

--- a/scripts/build_support_unlocks.py
+++ b/scripts/build_support_unlocks.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+RANK_2_THRESHOLD_CENTS = 500
+RANK_3_THRESHOLD_CENTS = 1000
+
+ACTION_ALLOWLIST = {
+    "NEW_SPONSORSHIP",
+    "SPONSORSHIP_STARTED",
+}
+
+IDENTITY_KEYS = {
+    "sponsor",
+    "sponsors",
+    "sponsorable",
+    "sponsorEntity",
+    "sponsor_login",
+    "sponsorLogin",
+    "login",
+    "email",
+    "name",
+}
+
+
+def parse_iso8601(value: str) -> datetime:
+    text = value.strip()
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def load_json(path: str) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def iter_activity_nodes(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    if isinstance(payload.get("nodes"), list):
+        return [node for node in payload["nodes"] if isinstance(node, dict)]
+
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else payload
+    candidates = []
+    if isinstance(data, dict):
+        candidates.extend([data.get("user"), data.get("organization"), data.get("viewer")])
+
+    for owner in candidates:
+        if not isinstance(owner, dict):
+            continue
+        activities = owner.get("sponsorsActivities")
+        if isinstance(activities, dict) and isinstance(activities.get("nodes"), list):
+            return [node for node in activities["nodes"] if isinstance(node, dict)]
+    return []
+
+
+def get_nested(mapping: dict[str, Any], path: list[str]) -> Any:
+    cursor: Any = mapping
+    for key in path:
+        if not isinstance(cursor, dict):
+            return None
+        cursor = cursor.get(key)
+    return cursor
+
+
+def event_time(node: dict[str, Any]) -> datetime | None:
+    for key in ("timestamp", "createdAt", "occurredAt", "created_at"):
+        value = node.get(key)
+        if isinstance(value, str) and value.strip():
+            return parse_iso8601(value)
+    return None
+
+
+def tier_object(node: dict[str, Any]) -> dict[str, Any]:
+    for path in (["sponsorsTier"], ["tier"], ["sponsorship", "tier"], ["sponsorship", "sponsorsTier"]):
+        value = get_nested(node, path)
+        if isinstance(value, dict):
+            return value
+    return {}
+
+
+def tier_amount_cents(tier: dict[str, Any]) -> int:
+    for key in ("monthlyPriceInCents", "amountInCents", "priceInCents", "oneTimePaymentInCents"):
+        value = tier.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str) and value.isdigit():
+            return int(value)
+    return 0
+
+
+def tier_is_one_time(tier: dict[str, Any], node: dict[str, Any]) -> bool:
+    for source in (tier, node, node.get("sponsorship") if isinstance(node.get("sponsorship"), dict) else {}):
+        if not isinstance(source, dict):
+            continue
+        for key in ("isOneTime", "oneTime", "is_one_time"):
+            if isinstance(source.get(key), bool):
+                return bool(source[key])
+    return False
+
+
+def contains_identity_key(value: Any) -> bool:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key in IDENTITY_KEYS:
+                return True
+            if contains_identity_key(child):
+                return True
+    if isinstance(value, list):
+        return any(contains_identity_key(child) for child in value)
+    return False
+
+
+def build_unlocks(payload: dict[str, Any], week_id: str, since: str, until: str, source: str) -> dict[str, Any]:
+    since_dt = parse_iso8601(since)
+    until_dt = parse_iso8601(until)
+    support_total_cents = 0
+    counted_event_count = 0
+    ignored_event_count = 0
+
+    for node in iter_activity_nodes(payload):
+        action = str(node.get("action", ""))
+        occurred_at = event_time(node)
+        tier = tier_object(node)
+        amount_cents = tier_amount_cents(tier)
+        one_time = tier_is_one_time(tier, node)
+
+        if action and action not in ACTION_ALLOWLIST:
+            ignored_event_count += 1
+            continue
+        if occurred_at is None or occurred_at < since_dt or occurred_at >= until_dt:
+            ignored_event_count += 1
+            continue
+        if not one_time:
+            ignored_event_count += 1
+            continue
+        if amount_cents <= 0:
+            ignored_event_count += 1
+            continue
+
+        support_total_cents += amount_cents
+        counted_event_count += 1
+
+    return {
+        "schema_version": "support-unlock.v1",
+        "week_id": week_id,
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "source": source,
+        "window": {
+            "since": since_dt.isoformat(timespec="seconds").replace("+00:00", "Z"),
+            "until": until_dt.isoformat(timespec="seconds").replace("+00:00", "Z"),
+        },
+        "thresholds": {
+            "rank_2_cents": RANK_2_THRESHOLD_CENTS,
+            "rank_3_cents": RANK_3_THRESHOLD_CENTS,
+        },
+        "support_total_cents": support_total_cents,
+        "support_total_usd": round(support_total_cents / 100, 2),
+        "counted_event_count": counted_event_count,
+        "ignored_event_count": ignored_event_count,
+        "rank_2_unlocked": support_total_cents >= RANK_2_THRESHOLD_CENTS,
+        "rank_3_unlocked": support_total_cents >= RANK_3_THRESHOLD_CENTS,
+        "privacy": {
+            "sponsor_identity_included": False,
+            "raw_sponsor_logins_included": False,
+            "raw_sponsor_emails_included": False,
+            "event_level_amounts_included": False,
+        },
+    }
+
+
+def validate_public_unlock(payload: dict[str, Any]) -> None:
+    if contains_identity_key(payload):
+        raise SystemExit("Support unlock output must not contain sponsor identity keys")
+    total = int(payload.get("support_total_cents", -1))
+    thresholds = payload.get("thresholds") or {}
+    if payload.get("rank_2_unlocked") != (total >= int(thresholds.get("rank_2_cents", RANK_2_THRESHOLD_CENTS))):
+        raise SystemExit("rank_2_unlocked does not match the configured threshold")
+    if payload.get("rank_3_unlocked") != (total >= int(thresholds.get("rank_3_cents", RANK_3_THRESHOLD_CENTS))):
+        raise SystemExit("rank_3_unlocked does not match the configured threshold")
+
+
+def write_outputs(unlock: dict[str, Any], out_dir: str, week_id: str) -> None:
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+    json_path = out_path / f"{week_id}.json"
+    json_path.write_text(json.dumps(unlock, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True, help="GraphQL sponsorship activity JSON")
+    parser.add_argument("--week-id", required=True)
+    parser.add_argument("--since", required=True)
+    parser.add_argument("--until", required=True)
+    parser.add_argument("--source", default="github-sponsors-graphql")
+    parser.add_argument("--out-dir", default="data/support-unlocks")
+    args = parser.parse_args()
+
+    unlock = build_unlocks(load_json(args.input), args.week_id, args.since, args.until, args.source)
+    validate_public_unlock(unlock)
+    write_outputs(unlock, args.out_dir, args.week_id)
+    print(f"support unlocks written: {args.out_dir}/{args.week_id}.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fetch_support_activities.py
+++ b/scripts/fetch_support_activities.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+QUERY = """
+query PromptVoteLabSupportActivities($login: String!, $since: DateTime!, $until: DateTime!, $after: String) {
+  user(login: $login) {
+    sponsorsActivities(
+      first: 100
+      after: $after
+      since: $since
+      until: $until
+      actions: [NEW_SPONSORSHIP]
+      includePrivate: true
+      includeAsSponsor: false
+      period: ALL
+      orderBy: {field: TIMESTAMP, direction: DESC}
+    ) {
+      nodes {
+        action
+        timestamp
+        sponsorsTier {
+          isOneTime
+          monthlyPriceInCents
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}
+""".strip()
+
+
+def gh_graphql(query: str, variables: dict[str, str]) -> dict:
+    cmd = ["gh", "api", "graphql", "-f", f"query={query}"]
+    for key, value in variables.items():
+        if value:
+            cmd.extend(["-F", f"{key}={value}"])
+    completed = subprocess.run(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+    if completed.returncode != 0:
+        sys.stderr.write(completed.stderr)
+        raise SystemExit(completed.returncode)
+    return json.loads(completed.stdout)
+
+
+def collect(login: str, since: str, until: str) -> dict:
+    all_nodes = []
+    after = ""
+    while True:
+        payload = gh_graphql(QUERY, {"login": login, "since": since, "until": until, "after": after})
+        user = (payload.get("data") or {}).get("user") or {}
+        activities = user.get("sponsorsActivities") or {}
+        nodes = activities.get("nodes") or []
+        all_nodes.extend(nodes)
+        page_info = activities.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        after = str(page_info.get("endCursor") or "")
+        if not after:
+            break
+    return {"data": {"user": {"sponsorsActivities": {"nodes": all_nodes}}}}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--login", default=os.getenv("SPONSORS_LOGIN", "Unjuno"))
+    parser.add_argument("--since", required=True)
+    parser.add_argument("--until", required=True)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    payload = collect(args.login, args.since, args.until)
+    Path(args.out).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"support activity payload written: {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/resolve_support_unlock.py
+++ b/scripts/resolve_support_unlock.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--week", required=True)
+    parser.add_argument("--dir", default="data/support-unlocks")
+    parser.add_argument("--out", default=".tmp/support-unlock-env.txt")
+    args = parser.parse_args()
+
+    path = Path(args.dir) / f"{args.week}.json"
+    support_total_usd = 0.0
+    rank_2 = False
+    rank_3 = False
+
+    if path.exists():
+        data = json.loads(path.read_text(encoding="utf-8"))
+        support_total_usd = float(data.get("support_total_usd") or 0)
+        rank_2 = bool(data.get("rank_2_unlocked"))
+        rank_3 = bool(data.get("rank_3_unlocked"))
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(
+        "SUPPORT_USD=" + str(support_total_usd) + "\n"
+        + "RANK_2_UNLOCKED=" + ("true" if rank_2 else "false") + "\n"
+        + "RANK_3_UNLOCKED=" + ("true" if rank_3 else "false") + "\n",
+        encoding="utf-8",
+    )
+    print(f"support_usd={support_total_usd}")
+    print(f"rank_2_unlocked={rank_2}")
+    print(f"rank_3_unlocked={rank_3}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/resolve_support_unlock.py
+++ b/scripts/resolve_support_unlock.py
@@ -6,6 +6,11 @@ import json
 from pathlib import Path
 
 
+def normalize_week_id(value: str) -> str:
+    text = value.strip()
+    return text[5:] if text.startswith("week-") else text
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--week", required=True)
@@ -13,7 +18,8 @@ def main() -> int:
     parser.add_argument("--out", default=".tmp/support-unlock-env.txt")
     args = parser.parse_args()
 
-    path = Path(args.dir) / f"{args.week}.json"
+    week_id = normalize_week_id(args.week)
+    path = Path(args.dir) / f"{week_id}.json"
     support_total_usd = 0.0
     rank_2 = False
     rank_3 = False
@@ -27,11 +33,13 @@ def main() -> int:
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(
-        "SUPPORT_USD=" + str(support_total_usd) + "\n"
+        "SUPPORT_UNLOCK_WEEK=" + week_id + "\n"
+        + "SUPPORT_USD=" + str(support_total_usd) + "\n"
         + "RANK_2_UNLOCKED=" + ("true" if rank_2 else "false") + "\n"
         + "RANK_3_UNLOCKED=" + ("true" if rank_3 else "false") + "\n",
         encoding="utf-8",
     )
+    print(f"support_unlock_week={week_id}")
     print(f"support_usd={support_total_usd}")
     print(f"rank_2_unlocked={rank_2}")
     print(f"rank_3_unlocked={rank_3}")

--- a/scripts/select_eligible.py
+++ b/scripts/select_eligible.py
@@ -32,17 +32,28 @@ def normalize_week_id(value: str) -> str:
     return text[5:] if text.startswith("week-") else text
 
 
-def support_from_unlock_file(week: str | None) -> float | None:
+def support_unlock_path(week: str | None) -> Path | None:
     if not week:
         return None
-    path = SUPPORT_UNLOCK_DIR / f"{normalize_week_id(week)}.json"
-    if not path.exists():
+    return SUPPORT_UNLOCK_DIR / f"{normalize_week_id(week)}.json"
+
+
+def support_from_unlock_file(week: str | None) -> float | None:
+    path = support_unlock_path(week)
+    if path is None or not path.exists():
         return None
     data = json.loads(path.read_text(encoding="utf-8"))
     support = float(data.get("support_total_usd") or 0)
     if not math.isfinite(support) or support < 0:
         raise ValueError(f"support unlock file has invalid support_total_usd: {path}")
     return support
+
+
+def support_source_for_week(week: str | None) -> str:
+    path = support_unlock_path(week)
+    if path is not None and path.exists():
+        return "support-unlock-file"
+    return "workflow-input"
 
 
 def parse_support_usd(value: str | int | float, week: str | None = None) -> float:
@@ -98,7 +109,15 @@ def select_eligible(candidates: list[dict[str, Any]], support_usd: str | int | f
     return eligible
 
 
-def write_outputs(eligible: list[dict[str, Any]], out: Path, flag: Path, meta: Path, candidates: list[dict[str, Any]], support_usd: float) -> None:
+def write_outputs(
+    eligible: list[dict[str, Any]],
+    out: Path,
+    flag: Path,
+    meta: Path,
+    candidates: list[dict[str, Any]],
+    support_usd: float,
+    support_source: str,
+) -> None:
     out.parent.mkdir(parents=True, exist_ok=True)
     flag.parent.mkdir(parents=True, exist_ok=True)
     meta.parent.mkdir(parents=True, exist_ok=True)
@@ -111,7 +130,7 @@ def write_outputs(eligible: list[dict[str, Any]], out: Path, flag: Path, meta: P
                 "eligible_count": len(eligible),
                 "eligible_ranks": [candidate.get("rank") for candidate in eligible],
                 "support_usd": support_usd,
-                "support_source": "support-unlock-file" if os.getenv("RUN_WEEK") and support_from_unlock_file(os.getenv("RUN_WEEK")) is not None else "workflow-input",
+                "support_source": support_source,
             },
             indent=2,
             ensure_ascii=False,
@@ -136,7 +155,15 @@ def main() -> int:
         raise SystemExit("candidates JSON must be a list")
     support = parse_support_usd(args.support_usd, week=args.week)
     eligible = select_eligible(candidates, support, week=args.week)
-    write_outputs(eligible, Path(args.out), Path(args.flag), Path(args.meta), candidates, support)
+    write_outputs(
+        eligible,
+        Path(args.out),
+        Path(args.flag),
+        Path(args.meta),
+        candidates,
+        support,
+        support_source_for_week(args.week),
+    )
     print(json.dumps({"eligible": eligible, "baseline_won": baseline_won(candidates), "support_usd": support}, indent=2, ensure_ascii=False))
     return 0
 

--- a/scripts/select_eligible.py
+++ b/scripts/select_eligible.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import os
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
@@ -23,9 +24,31 @@ NORMAL_RUN = "normal-weekly-run"
 SUPPORT_RUN = "support-unlocked-run"
 BASELINE_TYPE = "no-change-baseline"
 PROMPT_TYPE = "prompt-proposal"
+SUPPORT_UNLOCK_DIR = Path("data/support-unlocks")
 
 
-def parse_support_usd(value: str | int | float) -> float:
+def normalize_week_id(value: str) -> str:
+    text = value.strip()
+    return text[5:] if text.startswith("week-") else text
+
+
+def support_from_unlock_file(week: str | None) -> float | None:
+    if not week:
+        return None
+    path = SUPPORT_UNLOCK_DIR / f"{normalize_week_id(week)}.json"
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    support = float(data.get("support_total_usd") or 0)
+    if not math.isfinite(support) or support < 0:
+        raise ValueError(f"support unlock file has invalid support_total_usd: {path}")
+    return support
+
+
+def parse_support_usd(value: str | int | float, week: str | None = None) -> float:
+    override = support_from_unlock_file(week)
+    if override is not None:
+        return override
     support = float(value or 0)
     if not math.isfinite(support) or support < 0:
         raise ValueError("support_usd must be a finite non-negative number")
@@ -49,8 +72,8 @@ def baseline_won(candidates: list[dict[str, Any]]) -> bool:
     )
 
 
-def select_eligible(candidates: list[dict[str, Any]], support_usd: str | int | float) -> list[dict[str, Any]]:
-    support = parse_support_usd(support_usd)
+def select_eligible(candidates: list[dict[str, Any]], support_usd: str | int | float, week: str | None = None) -> list[dict[str, Any]]:
+    support = parse_support_usd(support_usd, week=week)
     if baseline_won(candidates):
         return []
 
@@ -75,7 +98,7 @@ def select_eligible(candidates: list[dict[str, Any]], support_usd: str | int | f
     return eligible
 
 
-def write_outputs(eligible: list[dict[str, Any]], out: Path, flag: Path, meta: Path, candidates: list[dict[str, Any]]) -> None:
+def write_outputs(eligible: list[dict[str, Any]], out: Path, flag: Path, meta: Path, candidates: list[dict[str, Any]], support_usd: float) -> None:
     out.parent.mkdir(parents=True, exist_ok=True)
     flag.parent.mkdir(parents=True, exist_ok=True)
     meta.parent.mkdir(parents=True, exist_ok=True)
@@ -87,6 +110,8 @@ def write_outputs(eligible: list[dict[str, Any]], out: Path, flag: Path, meta: P
                 "baseline_won": baseline_won(candidates),
                 "eligible_count": len(eligible),
                 "eligible_ranks": [candidate.get("rank") for candidate in eligible],
+                "support_usd": support_usd,
+                "support_source": "support-unlock-file" if os.getenv("RUN_WEEK") and support_from_unlock_file(os.getenv("RUN_WEEK")) is not None else "workflow-input",
             },
             indent=2,
             ensure_ascii=False,
@@ -100,6 +125,7 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--candidates", default=".tmp/weekly-candidates.json")
     parser.add_argument("--support-usd", default="0")
+    parser.add_argument("--week", default=os.getenv("RUN_WEEK", ""))
     parser.add_argument("--out", default=".tmp/eligible-candidates.json")
     parser.add_argument("--flag", default=".tmp/has-eligible.txt")
     parser.add_argument("--meta", default=".tmp/selection-meta.json")
@@ -108,9 +134,10 @@ def main() -> int:
     candidates = json.loads(Path(args.candidates).read_text(encoding="utf-8"))
     if not isinstance(candidates, list):
         raise SystemExit("candidates JSON must be a list")
-    eligible = select_eligible(candidates, args.support_usd)
-    write_outputs(eligible, Path(args.out), Path(args.flag), Path(args.meta), candidates)
-    print(json.dumps({"eligible": eligible, "baseline_won": baseline_won(candidates)}, indent=2, ensure_ascii=False))
+    support = parse_support_usd(args.support_usd, week=args.week)
+    eligible = select_eligible(candidates, support, week=args.week)
+    write_outputs(eligible, Path(args.out), Path(args.flag), Path(args.meta), candidates, support)
+    print(json.dumps({"eligible": eligible, "baseline_won": baseline_won(candidates), "support_usd": support}, indent=2, ensure_ascii=False))
     return 0
 
 

--- a/scripts/test_build_support_unlocks.py
+++ b/scripts/test_build_support_unlocks.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build_support_unlocks.py"
+FIXTURE = ROOT / "tests" / "fixtures" / "support-activities-w20.json"
+
+FORBIDDEN_PUBLIC_TEXT = [
+    "private-sponsor-one",
+    "private-sponsor-two",
+    "ignored-cancel",
+    "ignored-old",
+    "ignored-recurring",
+    "sponsor\"",
+    "login\"",
+    "email\"",
+]
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        out_dir = Path(tmp) / "support-unlocks"
+        subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--input",
+                str(FIXTURE),
+                "--week-id",
+                "2026-W20",
+                "--since",
+                "2026-05-04T00:00:00Z",
+                "--until",
+                "2026-05-11T00:00:00Z",
+                "--out-dir",
+                str(out_dir),
+            ],
+            cwd=ROOT,
+            check=True,
+        )
+        output_path = out_dir / "2026-W20.json"
+        text = output_path.read_text(encoding="utf-8")
+        data = json.loads(text)
+
+    if data["support_total_cents"] != 1000:
+        raise SystemExit(f"expected 1000 cents, got {data['support_total_cents']}")
+    if data["support_total_usd"] != 10:
+        raise SystemExit(f"expected 10 USD, got {data['support_total_usd']}")
+    if data["counted_event_count"] != 2:
+        raise SystemExit(f"expected 2 counted events, got {data['counted_event_count']}")
+    if data["ignored_event_count"] != 3:
+        raise SystemExit(f"expected 3 ignored events, got {data['ignored_event_count']}")
+    if data["rank_2_unlocked"] is not True:
+        raise SystemExit("rank 2 should be unlocked at 5 USD")
+    if data["rank_3_unlocked"] is not True:
+        raise SystemExit("rank 3 should be unlocked at 10 USD")
+    if data["privacy"]["sponsor_identity_included"] is not False:
+        raise SystemExit("public support unlock output must not include sponsor identity")
+
+    leaked = [item for item in FORBIDDEN_PUBLIC_TEXT if item in text]
+    if leaked:
+        raise SystemExit(f"public support unlock output leaked private fields: {leaked}")
+
+    print("support unlock builder test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_resolve_support_unlock.py
+++ b/scripts/test_resolve_support_unlock.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "resolve_support_unlock.py"
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        base = Path(tmp)
+        unlock_dir = base / "support-unlocks"
+        unlock_dir.mkdir()
+        (unlock_dir / "2026-W20.json").write_text(
+            json.dumps(
+                {
+                    "support_total_usd": 10,
+                    "rank_2_unlocked": True,
+                    "rank_3_unlocked": True,
+                }
+            ),
+            encoding="utf-8",
+        )
+        out = base / "env.txt"
+        subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--week",
+                "2026-W20",
+                "--dir",
+                str(unlock_dir),
+                "--out",
+                str(out),
+            ],
+            cwd=ROOT,
+            check=True,
+        )
+        text = out.read_text(encoding="utf-8")
+
+    required = ["SUPPORT_USD=10.0", "RANK_2_UNLOCKED=true", "RANK_3_UNLOCKED=true"]
+    missing = [item for item in required if item not in text]
+    if missing:
+        raise SystemExit(f"missing resolver output: {missing}")
+
+    print("support unlock resolver test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_select_eligible_support_unlock.py
+++ b/scripts/test_select_eligible_support_unlock.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "select_eligible.py"
+
+
+def main() -> int:
+    candidates = [
+        {"rank": 1, "issue_number": 101, "vote_count": 25, "candidate_type": "prompt-proposal", "title": "rank 1", "body": "rank 1"},
+        {"rank": 2, "issue_number": 102, "vote_count": 12, "candidate_type": "prompt-proposal", "title": "rank 2", "body": "rank 2"},
+        {"rank": 3, "issue_number": 103, "vote_count": 8, "candidate_type": "prompt-proposal", "title": "rank 3", "body": "rank 3"},
+        {"rank": 4, "issue_number": 0, "vote_count": 20, "candidate_type": "no-change-baseline", "title": "baseline", "body": "baseline"},
+    ]
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        (tmp_path / "data" / "support-unlocks").mkdir(parents=True)
+        (tmp_path / "data" / "support-unlocks" / "2026-W20.json").write_text(
+            json.dumps({"support_total_usd": 10, "rank_2_unlocked": True, "rank_3_unlocked": True}),
+            encoding="utf-8",
+        )
+        input_path = tmp_path / "candidates.json"
+        out_path = tmp_path / "eligible.json"
+        meta_path = tmp_path / "meta.json"
+        flag_path = tmp_path / "flag.txt"
+        input_path.write_text(json.dumps(candidates), encoding="utf-8")
+        subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--candidates",
+                str(input_path),
+                "--support-usd",
+                "0",
+                "--week",
+                "week-2026-W20",
+                "--out",
+                str(out_path),
+                "--flag",
+                str(flag_path),
+                "--meta",
+                str(meta_path),
+            ],
+            cwd=tmp_path,
+            check=True,
+        )
+        eligible = json.loads(out_path.read_text(encoding="utf-8"))
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+
+    ranks = [item["rank"] for item in eligible]
+    if ranks != [1, 2, 3]:
+        raise SystemExit(f"expected ranks 1,2,3 from support unlock file, got {ranks}")
+    if meta["support_usd"] != 10:
+        raise SystemExit(f"expected support_usd 10, got {meta['support_usd']}")
+    print("eligible selector support unlock test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_support_unlock_workflow_contract.py
+++ b/scripts/test_support_unlock_workflow_contract.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SUPPORT_WORKFLOW = ROOT / ".github" / "workflows" / "support-unlock-export.yml"
+WEEKLY_WORKFLOW = ROOT / ".github" / "workflows" / "weekly-auto-run.yml"
+SCRIPT_CHECK = ROOT / ".github" / "workflows" / "script-check.yml"
+
+
+def require(text: str, required: list[str], label: str) -> None:
+    missing = [item for item in required if item not in text]
+    if missing:
+        raise SystemExit(f"{label}: missing required text: {missing}")
+
+
+def reject(text: str, forbidden: list[str], label: str) -> None:
+    found = [item for item in forbidden if item in text]
+    if found:
+        raise SystemExit(f"{label}: forbidden text found: {found}")
+
+
+def main() -> int:
+    support = SUPPORT_WORKFLOW.read_text(encoding="utf-8")
+    weekly = WEEKLY_WORKFLOW.read_text(encoding="utf-8")
+    script_check = SCRIPT_CHECK.read_text(encoding="utf-8")
+
+    require(
+        support,
+        [
+            "name: Support Unlock Export",
+            "schedule:",
+            "workflow_dispatch:",
+            "SPONSORS_GRAPHQL_TOKEN",
+            "scripts/fetch_support_activities.py",
+            "scripts/build_support_unlocks.py",
+            "data/support-unlocks",
+            "git add data/support-unlocks/",
+        ],
+        "support workflow",
+    )
+    reject(
+        support,
+        [
+            "OPENAI_API_KEY",
+            "codex exec",
+            "gh pr merge",
+            "lab/index.html",
+            "lab/style.css",
+            "lab/app.js",
+        ],
+        "support workflow",
+    )
+
+    require(
+        weekly,
+        [
+            "Resolve automated support unlocks",
+            "scripts/resolve_support_unlock.py",
+            "SUPPORT_UNLOCK_WEEK",
+            "RANK_2_UNLOCKED",
+            "RANK_3_UNLOCKED",
+            "--week \"$RUN_WEEK\"",
+        ],
+        "weekly workflow",
+    )
+
+    require(
+        script_check,
+        [
+            "Run support unlock builder test",
+            "python scripts/test_build_support_unlocks.py",
+            "Run support unlock workflow contract test",
+            "python scripts/test_support_unlock_workflow_contract.py",
+            "Run eligible selector support unlock test",
+            "python scripts/test_select_eligible_support_unlock.py",
+            "Run support unlock resolver test",
+            "python scripts/test_resolve_support_unlock.py",
+        ],
+        "script check",
+    )
+
+    print("support unlock workflow contract test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_unlock_export_public.py
+++ b/scripts/test_unlock_export_public.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+
+def main() -> int:
+    print("unlock export smoke test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/support-activities-w20.json
+++ b/tests/fixtures/support-activities-w20.json
@@ -1,0 +1,65 @@
+{
+  "data": {
+    "user": {
+      "sponsorsActivities": {
+        "nodes": [
+          {
+            "action": "NEW_SPONSORSHIP",
+            "timestamp": "2026-05-05T12:00:00Z",
+            "sponsorsTier": {
+              "isOneTime": true,
+              "monthlyPriceInCents": 500
+            },
+            "sponsor": {
+              "login": "private-sponsor-one"
+            }
+          },
+          {
+            "action": "NEW_SPONSORSHIP",
+            "timestamp": "2026-05-06T12:00:00Z",
+            "sponsorsTier": {
+              "isOneTime": true,
+              "monthlyPriceInCents": 500
+            },
+            "sponsor": {
+              "login": "private-sponsor-two"
+            }
+          },
+          {
+            "action": "CANCELLED_SPONSORSHIP",
+            "timestamp": "2026-05-06T13:00:00Z",
+            "sponsorsTier": {
+              "isOneTime": true,
+              "monthlyPriceInCents": 500
+            },
+            "sponsor": {
+              "login": "ignored-cancel"
+            }
+          },
+          {
+            "action": "NEW_SPONSORSHIP",
+            "timestamp": "2026-05-01T12:00:00Z",
+            "sponsorsTier": {
+              "isOneTime": true,
+              "monthlyPriceInCents": 1000
+            },
+            "sponsor": {
+              "login": "ignored-old"
+            }
+          },
+          {
+            "action": "NEW_SPONSORSHIP",
+            "timestamp": "2026-05-07T12:00:00Z",
+            "sponsorsTier": {
+              "isOneTime": false,
+              "monthlyPriceInCents": 1000
+            },
+            "sponsor": {
+              "login": "ignored-recurring"
+            }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Automates support-unlocked comparison run eligibility using anonymized weekly support aggregates.

## Why

The support policy already defines these thresholds:

- 5 USD total weekly one-time support unlocks rank 2 comparison run
- 10 USD total weekly one-time support unlocks rank 3 comparison run

Before this change, weekly automation still depended on a manual `PROMPT_VOTE_LAB_SUPPORT_USD` variable. That is not fully automatic.

## Changes

- Add `scripts/fetch_support_activities.py` to fetch GitHub Sponsors activity through GraphQL.
- Add `scripts/build_support_unlocks.py` to turn raw activity into an anonymized aggregate file under `data/support-unlocks/<week>.json`.
- Add `scripts/resolve_support_unlock.py` so weekly runs can read the aggregate unlock file.
- Update `scripts/select_eligible.py` so support unlock files override manual support amount input.
- Add `support-unlock-export.yml` to periodically export anonymized support unlock files.
- Update `weekly-auto-run.yml` to resolve automated support unlocks before selecting eligible ranks.
- Add fixture and tests for support unlock totals, resolver behavior, weekly selector behavior, and workflow wiring.
- Document the support unlock automation privacy boundary.

## Privacy / safety boundary

- Raw activity payload is written only under `tmp/` during workflow execution.
- Only anonymized aggregate data is committed.
- Public output must not include sponsor login, name, email, individual events, or per-supporter amounts.
- Missing token or fetch failure must fail visibly; the workflow must not guess unlocks.

## Required repository setup after merge

Configure repository secret:

```text
SPONSORS_GRAPHQL_TOKEN
```

The token should use the least permissions that can read GitHub Sponsors activity for the maintainer account.

## Scope

- No root `lab/` implementation changes.
- No generated comparison evidence changes in this PR.
- No OpenAI/Codex behavior changes.
- Merge remains manual.