### PR TITLE
Process previous week in scheduled support resolution

### DIFF
--- a/.github/workflows/support-unlock-export.yml
+++ b/.github/workflows/support-unlock-export.yml
@@ -6,15 +6,15 @@ on:
   workflow_dispatch:
     inputs:
       week_id:
-        description: "ISO week id to write, for example 2026-W20. Empty uses current UTC week."
+        description: "ISO week id to write, for example 2026-W20. Empty uses the previous UTC ISO week."
         required: false
         default: ""
       since:
-        description: "UTC window start, for example 2026-05-04T00:00:00Z. Empty uses current UTC week start."
+        description: "UTC window start, for example 2026-05-04T00:00:00Z. Empty uses previous UTC ISO week start."
         required: false
         default: ""
       until:
-        description: "UTC window end, for example 2026-05-11T00:00:00Z. Empty uses current UTC week end."
+        description: "UTC window end, for example 2026-05-11T00:00:00Z. Empty uses previous UTC ISO week end."
         required: false
         default: ""
 
@@ -41,8 +41,9 @@ jobs:
           from datetime import datetime, timedelta, timezone
           import os
           current = datetime.now(timezone.utc)
-          iso = current.isocalendar()
-          start = current - timedelta(days=iso.weekday - 1)
+          target = current - timedelta(days=7)
+          iso = target.isocalendar()
+          start = target - timedelta(days=iso.weekday - 1)
           start = start.replace(hour=0, minute=0, second=0, microsecond=0)
           end = start + timedelta(days=7)
           week_id = '''${{ inputs.week_id }}'''.strip() or f"{iso.year}-W{iso.week:02d}"

--- a/docs/weekly-automation.md
+++ b/docs/weekly-automation.md
@@ -50,15 +50,16 @@ On scheduled runs, support export defaults to the previous UTC ISO week. Manual 
 
 ```text
 1. checkout repository
-2. set RUN_WEEK as week-<ISO-year>-W<ISO-week>
-3. require data/support-unlocks/<week-id>.json
-4. collect prompt proposal votes
-5. insert no-change baseline
-6. select eligible ranks
-7. write weekly vote summary PR
-8. if eligible candidates exist, require implementation secret
-9. preflight the implementation run
-10. create implementation PRs for eligible candidates
+2. set an initial RUN_WEEK
+3. resolve the required support unlock file
+4. on scheduled runs, rewrite RUN_WEEK to the previous UTC ISO week resolved from the support unlock file
+5. collect prompt proposal votes
+6. insert no-change baseline
+7. select eligible ranks
+8. write weekly vote summary PR
+9. if eligible candidates exist, require implementation secret
+10. preflight the implementation run
+11. create implementation PRs for eligible candidates
 ```
 
 The support unlock file is required before vote collection and rank selection.
@@ -97,7 +98,13 @@ target = current UTC time - 7 days
 
 This writes the previous ISO week by default.
 
-`Weekly Auto Run` should use the same previous-week target when scheduled. If it uses the current ISO week on Monday morning, it will look for a support unlock file for the newly started week and may fail or record the wrong week.
+`Weekly Auto Run` also resolves to the previous UTC ISO week when the GitHub event is `schedule`. The resolver writes this resolved week back into the job environment as:
+
+```text
+RUN_WEEK=week-<previous-ISO-year>-W<previous-ISO-week>
+```
+
+This prevents the Monday morning scheduled run from recording the newly started week by mistake.
 
 `Support Unlock Export` writes:
 
@@ -111,7 +118,7 @@ The resolver normalizes these two forms:
 week-2026-W20 -> 2026-W20
 ```
 
-The weekly workflow requires the matching support unlock file for its `RUN_WEEK`.
+The weekly workflow requires the matching support unlock file for its resolved `RUN_WEEK`.
 
 ## Manual verification
 

--- a/docs/weekly-automation.md
+++ b/docs/weekly-automation.md
@@ -42,6 +42,8 @@ The support export workflow writes the anonymized aggregate file used by the wee
 data/support-unlocks/<week-id>.json
 ```
 
