### PR TITLE
Validate support unlock output before committing

### DIFF
--- a/.github/workflows/support-unlock-export.yml
+++ b/.github/workflows/support-unlock-export.yml
@@ -71,6 +71,9 @@ jobs:
             --until "${{ steps.window.outputs.until }}" \
             --out-dir data/support-unlocks
 
+      - name: Validate public support unlock output
+        run: python scripts/test_unlock_export_public.py
+
       - name: Verify support unlock tooling
         run: python scripts/test_build_support_unlocks.py
 

--- a/scripts/test_support_unlock_workflow_contract.py
+++ b/scripts/test_support_unlock_workflow_contract.py
@@ -38,6 +38,8 @@ def main() -> int:
             "SPONSORS_GRAPHQL_TOKEN",
             "scripts/fetch_support_activities.py",
             "scripts/build_support_unlocks.py",
+            "Validate public support unlock output",
+            "python scripts/test_unlock_export_public.py",
             "data/support-unlocks",
             "git add data/support-unlocks/",
         ],
@@ -86,6 +88,9 @@ def main() -> int:
         ],
         "script check",
     )
+
+    if support.index("Validate public support unlock output") > support.index("Commit support unlocks"):
+        raise SystemExit("public support unlock output must be validated before commit")
 
     print("support unlock workflow contract test passed")
     return 0


### PR DESCRIPTION
## Summary

Runs public support unlock JSON validation inside `Support Unlock Export` before committing generated support unlock files.

## Why

Script Check validates public support unlock files on PRs, but the live export workflow should also validate the generated public JSON before it commits to `main`. Otherwise a bad live payload could be committed first and only detected later.

## Changes

- Add `Validate public support unlock output` step after building support unlocks and before committing them.
- Run `python scripts/test_unlock_export_public.py` in the export workflow.
- Extend the support unlock workflow contract test so this step is required and must appear before `Commit support unlocks`.

## Scope

- No root `lab/` changes.
- No generated evidence changes.
- No Sponsors query behavior changes.
- No sponsor identity or event-level data added.