### PR TITLE
Require support unlock data before weekly runs

### DIFF
--- a/.github/workflows/weekly-auto-run.yml
+++ b/.github/workflows/weekly-auto-run.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Resolve automated support unlocks
         run: |
-          python scripts/resolve_support_unlock.py --week "$RUN_WEEK" --out .tmp/support-unlock-env.txt
+          python scripts/resolve_support_unlock.py --week "$RUN_WEEK" --require --out .tmp/support-unlock-env.txt
           cat .tmp/support-unlock-env.txt >> "$GITHUB_ENV"
 
       - name: Collect prompt proposal votes
@@ -81,7 +81,7 @@ jobs:
             echo ""
             echo "## Support unlock source"
             echo ""
-            echo "${SUPPORT_UNLOCK_WEEK:-unrecorded} / rank2=${RANK_2_UNLOCKED:-false} / rank3=${RANK_3_UNLOCKED:-false}"
+            echo "${SUPPORT_UNLOCK_WEEK:-unrecorded} / ${SUPPORT_UNLOCK_FILE:-missing} / rank2=${RANK_2_UNLOCKED:-false} / rank3=${RANK_3_UNLOCKED:-false}"
             echo ""
             echo "## No-change baseline"
             echo ""

--- a/docs/support-unlock-automation.md
+++ b/docs/support-unlock-automation.md
@@ -77,6 +77,18 @@ If the generated file changes, the workflow commits it directly to `main`. If no
 
 Manual backfill must use the same privacy boundary as scheduled export: no sponsor identity, no per-supporter amount, and no raw activity payload committed.
 
+## Weekly run gate
+
+`Weekly Auto Run` must resolve the support unlock file before vote collection and candidate selection.
+
+Required file pattern:
+
+```text
+data/support-unlocks/<week-id>.json
+```
+
+If the file for `RUN_WEEK` is missing, `Weekly Auto Run` must fail before selecting eligible ranks. It must not silently treat missing support data as 0 USD, because that would undercount support and could wrongly suppress rank 2 or rank 3 comparison runs.
+
 ## CI contract
 
 Script Check must run:
@@ -97,6 +109,7 @@ Those tests verify:
 - sponsor identities from the raw fixture are not present in the public output
 - weekly selection can read `data/support-unlocks/<week-id>.json`
 - the support export workflow keeps manual `week_id`, `since`, and `until` inputs wired
+- the weekly workflow requires the support unlock file before selecting eligible ranks
 
 ## Failure mode
 

--- a/scripts/resolve_support_unlock.py
+++ b/scripts/resolve_support_unlock.py
@@ -16,6 +16,7 @@ def main() -> int:
     parser.add_argument("--week", required=True)
     parser.add_argument("--dir", default="data/support-unlocks")
     parser.add_argument("--out", default=".tmp/support-unlock-env.txt")
+    parser.add_argument("--require", action="store_true", help="fail when the weekly support unlock file is missing")
     args = parser.parse_args()
 
     week_id = normalize_week_id(args.week)
@@ -29,17 +30,24 @@ def main() -> int:
         support_total_usd = float(data.get("support_total_usd") or 0)
         rank_2 = bool(data.get("rank_2_unlocked"))
         rank_3 = bool(data.get("rank_3_unlocked"))
+    elif args.require:
+        raise SystemExit(
+            f"Missing required support unlock file: {path}. "
+            "Run Support Unlock Export before Weekly Auto Run."
+        )
 
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(
         "SUPPORT_UNLOCK_WEEK=" + week_id + "\n"
+        + "SUPPORT_UNLOCK_FILE=" + str(path) + "\n"
         + "SUPPORT_USD=" + str(support_total_usd) + "\n"
         + "RANK_2_UNLOCKED=" + ("true" if rank_2 else "false") + "\n"
         + "RANK_3_UNLOCKED=" + ("true" if rank_3 else "false") + "\n",
         encoding="utf-8",
     )
     print(f"support_unlock_week={week_id}")
+    print(f"support_unlock_file={path}")
     print(f"support_usd={support_total_usd}")
     print(f"rank_2_unlocked={rank_2}")
     print(f"rank_3_unlocked={rank_3}")

--- a/scripts/test_resolve_support_unlock.py
+++ b/scripts/test_resolve_support_unlock.py
@@ -32,21 +32,52 @@ def main() -> int:
                 sys.executable,
                 str(SCRIPT),
                 "--week",
-                "2026-W20",
+                "week-2026-W20",
                 "--dir",
                 str(unlock_dir),
                 "--out",
                 str(out),
+                "--require",
             ],
             cwd=ROOT,
             check=True,
         )
         text = out.read_text(encoding="utf-8")
 
-    required = ["SUPPORT_USD=10.0", "RANK_2_UNLOCKED=true", "RANK_3_UNLOCKED=true"]
+        missing_result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--week",
+                "week-2026-W21",
+                "--dir",
+                str(unlock_dir),
+                "--out",
+                str(base / "missing-env.txt"),
+                "--require",
+            ],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+    required = [
+        "SUPPORT_UNLOCK_WEEK=2026-W20",
+        "SUPPORT_UNLOCK_FILE=",
+        "SUPPORT_USD=10.0",
+        "RANK_2_UNLOCKED=true",
+        "RANK_3_UNLOCKED=true",
+    ]
     missing = [item for item in required if item not in text]
     if missing:
         raise SystemExit(f"missing resolver output: {missing}")
+
+    if missing_result.returncode == 0:
+        raise SystemExit("--require should fail when the weekly support unlock file is missing")
+    if "Missing required support unlock file" not in (missing_result.stdout + missing_result.stderr):
+        raise SystemExit("missing required support unlock failure message was not emitted")
 
     print("support unlock resolver test passed")
     return 0

--- a/scripts/test_support_unlock_workflow_contract.py
+++ b/scripts/test_support_unlock_workflow_contract.py
@@ -62,9 +62,11 @@ def main() -> int:
             "Resolve automated support unlocks",
             "scripts/resolve_support_unlock.py",
             "SUPPORT_UNLOCK_WEEK",
+            "SUPPORT_UNLOCK_FILE",
             "RANK_2_UNLOCKED",
             "RANK_3_UNLOCKED",
             "--week \"$RUN_WEEK\"",
+            "--require",
         ],
         "weekly workflow",
     )


### PR DESCRIPTION
## Summary

Stops `Weekly Auto Run` from silently treating missing weekly support data as 0 USD.

## Why

Support unlocks now determine whether rank 2 and rank 3 comparison runs are eligible. If `data/support-unlocks/<week-id>.json` is missing, treating that as 0 USD can undercount support and suppress comparison runs that should have been unlocked.

## Changes

- Add `--require` to `scripts/resolve_support_unlock.py`.
- Use `--require` in `weekly-auto-run.yml` before vote collection and candidate selection.
- Include `SUPPORT_UNLOCK_FILE` in weekly vote summary output.
- Extend resolver tests to verify missing required support unlock data fails.
- Extend support unlock workflow contract tests so the weekly gate cannot be removed silently.
- Document the weekly support unlock gate.

## Scope

- No root `lab/` changes.
- No generated evidence changes.
- No model/API run behavior changes.
- No sponsor identity or event-level data changes.