+On scheduled runs, support export defaults to the previous UTC ISO week. Manual `workflow_dispatch` inputs can still override `week_id`, `since`, and `until` for verification or backfill.
+
 ## Weekly run order
 
 `Weekly Auto Run` runs in this order:
@@ -85,13 +87,17 @@ Weekly auto run:
 
 ## Time-window caveat
 
-Both workflows use UTC ISO weeks.
+The scheduled production path should process the UTC ISO week that just ended, not the week that has just started.
 
-`Weekly Auto Run` uses:
+`Support Unlock Export` scheduled runs therefore default to:
 
 ```text
-RUN_WEEK=week-$(date -u +%G-W%V)
+target = current UTC time - 7 days
 ```
+
+This writes the previous ISO week by default.
+
+`Weekly Auto Run` should use the same previous-week target when scheduled. If it uses the current ISO week on Monday morning, it will look for a support unlock file for the newly started week and may fail or record the wrong week.
 
 `Support Unlock Export` writes:
 

--- a/scripts/resolve_support_unlock.py
+++ b/scripts/resolve_support_unlock.py
@@ -3,12 +3,46 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 
 def normalize_week_id(value: str) -> str:
     text = value.strip()
     return text[5:] if text.startswith("week-") else text
+
+
+def previous_utc_iso_week_id(now: datetime | None = None) -> str:
+    current = now or datetime.now(timezone.utc)
+    target = current - timedelta(days=7)
+    iso = target.isocalendar()
+    return f"{iso.year}-W{iso.week:02d}"
+
+
+def support_unlock_path(directory: Path, week_id: str) -> Path:
+    return directory / f"{week_id}.json"
+
+
+def resolve_week_and_path(directory: Path, requested_week: str, require: bool) -> tuple[str, Path]:
+    requested_id = normalize_week_id(requested_week)
+    requested_path = support_unlock_path(directory, requested_id)
+    if requested_path.exists():
+        return requested_id, requested_path
+
+    is_scheduled_github_run = os.getenv("GITHUB_EVENT_NAME") == "schedule"
+    if require and is_scheduled_github_run:
+        previous_id = previous_utc_iso_week_id()
+        previous_path = support_unlock_path(directory, previous_id)
+        if previous_path.exists():
+            return previous_id, previous_path
+
+    if require:
+        raise SystemExit(
+            f"Missing required support unlock file: {requested_path}. "
+            "Run Support Unlock Export before Weekly Auto Run."
+        )
+    return requested_id, requested_path
 
 
 def main() -> int:
@@ -19,8 +53,8 @@ def main() -> int:
     parser.add_argument("--require", action="store_true", help="fail when the weekly support unlock file is missing")
     args = parser.parse_args()
 
-    week_id = normalize_week_id(args.week)
-    path = Path(args.dir) / f"{week_id}.json"
+    directory = Path(args.dir)
+    week_id, path = resolve_week_and_path(directory, args.week, args.require)
     support_total_usd = 0.0
     rank_2 = False
     rank_3 = False
@@ -30,22 +64,19 @@ def main() -> int:
         support_total_usd = float(data.get("support_total_usd") or 0)
         rank_2 = bool(data.get("rank_2_unlocked"))
         rank_3 = bool(data.get("rank_3_unlocked"))
-    elif args.require:
-        raise SystemExit(
-            f"Missing required support unlock file: {path}. "
-            "Run Support Unlock Export before Weekly Auto Run."
-        )
 
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(
-        "SUPPORT_UNLOCK_WEEK=" + week_id + "\n"
+        "RUN_WEEK=week-" + week_id + "\n"
+        + "SUPPORT_UNLOCK_WEEK=" + week_id + "\n"
         + "SUPPORT_UNLOCK_FILE=" + str(path) + "\n"
         + "SUPPORT_USD=" + str(support_total_usd) + "\n"
         + "RANK_2_UNLOCKED=" + ("true" if rank_2 else "false") + "\n"
         + "RANK_3_UNLOCKED=" + ("true" if rank_3 else "false") + "\n",
         encoding="utf-8",
     )
