### PR TITLE
Document weekly automation schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,25 @@ This cumulative pressure is part of the game and the experiment. Over time, the 
 
 Rejected, failed, unsafe, and unmerged comparison PRs do not become the next week's base state.
 
+## Weekly automation status
+
+Weekly automation is implemented but still requires live production verification.
+
+Scheduled workflows:
+
+- `Support Unlock Export`: every day at 00:17 UTC / 09:17 JST.
+- `Weekly Auto Run`: every Monday at 00:23 UTC / 09:23 JST.
+
+The weekly run requires a matching anonymized support unlock file before vote collection:
+
+```text
+data/support-unlocks/<week-id>.json
+```
+
+If the support unlock file is missing, the weekly run fails before selecting eligible ranks. Missing support data is not treated as 0 USD.
+
+See [`docs/weekly-automation.md`](docs/weekly-automation.md).
+
 ## Weekly loop
 
 1. Players submit prompts as GitHub Issues.
@@ -206,6 +225,7 @@ Key documents:
 
 - [`docs/experiment-model.md`](docs/experiment-model.md) — project concept and boundaries
 - [`docs/how-to-participate.md`](docs/how-to-participate.md) — how to submit, vote, and review as a player
+- [`docs/weekly-automation.md`](docs/weekly-automation.md) — weekly schedule and support unlock prerequisite
 - [`docs/usable-experiment-ops.md`](docs/usable-experiment-ops.md) — current usable manual experiment operations
 - [`docs/no-change-baseline.md`](docs/no-change-baseline.md) — no-change baseline explanation
 - [`docs/support-policy.md`](docs/support-policy.md) — support tiers and thresholds

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ Closed Issues remain visible. They are not deleted.
 
 The repository has scheduled weekly automation and support-unlock gates implemented, but live production verification is still pending.
 
-Manual canary and comparison operations remain available:
+Manual canary experiments and comparison operations remain available:
 
 ```text
 Issue safety scan

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,18 +16,19 @@ Prompt Vote Lab is a prompt game and experiment. Players compete by writing prom
 6. [Issue lifecycle](./issue-lifecycle.md) — weekly close policy; Issues are closed, not deleted.
 7. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
 8. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
-9. [Automation map](./automation-map.md) — workflow boundaries.
-10. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
-11. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
-12. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and pre-canary cleanup.
-13. [Fixed first canary prompt](./first-canary-prompt.md) — the only allowed first real canary prompt.
-14. [First canary readiness checklist](./first-canary-readiness.md) — final check before running the first real canary.
-15. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
-16. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
-17. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
-18. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
-19. [Report policy](./report-policy.md) — weekly report draft policy.
-20. [Pre-API freeze checklist](./pre-api-freeze.md) — gates before paid agent runs.
+9. [Weekly automation](./weekly-automation.md) — weekly schedule, support unlock prerequisite, and E2E status.
+10. [Automation map](./automation-map.md) — workflow boundaries.
+11. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
+12. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
+13. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and pre-canary cleanup.
+14. [Fixed first canary prompt](./first-canary-prompt.md) — the only allowed first real canary prompt.
+15. [First canary readiness checklist](./first-canary-readiness.md) — final check before running the first real canary.
+16. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
+17. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
+18. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
+19. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
+20. [Report policy](./report-policy.md) — weekly report draft policy.
+21. [Pre-API freeze checklist](./pre-api-freeze.md) — gates before paid agent runs.
 
 ## Current reputation status
 
@@ -79,7 +80,9 @@ Closed Issues remain visible. They are not deleted.
 
 ## Current usable experiment status
 
-The repository is currently usable for manual canary experiments:
+The repository has scheduled weekly automation and support-unlock gates implemented, but live production verification is still pending.
+
+Manual canary and comparison operations remain available:
 
 ```text
 Issue safety scan
@@ -91,7 +94,7 @@ Issue safety scan
 → runs/ record
 ```
 
-It is not yet a fully automatic weekly production system.
+Scheduled weekly automation is documented in [Weekly automation](./weekly-automation.md). It still requires live `SPONSORS_GRAPHQL_TOKEN` verification and Weekly Auto Run E2E verification before it should be called fully production-verified.
 
 ## Pre-API freeze status
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ Closed Issues remain visible. They are not deleted.
 
 The repository has scheduled weekly automation and support-unlock gates implemented, but live production verification is still pending.
 
-Manual canary experiments and comparison operations remain available:
+manual canary experiments and comparison operations remain available:
 
 ```text
 Issue safety scan

