### PR TITLE
Fix support unlock privacy flag validation

### DIFF
--- a/scripts/test_unlock_export_public.py
+++ b/scripts/test_unlock_export_public.py
@@ -45,7 +45,7 @@ FORBIDDEN_KEYS = {
     "account",
 }
 
-FORBIDDEN_TEXT_FRAGMENTS = [
+FORBIDDEN_STRING_VALUE_FRAGMENTS = [
     "@",
     "private-sponsor",
     "sponsor_login",
@@ -69,9 +69,26 @@ def contains_forbidden_key(value: Any) -> str | None:
     return None
 
 
+def contains_forbidden_string_value(value: Any) -> str | None:
+    if isinstance(value, str):
+        for fragment in FORBIDDEN_STRING_VALUE_FRAGMENTS:
+            if fragment in value:
+                return fragment
+    if isinstance(value, dict):
+        for child in value.values():
+            nested = contains_forbidden_string_value(child)
+            if nested:
+                return nested
+    if isinstance(value, list):
+        for child in value:
+            nested = contains_forbidden_string_value(child)
+            if nested:
+                return nested
+    return None
+
+
 def validate_unlock(path: Path) -> None:
-    text = path.read_text(encoding="utf-8")
-    data = json.loads(text)
+    data = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
         raise SystemExit(f"{path}: support unlock JSON must be an object")
 
@@ -87,9 +104,9 @@ def validate_unlock(path: Path) -> None:
     if forbidden_key:
         raise SystemExit(f"{path}: forbidden identity key found: {forbidden_key}")
 
-    leaked_fragments = [fragment for fragment in FORBIDDEN_TEXT_FRAGMENTS if fragment in text]
-    if leaked_fragments:
-        raise SystemExit(f"{path}: forbidden text fragment found: {leaked_fragments}")
+    leaked_fragment = contains_forbidden_string_value(data)
+    if leaked_fragment:
+        raise SystemExit(f"{path}: forbidden string value fragment found: {leaked_fragment}")
 
     if data["schema_version"] != "support-unlock.v1":
         raise SystemExit(f"{path}: unexpected schema_version")


### PR DESCRIPTION
## Summary

Fixes a false positive in public support unlock validation.

## Why

The live `Support Unlock Export` reached `Build support unlocks`, but failed at `Validate public support unlock output` because the validator searched the raw JSON text for `sponsor_login`.

That incorrectly flags the allowed privacy flag name `raw_sponsor_logins_included` as leaked sponsor identity data.

## Changes

- Stop scanning the raw JSON text for forbidden fragments.
- Keep strict forbidden key checks for identity-shaped keys such as `login`, `email`, `name`, and `sponsor_login`.
- Scan only string values for obvious leaked private fragments such as `@`, `private-sponsor`, `sponsor_login`, and `sponsorLogin`.
- Keep privacy flags required and forced to `false`.

## Scope

- No root `lab/` changes.
- No workflow behavior changes.
- No generated support unlock JSON committed in this PR.
- No sponsor identity or event-level data added.