### PR TITLE
Add participant guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ The game is not only about getting votes. It is about earning trust by proposing
 Prompt → 20-vote gate → agent PR → public outcome → reputation memory
 ```
 
+## Start as a participant
+
+The lowest-friction first action is voting, not writing a prompt.
+
+```text
+1. Open Issues labeled prompt-proposal.
+2. Read the prompt.
+3. Add 👍 only if you trust it enough to spend one bounded implementation-agent attempt.
+4. Submit your own prompt after you understand what good prompts look like.
+```
+
+Start with [`docs/for-participants.md`](docs/for-participants.md).
+
 ## Short explanation
 
 Prompt Vote Lab is a competitive prompt market plus a constrained, cumulative implementation sandbox.
@@ -90,7 +103,7 @@ Rejected, failed, unsafe, and unmerged comparison PRs do not become the next wee
 
 ## Weekly automation status
 
-Weekly automation is implemented but still requires live production verification.
+Weekly automation is implemented. The no-eligible live path has been verified, and the eligible implementation-agent PR path still needs live E2E verification.
 
 Scheduled workflows:
 
@@ -109,8 +122,8 @@ See [`docs/weekly-automation.md`](docs/weekly-automation.md).
 
 ## Weekly loop
 
-1. Players submit prompts as GitHub Issues.
-2. Players vote with GitHub reactions.
+1. Players vote with GitHub 👍 reactions.
+2. Players submit prompts as GitHub Issues.
 3. A virtual no-change baseline is inserted with 20 virtual votes.
 4. Candidates are ranked by vote count.
 5. If the no-change baseline ranks first, no implementation run is created.
@@ -223,6 +236,7 @@ Start with [`docs/README.md`](docs/README.md).
 
 Key documents:
 
+- [`docs/for-participants.md`](docs/for-participants.md) — start by voting with 👍, then submit prompts when ready
 - [`docs/experiment-model.md`](docs/experiment-model.md) — project concept and boundaries
 - [`docs/how-to-participate.md`](docs/how-to-participate.md) — how to submit, vote, and review as a player
 - [`docs/weekly-automation.md`](docs/weekly-automation.md) — weekly schedule and support unlock prerequisite
@@ -230,6 +244,7 @@ Key documents:
 - [`docs/no-change-baseline.md`](docs/no-change-baseline.md) — no-change baseline explanation
 - [`docs/support-policy.md`](docs/support-policy.md) — support tiers and thresholds
 - [`docs/automation-map.md`](docs/automation-map.md) — automation boundary
+- [`docs/operator-runbook.md`](docs/operator-runbook.md) — maintainer operation guide
 
 Operational rules live in [`rules/`](rules/).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,34 +8,41 @@ Prompt Vote Lab is a prompt game and experiment. Players compete by writing prom
 
 ## Start here
 
-1. [Experiment model](./experiment-model.md) — game model and boundaries.
-2. [How to participate](./how-to-participate.md) — submit, vote, and review.
-3. [Usable experiment operations](./usable-experiment-ops.md) — current manual canary and comparison-run operations.
-4. [Operator runbook](./operator-runbook.md) — maintainer checklist for weekly operation, failures, merge decisions, tokens, and cleanup boundaries.
-5. [Public results export](./public-results-export.md) — raw public data snapshots for participant analysis.
-6. [Public agent run bundle](./public-agent-run-bundle.md) — redacted raw agent-run evidence; summaries are not primary evidence.
-7. [Issue lifecycle](./issue-lifecycle.md) — weekly close policy; Issues are closed, not deleted.
-8. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
-9. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
-10. [Weekly automation](./weekly-automation.md) — weekly schedule, support unlock prerequisite, and E2E status.
-11. [Automation map](./automation-map.md) — workflow boundaries.
-12. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
-13. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
-14. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and pre-canary cleanup.
-15. [Fixed first canary prompt](./first-canary-prompt.md) — the only allowed first real canary prompt.
-16. [First canary readiness checklist](./first-canary-readiness.md) — final check before running the first real canary.
-17. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
-18. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
-19. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
-20. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
-21. [Report policy](./report-policy.md) — weekly report draft policy.
-22. [Pre-API freeze checklist](./pre-api-freeze.md) — gates before paid agent runs.
+1. [Participant guide](./for-participants.md) — start by voting with 👍, then submit prompts when ready.
+2. [Experiment model](./experiment-model.md) — game model and boundaries.
+3. [How to participate](./how-to-participate.md) — submit, vote, and review.
+4. [Usable experiment operations](./usable-experiment-ops.md) — current manual canary and comparison-run operations.
+5. [Operator runbook](./operator-runbook.md) — maintainer checklist for weekly operation, failures, merge decisions, tokens, and cleanup boundaries.
+6. [Public results export](./public-results-export.md) — raw public data snapshots for participant analysis.
+7. [Public agent run bundle](./public-agent-run-bundle.md) — redacted raw agent-run evidence; summaries are not primary evidence.
+8. [Issue lifecycle](./issue-lifecycle.md) — weekly close policy; Issues are closed, not deleted.
+9. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
+10. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
+11. [Weekly automation](./weekly-automation.md) — weekly schedule, support unlock prerequisite, and E2E status.
+12. [Automation map](./automation-map.md) — workflow boundaries.
+13. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
+14. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
+15. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and pre-canary cleanup.
+16. [Fixed first canary prompt](./first-canary-prompt.md) — the only allowed first real canary prompt.
+17. [First canary readiness checklist](./first-canary-readiness.md) — final check before running the first real canary.
+18. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
+19. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
+20. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
+21. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
+22. [Report policy](./report-policy.md) — weekly report draft policy.
+23. [Pre-API freeze checklist](./pre-api-freeze.md) — gates before paid agent runs.
 
 ## Current reputation status
 
 Reputation is currently social memory, not an automated score.
 
 The repository records outcomes. Workflows do not yet compute player rankings, trust scores, author scores, or penalties.
+
+## Participant status
+
+Participants should start with [Participant guide](./for-participants.md).
+
+The first useful action is usually voting with 👍 on an existing `prompt-proposal` Issue. Prompt submission is the second step, not the first step.
 
 ## Report status
 

--- a/docs/for-participants.md
+++ b/docs/for-participants.md
@@ -1,0 +1,238 @@
+# Participant guide
+
+This guide is for people who want to participate in Prompt Vote Lab.
+
+The fastest useful action is not writing a prompt. It is voting on an existing prompt.
+
+## What this is
+
+Prompt Vote Lab is a public prompt game.
+
+Participants propose prompts as GitHub Issues. Other participants vote with GitHub 👍 reactions. Each week, the highest-trust prompt may get one bounded implementation-agent attempt against the current static lab.
+
+The result is public:
+
+```text
+prompt -> votes -> no-change baseline comparison -> agent PR or no run -> public outcome
+```
+
+## Start here
+
+Do this first:
+
+```text
+1. Open the prompt proposal Issues.
+2. Read a few prompts.
+3. Add 👍 to prompts you trust.
+4. Do not vote for vague prompts just because they sound ambitious.
+```
+
+Voting is the lowest-friction way to participate.
+
+## Why voting matters
+
+Every week includes a virtual baseline:
+
+```text
+[Baseline]: No change this week
+20 virtual votes
+```
+
+If no real prompt beats the baseline, no implementation-agent attempt is created.
+
+That is not failure. It means the group preferred not to spend a bounded attempt on weak prompts.
+
+## How to vote
+
+1. Go to the repository Issues page.
+2. Find Issues labeled `prompt-proposal`.
+3. Open a prompt.
+4. Click the 👍 reaction on the Issue.
+
+Use 👍 only when the prompt is specific enough that you would be willing to see an implementation attempt.
+
+## How to judge a prompt
+
+Prefer prompts that are:
+
+```text
+small
+specific
+static-site compatible
+reviewable
+clear about visible user value
+possible inside lab/index.html, lab/style.css, and lab/app.js
+```
+
+Be skeptical of prompts that are:
+
+```text
+vague
+large redesigns
+backend-dependent
+login/payment dependent
+network/API dependent
+unclear about what should change
+hard to review
+```
+
+## How to submit a prompt
+
+Create a GitHub Issue using the prompt proposal format.
+
+A useful prompt should include:
+
+```text
+1. What should change visibly?
+2. Why is it useful to participants?
+3. What should stay unchanged?
+4. What would count as a bad implementation?
+```
+
+Good example:
+
+```text
+Add a compact "How to participate" panel to the lab page.
+It should explain: vote with 👍, submit prompts as Issues, and check weekly results.
+Keep it static and do not add external scripts or network calls.
+Bad implementation: a large redesign, login flow, or external dependency.
+```
+
+Weak example:
+
+```text
+Make the site better and more viral.
+```
+
+The weak example is not actionable. It hides too many decisions inside the implementation agent.
+
+## What the implementation agent can edit
+
+The implementation agent may edit only:
+
+```text
+lab/index.html
+lab/style.css
+lab/app.js
+```
+
+It must not edit workflows, docs, rules, run records, backend files, configuration, secrets, or files outside `lab/`.
+
+It must not add:
+
+```text
+external scripts
+CDNs
+network calls
+trackers
+cookies
+login
+payment behavior
+iframes
+eval
+unsafe dynamic code
+```
+
+## What support can and cannot do
+
+Support can unlock extra comparison runs for rank 2 and rank 3 when the weekly support threshold is met.
+
+Support cannot buy:
+
+```text
+votes
+merge
+success
+review priority
+maintenance
+feature control
+private request handling
+```
+
+Support increases comparison capacity. It does not override the game.
+
+## Where to see results
+
+Useful places:
+
+```text
+/lab/                                  current lab UI
+runs/                                  weekly vote summaries and run records
+data/public-results.json               raw public result data
+data/public-results.md                 readable public result summary
+lab/comparisons/<week>/                comparison dashboards
+lab/history/                           historical state flow
+```
+
+## What happens after a prompt wins
+
+If a prompt beats the no-change baseline and is eligible:
+
+```text
+1. The workflow selects the candidate.
+2. The implementation agent gets one bounded attempt.
+3. The agent may open a PR changing only lab files.
+4. Checks run before or during PR creation.
+5. A maintainer reviews the PR manually.
+6. Only merged PRs become the inherited lab state for future weeks.
+```
+
+If the agent fails, that failure is recorded. It is not hidden by automatic retries.
+
+## Common questions
+
+### Do I need to code?
+
+No. Voting is enough.
+
+### Do I need a GitHub account?
+
+Yes, to vote with reactions or create Issues.
+
+### Does the most popular prompt always merge?
+
+No. Votes select candidates for bounded attempts. Merge still requires review.
+
+### Can a failed prompt be useful?
+
+Yes. A failed prompt teaches participants what kinds of prompts are too vague, too large, unsafe, or hard to implement.
+
+### Are supporter identities published?
+
+No. Public support unlock files should contain aggregate unlock information only, not sponsor identity or event-level amounts.
+
+### Why is there a no-change baseline?
+
+The baseline prevents weak prompts from consuming implementation attempts. A prompt must be better than doing nothing that week.
+
+## Good participant behavior
+
+Do:
+
+```text
+vote carefully
+write small prompts
+explain expected visible behavior
+mention what should not change
+review outcomes after voting
+learn from failed runs
+```
+
+Do not:
+
+```text
+vote for vague hype
+ask for private handling
+try to buy merge
+request external services
+hide requirements in comments after selection
+pressure maintainers to rerun failures
+```
+
+## First action
+
+Start by voting.
+
+If you can explain why a prompt deserves one bounded implementation attempt, give it 👍.
+
+If you cannot explain that, do not vote for it.


### PR DESCRIPTION
## Summary

Adds a participant-facing guide and makes it the first documentation entry.

## Changes

- Add `docs/for-participants.md`.
- Link it from `docs/README.md`.
- Add a short participant start section to root `README.md`.
- Make voting with 👍 the first suggested action before prompt submission.

## Scope

Documentation only. No workflow, lab, or generated evidence changes.