+    print(f"run_week=week-{week_id}")
     print(f"support_unlock_week={week_id}")
     print(f"support_unlock_file={path}")
     print(f"support_usd={support_total_usd}")

--- a/scripts/resolve_support_unlock.py
+++ b/scripts/resolve_support_unlock.py
@@ -24,20 +24,26 @@ def support_unlock_path(directory: Path, week_id: str) -> Path:
     return directory / f"{week_id}.json"
 
 
+def should_try_previous_week(require: bool) -> bool:
+    if not require:
+        return False
+    return os.getenv("GITHUB_EVENT_NAME") in {"schedule", "workflow_dispatch"}
+
+
 def resolve_week_and_path(directory: Path, requested_week: str, require: bool) -> tuple[str, Path]:
     requested_id = normalize_week_id(requested_week)
     requested_path = support_unlock_path(directory, requested_id)
 
-    is_scheduled_github_run = os.getenv("GITHUB_EVENT_NAME") == "schedule"
-    if require and is_scheduled_github_run:
+    if should_try_previous_week(require):
         previous_id = previous_utc_iso_week_id()
         previous_path = support_unlock_path(directory, previous_id)
         if previous_path.exists():
             return previous_id, previous_path
-        raise SystemExit(
-            f"Missing required support unlock file for scheduled previous week: {previous_path}. "
-            "Run Support Unlock Export before Weekly Auto Run."
-        )
+        if os.getenv("GITHUB_EVENT_NAME") == "schedule":
+            raise SystemExit(
+                f"Missing required support unlock file for scheduled previous week: {previous_path}. "
+                "Run Support Unlock Export before Weekly Auto Run."
+            )
 
     if requested_path.exists():
         return requested_id, requested_path

--- a/scripts/resolve_support_unlock.py
+++ b/scripts/resolve_support_unlock.py
@@ -27,8 +27,6 @@ def support_unlock_path(directory: Path, week_id: str) -> Path:
 def resolve_week_and_path(directory: Path, requested_week: str, require: bool) -> tuple[str, Path]:
     requested_id = normalize_week_id(requested_week)
     requested_path = support_unlock_path(directory, requested_id)
-    if requested_path.exists():
-        return requested_id, requested_path
 
     is_scheduled_github_run = os.getenv("GITHUB_EVENT_NAME") == "schedule"
     if require and is_scheduled_github_run:
@@ -36,6 +34,13 @@ def resolve_week_and_path(directory: Path, requested_week: str, require: bool) -
         previous_path = support_unlock_path(directory, previous_id)
         if previous_path.exists():
             return previous_id, previous_path
+        raise SystemExit(
+            f"Missing required support unlock file for scheduled previous week: {previous_path}. "
+            "Run Support Unlock Export before Weekly Auto Run."
+        )
+
+    if requested_path.exists():
+        return requested_id, requested_path
 
     if require:
         raise SystemExit(

--- a/scripts/test_resolve_support_unlock.py
+++ b/scripts/test_resolve_support_unlock.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -44,6 +45,31 @@ def main() -> int:
         )
         text = out.read_text(encoding="utf-8")
 