--- a/docs/automation-map.md
+++ b/docs/automation-map.md
@@ -41,6 +41,8 @@ The project may automate:
 - weekly public briefing draft artifact creation
 - event log artifact creation
 - HN/blog/report draft artifact creation
+- anonymized support unlock export
+- support unlock file validation before export commit
 
 ## Not automated
 
@@ -56,20 +58,40 @@ The project must not automate:
 
 ## Main workflows
 
-| Workflow | Status | Purpose | API cost |
-|---|---|---|---:|
-| `setup-labels.yml` | implemented | Create project labels | 0 |
-| `safety-check.yml` | implemented | Check lab PRs when PR-triggered checks run | 0 |
-| `static-site-check.yml` | implemented | Check public page structure, support wording, and lab smoke expectations | 0 |
-| `lab-pr-scope-check.yml` | implemented | Prevent lab implementation PRs from mixing lab and non-lab files | 0 |
-| `script-check.yml` | implemented | Check scripts, offline workflow smoke tests, and lab scope guard tests | 0 |
-| `evidence-pipeline-dry-run.yml` | implemented | Manually generate snapshot, run log, weekly summary, public briefing, and HN draft as artifact | 0 |
-| `exception-matrix-test.yml` | implemented | Test known pass/fail boundary cases | 0 |
-| `multi-fuzz-test.yml` | implemented | Run weighted random boundary mutations | 0 |
-| `weekly-mock-run.yml` | implemented | Test weekly selection and PR creation without model API calls | 0 |
-| `weekly-auto-run.yml` | implemented, not fully production-verified | Collect votes and create implementation PRs for eligible prompts | paid only if eligible |
-| `blog-report.yml` | implemented, not fully production-verified | Generate report PRs from recorded run data | paid when manually confirmed |
-| `terminal-state-report.yml` | implemented | Record final PR state from labels | 0 |
+| Workflow | Status | Schedule | Purpose | API cost |
+|---|---|---|---|---:|
+| `setup-labels.yml` | implemented | manual | Create project labels | 0 |
+| `safety-check.yml` | implemented | PR/path-triggered | Check lab PRs when PR-triggered checks run | 0 |
+| `static-site-check.yml` | implemented | PR/path-triggered | Check public page structure, support wording, and lab smoke expectations | 0 |
+| `lab-pr-scope-check.yml` | implemented | PR/path-triggered | Prevent lab implementation PRs from mixing lab and non-lab files | 0 |
+| `script-check.yml` | implemented | PR/path-triggered + manual | Check scripts, offline workflow smoke tests, and workflow contracts | 0 |
+| `support-unlock-export.yml` | implemented, live-token verification pending | daily 00:17 UTC / 09:17 JST + manual | Export anonymized support unlock aggregates and validate them before commit | 0 |
+| `weekly-auto-run.yml` | implemented, not fully production-verified | Monday 00:23 UTC / 09:23 JST + manual | Collect votes and create implementation PRs for eligible prompts | paid only if eligible |
+| `evidence-pipeline-dry-run.yml` | implemented | manual | Manually generate snapshot, run log, weekly summary, public briefing, and HN draft as artifact | 0 |
+| `exception-matrix-test.yml` | implemented | PR/manual | Test known pass/fail boundary cases | 0 |
+| `multi-fuzz-test.yml` | implemented | PR/manual | Run weighted random boundary mutations | 0 |
+| `weekly-mock-run.yml` | implemented | manual | Test weekly selection and PR creation without model API calls | 0 |
+| `blog-report.yml` | implemented, not fully production-verified | manual | Generate report PRs from recorded run data | paid when manually confirmed |
+| `terminal-state-report.yml` | implemented | PR/label-triggered | Record final PR state from labels | 0 |
+
+## Scheduled weekly path
+
+The scheduled production path is split into two workflows:
+
+```text
+Support Unlock Export
+→ data/support-unlocks/<week-id>.json
+→ Weekly Auto Run
+→ vote summary PR
+→ implementation PRs, if eligible
+→ manual review/merge
+```
+
+`Support Unlock Export` runs daily and writes only anonymized aggregate data. It validates public support unlock JSON before committing.
+
+`Weekly Auto Run` runs every Monday. It requires the matching support unlock file for `RUN_WEEK` before collecting votes. Missing support data is a hard failure, not 0 USD.
+
+See [`weekly-automation.md`](weekly-automation.md).
 
 ## Important GitHub Actions caveat
 

