### PR TITLE
Filter non-terminal workflow runs from public results

### DIFF
--- a/scripts/build_public_results_export.py
+++ b/scripts/build_public_results_export.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 SCHEMA_VERSION = "prompt-vote-lab-public-results-export-v1"
+TERMINAL_WORKFLOW_STATUSES = {"completed"}
 
 
 def utc_now() -> str:
@@ -142,7 +143,13 @@ def normalize_pr(pr: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def normalize_run(run: dict[str, Any]) -> dict[str, Any]:
+def is_terminal_workflow_run(run: dict[str, Any]) -> bool:
+    return str(run.get("status") or "").lower() in TERMINAL_WORKFLOW_STATUSES
+
+
+def normalize_run(run: dict[str, Any]) -> dict[str, Any] | None:
+    if not is_terminal_workflow_run(run):
+        return None
     return {
         "database_id": run.get("databaseId"),
         "name": run.get("name"),
@@ -157,6 +164,15 @@ def normalize_run(run: dict[str, Any]) -> dict[str, Any]:
         "head_sha": run.get("headSha"),
         "url": run.get("url"),
     }
+
+
+def normalize_runs(runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for run in runs:
+        item = normalize_run(run)
+        if item is not None:
+            normalized.append(item)
+    return normalized
 
 
 def run_records(runs_dir: Path) -> list[dict[str, Any]]:
@@ -255,7 +271,7 @@ def main() -> int:
 
     issues = [normalize_issue(item) for item in read_json(Path(args.issues), [])]
     prs = [normalize_pr(item) for item in read_json(Path(args.prs), [])]
-    workflow_runs = [normalize_run(item) for item in read_json(Path(args.workflow_runs), [])]
+    workflow_runs = normalize_runs(read_json(Path(args.workflow_runs), []))
     labels = read_json(Path(args.labels), [])
     records = run_records(Path(args.runs_dir))
 
@@ -267,6 +283,7 @@ def main() -> int:
             "interpretation": "none; participant analysis expected",
             "secrets": "not collected",
             "raw_actions_logs": "not collected",
+            "workflow_runs": "terminal workflow runs only; queued and in-progress runs are excluded",
         },
         "summary": summarize(issues, prs, workflow_runs, records),
         "issues": issues,

--- a/scripts/test_build_public_results_export.py
+++ b/scripts/test_build_public_results_export.py
@@ -106,7 +106,35 @@ def main() -> int:
                     "headBranch": "branch",
                     "headSha": "sha",
                     "url": "https://example.test/actions/100",
-                }
+                },
+                {
+                    "databaseId": 101,
+                    "name": "Public Results Export",
+                    "workflowName": "Public Results Export",
+                    "displayTitle": "Export currently running",
+                    "event": "push",
+                    "status": "in_progress",
+                    "conclusion": None,
+                    "createdAt": "2026-05-07T00:03:00Z",
+                    "updatedAt": "2026-05-07T00:04:00Z",
+                    "headBranch": "main",
+                    "headSha": "sha2",
+                    "url": "https://example.test/actions/101",
+                },
+                {
+                    "databaseId": 102,
+                    "name": "pages-build-deployment",
+                    "workflowName": "pages-build-deployment",
+                    "displayTitle": "Pages queued",
+                    "event": "dynamic",
+                    "status": "queued",
+                    "conclusion": None,
+                    "createdAt": "2026-05-07T00:05:00Z",
+                    "updatedAt": "2026-05-07T00:05:00Z",
+                    "headBranch": "main",
+                    "headSha": "sha3",
+                    "url": "https://example.test/actions/102",
+                },
             ],
         )
         write(labels, [{"name": "issue-safety:clear", "color": "2ea043", "description": "clear"}])
@@ -142,11 +170,15 @@ def main() -> int:
         export = json.loads(out_json.read_text(encoding="utf-8"))
         assert export["schema_version"] == "prompt-vote-lab-public-results-export-v1"
         assert export["scope"]["interpretation"] == "none; participant analysis expected"
+        assert export["scope"]["workflow_runs"] == "terminal workflow runs only; queued and in-progress runs are excluded"
         assert export["summary"]["issue_count"] == 2
         assert export["summary"]["blocked_issue_count"] == 1
         assert export["summary"]["clear_issue_count"] == 1
         assert export["summary"]["authorized_canary_issue_count"] == 1
         assert export["summary"]["merged_pr_count"] == 1
+        assert export["summary"]["workflow_run_count"] == 1
+        assert export["workflow_runs"][0]["database_id"] == 100
+        assert all(run["status"] == "completed" for run in export["workflow_runs"])
         assert export["issues"][0]["reaction_plus_one_count"] == 7
         assert export["issues"][0]["body"] == "Show a local card."
         assert export["pull_requests"][0]["files"][0]["path"] == "lab/index.html"
@@ -155,6 +187,8 @@ def main() -> int:
         assert "This file is a raw results surface for participants" in md
         assert "## Recent Issues" in md
         assert "## Recent Pull Requests" in md
+        assert "Export currently running" not in md
+        assert "Pages queued" not in md
 
     print("public results export builder test passed")
     return 0


### PR DESCRIPTION
## Summary

Filters queued and in-progress workflow runs out of the public results export.

## Why

`Public Results Export` currently captures workflow runs while it is running. That can leave volatile `queued` or `in_progress` rows in `data/public-results.json` and `data/public-results.md`, even though those states may be obsolete moments later. Public evidence should prefer terminal workflow states.

## Changes

- Add terminal workflow-run filtering in `scripts/build_public_results_export.py`.
- Keep only workflow runs with `status == completed`.
- Add a scope note that queued and in-progress workflow runs are excluded.
- Extend the public results builder test to verify `in_progress` and `queued` runs are excluded from JSON and Markdown output.

## Scope

- No root `lab/` changes.
- No generated evidence changes in this PR.
- No workflow behavior changes.
- No support unlock behavior changes.