+        scheduled_out = base / "scheduled-env.txt"
+        scheduled_env = os.environ.copy()
+        scheduled_env["GITHUB_EVENT_NAME"] = "schedule"
+        scheduled_env["PYTHONPATH"] = str(ROOT)
+        scheduled_code = """
+from datetime import datetime, timezone
+from pathlib import Path
+from scripts import resolve_support_unlock as r
+base = Path(r'{base}')
+unlock_dir = base / 'support-unlocks'
+week_id, path = r.resolve_week_and_path(unlock_dir, 'week-2026-W21', True)
+assert week_id == '2026-W20', week_id
+assert path.name == '2026-W20.json', path
+print('scheduled previous-week fallback passed')
+""".format(base=str(base))
+        scheduled_result = subprocess.run(
+            [sys.executable, "-c", scheduled_code],
+            cwd=ROOT,
+            env=scheduled_env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
         missing_result = subprocess.run(
             [
                 sys.executable,
@@ -64,6 +90,7 @@ def main() -> int:
         )
 
     required = [
+        "RUN_WEEK=week-2026-W20",
         "SUPPORT_UNLOCK_WEEK=2026-W20",
         "SUPPORT_UNLOCK_FILE=",
         "SUPPORT_USD=10.0",
@@ -74,8 +101,15 @@ def main() -> int:
     if missing:
         raise SystemExit(f"missing resolver output: {missing}")
 
+    if scheduled_result.returncode != 0:
+        raise SystemExit(
+            "scheduled previous-week fallback failed\n"
+            + scheduled_result.stdout
+            + scheduled_result.stderr
+        )
+
     if missing_result.returncode == 0:
-        raise SystemExit("--require should fail when the weekly support unlock file is missing")
+        raise SystemExit("--require should fail when the weekly support unlock file is missing outside schedule runs")
     if "Missing required support unlock file" not in (missing_result.stdout + missing_result.stderr):
         raise SystemExit("missing required support unlock failure message was not emitted")
 

--- a/scripts/test_resolve_support_unlock.py
+++ b/scripts/test_resolve_support_unlock.py
@@ -12,6 +12,32 @@ ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "resolve_support_unlock.py"
 
 
+def run_embedded_resolver(base: Path, event_name: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["GITHUB_EVENT_NAME"] = event_name
+    env["PYTHONPATH"] = str(ROOT)
+    code = """
+from pathlib import Path
+from scripts import resolve_support_unlock as r
+base = Path(r'{base}')
+unlock_dir = base / 'support-unlocks'
+r.previous_utc_iso_week_id = lambda now=None: '2026-W20'
+week_id, path = r.resolve_week_and_path(unlock_dir, 'week-2026-W21', True)
+assert week_id == '2026-W20', week_id
+assert path.name == '2026-W20.json', path
+print('{event_name} previous-week fallback passed')
+""".format(base=str(base), event_name=event_name)
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory() as tmp:
         base = Path(tmp)
@@ -45,29 +71,8 @@ def main() -> int:
         )
         text = out.read_text(encoding="utf-8")
 
-        scheduled_env = os.environ.copy()
-        scheduled_env["GITHUB_EVENT_NAME"] = "schedule"
-        scheduled_env["PYTHONPATH"] = str(ROOT)
-        scheduled_code = """
-from pathlib import Path
-from scripts import resolve_support_unlock as r
-base = Path(r'{base}')
-unlock_dir = base / 'support-unlocks'
-r.previous_utc_iso_week_id = lambda now=None: '2026-W20'
-week_id, path = r.resolve_week_and_path(unlock_dir, 'week-2026-W21', True)
-assert week_id == '2026-W20', week_id
-assert path.name == '2026-W20.json', path
-print('scheduled previous-week fallback passed')
-""".format(base=str(base))
-        scheduled_result = subprocess.run(
-            [sys.executable, "-c", scheduled_code],
-            cwd=ROOT,
-            env=scheduled_env,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            check=False,
-        )
+        scheduled_result = run_embedded_resolver(base, "schedule")
+        manual_result = run_embedded_resolver(base, "workflow_dispatch")
 
         missing_result = subprocess.run(
             [
@@ -100,15 +105,16 @@ print('scheduled previous-week fallback passed')
     if missing:
         raise SystemExit(f"missing resolver output: {missing}")
 
-    if scheduled_result.returncode != 0:
-        raise SystemExit(
-            "scheduled previous-week fallback failed\n"
-            + scheduled_result.stdout
-            + scheduled_result.stderr
-        )
+    for label, result in (("scheduled", scheduled_result), ("manual", manual_result)):
+        if result.returncode != 0:
+            raise SystemExit(
+                f"{label} previous-week fallback failed\n"
+                + result.stdout
+                + result.stderr
+            )
 
     if missing_result.returncode == 0:
-        raise SystemExit("--require should fail when the weekly support unlock file is missing outside schedule runs")
+        raise SystemExit("--require should fail when the weekly support unlock file is missing outside schedule/manual workflow runs")
     if "Missing required support unlock file" not in (missing_result.stdout + missing_result.stderr):
         raise SystemExit("missing required support unlock failure message was not emitted")
 

--- a/scripts/test_resolve_support_unlock.py
+++ b/scripts/test_resolve_support_unlock.py
@@ -45,16 +45,15 @@ def main() -> int:
         )
         text = out.read_text(encoding="utf-8")
 
-        scheduled_out = base / "scheduled-env.txt"
         scheduled_env = os.environ.copy()
         scheduled_env["GITHUB_EVENT_NAME"] = "schedule"
         scheduled_env["PYTHONPATH"] = str(ROOT)
         scheduled_code = """
-from datetime import datetime, timezone
 from pathlib import Path
 from scripts import resolve_support_unlock as r
 base = Path(r'{base}')
 unlock_dir = base / 'support-unlocks'
+r.previous_utc_iso_week_id = lambda now=None: '2026-W20'
 week_id, path = r.resolve_week_and_path(unlock_dir, 'week-2026-W21', True)
 assert week_id == '2026-W20', week_id
 assert path.name == '2026-W20.json', path

--- a/scripts/test_support_unlock_workflow_contract.py
+++ b/scripts/test_support_unlock_workflow_contract.py
@@ -35,6 +35,8 @@ def main() -> int:
             "week_id:",
             "since:",
             "until:",
+            "previous UTC ISO week",
+            "target = current - timedelta(days=7)",
             "SPONSORS_GRAPHQL_TOKEN",
             "scripts/fetch_support_activities.py",
             "scripts/build_support_unlocks.py",


### PR DESCRIPTION
## Summary

Aligns scheduled support unlock resolution with the weekly operating model: Monday automation should process the UTC ISO week that just ended, not the newly started week.

## Why

`Weekly Auto Run` currently initializes `RUN_WEEK` from the current UTC ISO week. On Monday morning, that points at the week that just started. The support export and weekly vote evidence should instead resolve to the previous completed week.

Directly rewriting the full weekly workflow was avoided because that file contains multiple implementation secret bindings. This PR keeps workflow behavior compatible and moves the previous-week resolution into the support unlock resolver, which already writes environment variables back into `$GITHUB_ENV`.

## Changes

- Make `Support Unlock Export` default to the previous UTC ISO week when manual inputs are omitted.
- Update `resolve_support_unlock.py` so scheduled and manual workflow runs can resolve the previous week's support unlock file and write the resolved `RUN_WEEK` back to the environment.
- Add deterministic resolver tests for scheduled and manual previous-week fallback.
- Extend the support unlock workflow contract test so previous-week support export defaults are preserved.
- Update `docs/weekly-automation.md` to explain previous-week resolution.

## Behavior

Scheduled path:

```text
Support Unlock Export → previous ISO week JSON
Weekly Auto Run → resolver finds previous ISO week JSON → RUN_WEEK is rewritten to week-<previous week>
```

Manual path:

```text
Support Unlock Export can still accept explicit week_id/since/until
Weekly Auto Run can resolve previous week when current week support data is absent
```

## Scope

- No root `lab/` changes.
- No generated evidence changes.
- No implementation model behavior changes.
- No sponsor identity or event-level data changes.