--- a/docs/weekly-automation.md
+++ b/docs/weekly-automation.md
@@ -1,0 +1,145 @@
+# Weekly automation
+
+This document explains what runs automatically, when it runs, and what must exist before each weekly run can proceed.
+
+## Short answer
+
+Yes. `Weekly Auto Run` is scheduled to run every week.
+
+```text
+.github/workflows/weekly-auto-run.yml
+cron: 23 0 * * 1
+```
+
+That means:
+
+```text
+Monday 00:23 UTC
+Monday 09:23 JST
+```
+
+It can also be started manually with `workflow_dispatch`.
+
+## Related scheduled workflow
+
+Support unlock aggregation is a separate workflow.
+
+```text
+.github/workflows/support-unlock-export.yml
+cron: 17 0 * * *
+```
+
+That means:
+
+```text
+every day 00:17 UTC
+every day 09:17 JST
+```
+
+The support export workflow writes the anonymized aggregate file used by the weekly run:
+
+```text
+data/support-unlocks/<week-id>.json
+```
+
+## Weekly run order
+
+`Weekly Auto Run` runs in this order:
+
+```text
+1. checkout repository
+2. set RUN_WEEK as week-<ISO-year>-W<ISO-week>
+3. require data/support-unlocks/<week-id>.json
+4. collect prompt proposal votes
+5. insert no-change baseline
+6. select eligible ranks
+7. write weekly vote summary PR
+8. if eligible candidates exist, require implementation secret
+9. preflight the implementation run
+10. create implementation PRs for eligible candidates
+```
+
+The support unlock file is required before vote collection and rank selection.
+
+If the file is missing, the weekly workflow fails before selecting eligible ranks. It must not silently treat missing support data as 0 USD.
+
+## Why support export is separate
+
+Support aggregation and prompt implementation are different jobs.
+
+Support export:
+
+- reads GitHub Sponsors activity
+- writes only anonymized weekly aggregate data
+- validates public JSON before commit
+- must not call the implementation model
+- must not modify `lab/`
+
+Weekly auto run:
+
+- reads prompt Issues and reactions
+- reads the weekly support unlock file
+- creates vote summary PRs
+- creates implementation PRs only when candidates are eligible
+- must not merge PRs automatically
+
+## Time-window caveat
+
+Both workflows use UTC ISO weeks.
+
+`Weekly Auto Run` uses:
+
+```text
+RUN_WEEK=week-$(date -u +%G-W%V)
+```
+
+`Support Unlock Export` writes:
+
+```text
+data/support-unlocks/<ISO-year>-W<ISO-week>.json
+```
+
+The resolver normalizes these two forms:
+
+```text
+week-2026-W20 -> 2026-W20
+```
+
+The weekly workflow requires the matching support unlock file for its `RUN_WEEK`.
+
+## Manual verification
+
+Before trusting the scheduled path, run `Support Unlock Export` manually after `SPONSORS_GRAPHQL_TOKEN` is configured.
+
+Example:
+
+```text
+week_id: 2026-W20
+since: 2026-05-04T00:00:00Z
+until: 2026-05-11T00:00:00Z
+```
+
+Expected public output:
+
+```text
+data/support-unlocks/2026-W20.json
+```
+
+Then run `Weekly Auto Run` manually and confirm that it reads the support unlock file before vote collection.
+
+## Merge policy
+
+Automation may create PRs, but it must not merge them.
+
+`main` merge remains manual.
+
+## Current production status
+
+The schedules and gates are implemented.
+
+Still required before calling this fully production-verified:
+
+- configure `SPONSORS_GRAPHQL_TOKEN`
+- run `Support Unlock Export` against live Sponsors data
+- confirm public support unlock JSON validation passes
+- run `Weekly Auto Run` end-to-end with the generated unlock file


### PR DESCRIPTION
## Summary

Clarifies that Prompt Vote Lab has scheduled weekly automation, and documents how it depends on the support unlock export workflow.

## Why

The implementation already schedules:

- `Support Unlock Export`: daily at 00:17 UTC / 09:17 JST
- `Weekly Auto Run`: Mondays at 00:23 UTC / 09:23 JST

But the public docs did not clearly explain the relationship between the daily support export, the weekly run, the required `data/support-unlocks/<week-id>.json` file, and the still-pending live verification status.

## Changes

- Add `docs/weekly-automation.md` with the schedule, run order, support unlock prerequisite, and production-verification status.
- Update root `README.md` with a concise weekly automation section.
- Update `docs/README.md` to link the new document and clarify current usable status.
- Update `docs/automation-map.md` to list `support-unlock-export.yml`, schedules, and the scheduled weekly path.

## Scope

- Documentation only.
- No root `lab/` changes.
- No workflow behavior changes.
- No generated evidence changes.