### PR TITLE
Reconcile active implementation model and verification docs

### DIFF
--- a/.github/workflows/first-canary-run.yml
+++ b/.github/workflows/first-canary-run.yml
@@ -15,7 +15,7 @@ jobs:
   first-canary-run:
     runs-on: ubuntu-latest
     env:
-      IMPLEMENTATION_MODEL: gpt-5-nano
+      IMPLEMENTATION_MODEL: gpt-5.4-nano
       MAX_OUTPUT_TOKENS: "5000"
       SDK_MAX_RETRIES: "0"
       RUN_WEEK: first-canary-001
@@ -28,7 +28,7 @@ jobs:
       - name: Verify clean first-canary state
         shell: bash
         run: |
-          if [ "${IMPLEMENTATION_MODEL}" != "gpt-5-nano" ]; then
+          if [ "${IMPLEMENTATION_MODEL}" != "gpt-5.4-nano" ]; then
             echo "Unexpected model: ${IMPLEMENTATION_MODEL}"
             exit 1
           fi
@@ -141,7 +141,7 @@ jobs:
           - Issue: #0
           - Votes: 0
           - Inherited lab base: \`$base_sha\`
-          - Implementation model: \`gpt-5-nano\`
+          - Implementation model: \`gpt-5.4-nano\`
           - Max output tokens: \`5000\`
           - SDK max retries: \`0\`
           - API call limit per candidate: \`1\`

--- a/.github/workflows/weekly-auto-run.yml
+++ b/.github/workflows/weekly-auto-run.yml
@@ -13,7 +13,7 @@ permissions:
 env:
   DEFAULT_NO_CHANGE_BASELINE: "20"
   DEFAULT_SUPPORT_USD: "0"
-  AUTO_IMPLEMENTATION_MODEL: "gpt-5-nano"
+  AUTO_IMPLEMENTATION_MODEL: "gpt-5.4-nano"
 
 concurrency:
   group: weekly-auto-run
@@ -146,7 +146,7 @@ jobs:
           OPENAI_API_KEY_: ${{ secrets.OPENAI_API_KEY_ }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_IMPLEMENTATION_API_KEY: ${{ secrets.OPENAI_IMPLEMENTATION_API_KEY }}
-          IMPLEMENTATION_MODEL: gpt-5-nano
+          IMPLEMENTATION_MODEL: gpt-5.4-nano
           MAX_OUTPUT_TOKENS: "5000"
           SDK_MAX_RETRIES: "0"
         run: |
@@ -169,7 +169,7 @@ jobs:
           OPENAI_API_KEY_TRAILING: ${{ secrets.OPENAI_API_KEY_ }}
           OPENAI_API_KEY_PRIMARY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_API_KEY_IMPLEMENTATION: ${{ secrets.OPENAI_IMPLEMENTATION_API_KEY }}
-          IMPLEMENTATION_MODEL: gpt-5-nano
+          IMPLEMENTATION_MODEL: gpt-5.4-nano
           MAX_OUTPUT_TOKENS: "5000"
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -236,8 +236,8 @@ jobs:
                   f'- Votes: {votes}',
                   f'- Run reason: {reason}',
                   f'- Inherited lab base: `{base_sha}`',
-                  '- Implementation model: `gpt-5-nano`',
-                  '- Model policy: `rules/model-policy-v1.0.md`',
+                  '- Implementation model: `gpt-5.4-nano`',
+                  '- Model policy: `rules/model-policy-v1.1.md`',
                   '- Agent-run policy: `rules/agent-run-policy-v1.0.md`',
                   '- Internal checks: `safety-check` and `static-site-check` passed before PR creation',
                   '- Created by: `Weekly Auto Run`',

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ See [`docs/no-change-baseline.md`](docs/no-change-baseline.md).
 Current active implementation condition:
 
 ```text
-model-policy-v1.1: gpt-5-nano
+model-policy-v1.1: gpt-5.4-nano
 max_output_tokens: 5000
 ```
 
@@ -175,7 +175,7 @@ The implementation model and output budget are fixed by `rules/model-policy-v1.1
 
 All ranked candidates in the same weekly vote must use the same implementation condition.
 
-`gpt-5.4-nano / 12000` is not active. It may be reconsidered only after the system is complete and the eligible implementation PR path has passed live E2E verification.
+`max_output_tokens: 12000` is not active. It may be reconsidered only after the system is complete and the eligible implementation PR path has passed live E2E verification.
 
 A stronger model may be used only for evaluation and blog/report writing. The evaluation model must not modify `lab/`.
 

--- a/README.md
+++ b/README.md
@@ -164,15 +164,18 @@ See [`docs/no-change-baseline.md`](docs/no-change-baseline.md).
 
 ## Implementation agent policy
 
-Current implementation agent/model policy:
+Current active implementation condition:
 
 ```text
-model-policy-v1.1: gpt-5.4-nano
+model-policy-v1.1: gpt-5-nano
+max_output_tokens: 5000
 ```
 
-The implementation model is fixed by `rules/model-policy-v1.1.md` for the current canary comparison period.
+The implementation model and output budget are fixed by `rules/model-policy-v1.1.md` during the current stabilization phase.
 
 All ranked candidates in the same weekly vote must use the same implementation condition.
+
+`gpt-5.4-nano / 12000` is not active. It may be reconsidered only after the system is complete and the eligible implementation PR path has passed live E2E verification.
 
 A stronger model may be used only for evaluation and blog/report writing. The evaluation model must not modify `lab/`.
 

--- a/docs/canary-policy.md
+++ b/docs/canary-policy.md
@@ -32,7 +32,7 @@ Add a small visible canary panel to the lab page explaining that this is the fir
 The canary must use:
 
 ```text
-model: gpt-5-nano
+model: gpt-5.4-nano
 candidate count: 1
 attempts per candidate: 1
 SDK max_retries: 0
@@ -40,6 +40,8 @@ fallback model: none
 max_output_tokens: 5000
 automatic merge: no
 ```
+
+`max_output_tokens: 12000` is deferred until after system completion and live eligible-path verification.
 
 ## Allowed output
 

--- a/docs/current-features.md
+++ b/docs/current-features.md
@@ -72,9 +72,11 @@ baseline itself is never eligible
 
 Implemented:
 
+- `Support Unlock Export`
 - `Weekly Auto Run`
 - `Weekly Mock Run`
 - `Weekly Report Draft`
+- support unlock JSON generation under `data/support-unlocks/`
 - synthetic mock vote summary PR
 - synthetic mock implementation PR
 - model-free weekly report draft PR
@@ -83,11 +85,14 @@ Implemented:
 
 Verified:
 
-- Weekly Auto Run no-eligible production path created only `runs/week-2026-W19-vote-summary.md` in PR #81.
+- Support Unlock Export live path: verified.
+- `data/support-unlocks/2026-W19.json` was generated and validated as anonymized aggregate output.
+- Weekly Auto Run no-eligible production path created only `runs/week-2026-W19-vote-summary.md` in PR #243.
 - The recorded summary had baseline rank 1 with 20 virtual votes.
 - `eligible_count` was 0.
 - `eligible_ranks` was empty.
 - No implementation PR was created during that no-eligible run.
+- Earlier no-eligible evidence also exists in PR #81, before the support-unlock prerequisite was added.
 
 Not implemented:
 
@@ -101,7 +106,7 @@ Not implemented:
 
 Prepared but not yet executed:
 
-- fixed implementation model: `gpt-5-nano`
+- fixed implementation model: `gpt-5.4-nano`
 - one implementation attempt per candidate
 - SDK retry must be 0
 - no fallback model
@@ -109,6 +114,10 @@ Prepared but not yet executed:
 - eligible candidate secret requirement
 - no-eligible path does not require implementation-agent secret
 - preflight script before API dependency install
+
+Deferred:
+
+- raising max output tokens to 12000
 
 Not yet done:
 
@@ -221,6 +230,7 @@ Implemented:
 - pre-API freeze checklist
 - pre-API freeze audit script
 - pre-API freeze audit CI
+- Support Unlock Export live path verification
 - Weekly Auto Run no-eligible production path verification
 - Evidence Pipeline Dry Run fixture path verification
 - Evidence Pipeline Dry Run live path verification
@@ -238,6 +248,7 @@ Current state:
 ```text
 MVP structure: mostly complete
 offline verification: strong
+support unlock live path: verified
 no-eligible production workflow path: verified
 fixture evidence dry-run path: verified
 live evidence dry-run path: verified

--- a/docs/first-canary-readiness.md
+++ b/docs/first-canary-readiness.md
@@ -29,7 +29,8 @@ Do not run the canary unless every required item is PASS.
 ## Required evidence state
 
 ```text
-[ ] Weekly Auto Run no-eligible production path: PASS
+[ ] Support Unlock Export live path: PASS
+[ ] Weekly Auto Run no-eligible live path: PASS
 [ ] Evidence Pipeline Dry Run source=fixture: PASS
 [ ] Evidence Pipeline Dry Run source=live: PASS
 [ ] live evidence human review: PASS
@@ -39,7 +40,7 @@ Do not run the canary unless every required item is PASS.
 ## Required canary configuration
 
 ```text
-[ ] model: gpt-5-nano
+[ ] model: gpt-5.4-nano
 [ ] candidate count: 1
 [ ] attempts per candidate: 1
 [ ] SDK max_retries: 0
@@ -49,6 +50,8 @@ Do not run the canary unless every required item is PASS.
 [ ] auto-merge: disabled
 [ ] external publishing: disabled
 ```
+
+`max output tokens: 12000` is deferred until after system completion and live eligible-path verification.
 
 ## Required prompt
 

--- a/docs/pre-api-freeze.md
+++ b/docs/pre-api-freeze.md
@@ -37,7 +37,8 @@ All of these must pass before the first real canary run.
 | Lean Proof Test | PASS | CI |
 | Weekly Report Draft workflow | PASS, report PR only | completed before canary |
 | Weekly Mock Run workflow | PASS, summary PR + mock implementation PR only | completed before canary |
-| Weekly Auto Run no-eligible workflow | PASS, summary PR only | PR #81 |
+| Support Unlock Export live path | PASS, anonymized JSON only | `data/support-unlocks/2026-W19.json` |
+| Weekly Auto Run no-eligible workflow | PASS, summary PR only | PR #243 / `runs/week-2026-W19-vote-summary.md` |
 | Evidence Pipeline Dry Run with `source=fixture` | PASS, validator and artifact upload | run `25335321720` |
 | Evidence Pipeline Dry Run with `source=live` | PASS, artifact review only | `runs/dry-run-001-evidence-review.md` |
 
@@ -46,21 +47,25 @@ All of these must pass before the first real canary run.
 A real implementation-agent canary is allowed only after:
 
 ```text
+Support Unlock Export live path has produced anonymized support unlock JSON
 Weekly Auto Run no-eligible path has produced only a summary PR
 Evidence Pipeline Dry Run source=fixture has passed the workflow validator
 Evidence Pipeline Dry Run source=live has produced reviewable artifacts
 the live artifact review passes docs/evidence-artifact-review.md
 ```
 
-The no-eligible production path was verified in PR #81:
+The latest no-eligible production path was verified in PR #243:
 
 ```text
+support unlock file: data/support-unlocks/2026-W19.json
 changed file: runs/week-2026-W19-vote-summary.md
 baseline_won: true
 eligible_count: 0
 eligible_ranks: []
 implementation PR created: no
 ```
+
+Earlier no-eligible evidence also exists in PR #81. PR #243 is the current live path because it includes the support-unlock prerequisite.
 
 The fixture evidence dry-run path was verified in Actions run `25335321720`:
 
@@ -99,7 +104,7 @@ Add a small visible canary panel to lab/ explaining that this is the first bound
 Required canary run constraints:
 
 ```text
-model: gpt-5-nano
+model: gpt-5.4-nano
 one agent attempt
 one model
 no retry
@@ -112,6 +117,8 @@ safety-check PASS
 static-site-check PASS
 manual review before merge
 ```
+
+`max output tokens: 12000` is deferred until after system completion and live eligible-path verification.
 
 ## Stop conditions
 

--- a/docs/weekly-automation.md
+++ b/docs/weekly-automation.md
@@ -52,7 +52,7 @@ On scheduled runs, support export defaults to the previous UTC ISO week. Manual 
 1. checkout repository
 2. set an initial RUN_WEEK
 3. resolve the required support unlock file
-4. on scheduled runs, rewrite RUN_WEEK to the previous UTC ISO week resolved from the support unlock file
+4. prefer the previous UTC ISO week when its support unlock file exists
 5. collect prompt proposal votes
 6. insert no-change baseline
 7. select eligible ranks
@@ -98,13 +98,13 @@ target = current UTC time - 7 days
 
 This writes the previous ISO week by default.
 
-`Weekly Auto Run` also resolves to the previous UTC ISO week when the GitHub event is `schedule`. The resolver writes this resolved week back into the job environment as:
+`Weekly Auto Run` resolves the support unlock file before vote collection. When a previous-week support unlock file exists, the resolver writes this resolved week back into the job environment as:
 
 ```text
 RUN_WEEK=week-<previous-ISO-year>-W<previous-ISO-week>
 ```
 
-This prevents the Monday morning scheduled run from recording the newly started week by mistake.
+This prevents the Monday morning run from recording the newly started week by mistake.
 
 `Support Unlock Export` writes:
 
@@ -122,12 +122,36 @@ The weekly workflow requires the matching support unlock file for its resolved `
 
 ## Manual verification
 
-Before trusting the scheduled path, run `Support Unlock Export` manually after `SPONSORS_GRAPHQL_TOKEN` is configured.
+The live no-eligible path has been verified.
 
-Example:
+Verified support export evidence:
 
 ```text
-week_id: 2026-W20
+Support Unlock Export: PASS
+data/support-unlocks/2026-W19.json
+support_total_usd: 0.0
+rank_2_unlocked: false
+rank_3_unlocked: false
+privacy flags: all false
+```
+
+Verified weekly automation evidence:
+
+```text
+Weekly Auto Run: PASS
+runs/week-2026-W19-vote-summary.md
+PR #243 merged
+baseline_won: true
+eligible_count: 0
+implementation PR: none
+```
+
+Manual verification is still useful after token rotation, workflow changes, or backfills.
+
+Example support export input:
+
+```text
+week_id: 2026-W19
 since: 2026-05-04T00:00:00Z
 until: 2026-05-11T00:00:00Z
 ```
@@ -135,7 +159,7 @@ until: 2026-05-11T00:00:00Z
 Expected public output:
 
 ```text
-data/support-unlocks/2026-W20.json
+data/support-unlocks/2026-W19.json
 ```
 
 Then run `Weekly Auto Run` manually and confirm that it reads the support unlock file before vote collection.
@@ -148,11 +172,13 @@ Automation may create PRs, but it must not merge them.
 
 ## Current production status
 
-The schedules and gates are implemented.
+Implemented and live-verified:
 
-Still required before calling this fully production-verified:
+- `SPONSORS_GRAPHQL_TOKEN` can read support activity for the export path.
+- `Support Unlock Export` can generate and validate an anonymized support unlock file.
+- `Weekly Auto Run` can read that unlock file and create a no-eligible vote summary PR.
+- The no-change baseline path can complete without creating an implementation PR.
 
-- configure `SPONSORS_GRAPHQL_TOKEN`
-- run `Support Unlock Export` against live Sponsors data
-- confirm public support unlock JSON validation passes
-- run `Weekly Auto Run` end-to-end with the generated unlock file
+Still not fully production-verified:
+
+- eligible prompt -> implementation-agent preflight -> implementation-agent run -> lab-only implementation PR

--- a/rules/model-policy-v1.1.md
+++ b/rules/model-policy-v1.1.md
@@ -33,6 +33,8 @@ first-canary-run
 weekly-auto-run eligible implementation path
 ```
 
+Historical canary evidence may still mention earlier isolated paths, including `first-canary-009`, but current active paid implementation settings are defined by this file and the current workflows.
+
 The eligible implementation path has not yet been live-verified end-to-end. The no-eligible weekly path has been live-verified.
 
 ## Fixed comparison rule
@@ -109,6 +111,8 @@ max_output_tokens: 5000
 ```
 
 This file also records that `max_output_tokens: 12000` is deferred, not active.
+
+Do not directly compare prompt results across v1.0 and v1.1 without noting the model-policy change.
 
 Do not directly compare prompt results across model or token-budget changes without noting the policy change.
 

--- a/rules/model-policy-v1.1.md
+++ b/rules/model-policy-v1.1.md
@@ -9,7 +9,7 @@ Prompt Vote Lab evaluates prompt candidates. To compare prompts fairly, the impl
 ## Active implementation model
 
 ```text
-gpt-5-nano
+gpt-5.4-nano
 ```
 
 ## Scope
@@ -56,7 +56,7 @@ Do not run rank 1, rank 2, and rank 3 with different implementation models in th
 ## Active settings
 
 ```text
-model: gpt-5-nano
+model: gpt-5.4-nano
 temperature_policy: model-default
 top_p_policy: model-default
 max_output_tokens: 5000
@@ -69,16 +69,15 @@ The implementation runner records the temperature and top_p policies as `model-d
 
 ## Deferred settings
 
-The following settings are not active during the stabilization phase:
+The following setting is not active during the stabilization phase:
 
 ```text
-model: gpt-5.4-nano
 max_output_tokens: 12000
 ```
 
-They may be reconsidered only after the system is complete and the eligible implementation PR path has passed at least one live end-to-end run.
+It may be reconsidered only after the system is complete and the eligible implementation PR path has passed at least one live end-to-end run.
 
-Do not change the active model or token budget during stabilization merely to increase implementation capacity.
+Do not change the active token budget during stabilization merely to increase implementation capacity.
 
 ## Ranked candidates
 
@@ -102,13 +101,14 @@ If retries are introduced later, they must use the same implementation model and
 gpt-5-nano
 ```
 
-`model-policy-v1.1` keeps the same active model and makes the stabilization output budget explicit:
+`model-policy-v1.1` records the active stabilization model and output budget:
 
 ```text
+model: gpt-5.4-nano
 max_output_tokens: 5000
 ```
 
-This file also records that `gpt-5.4-nano / 12000` is deferred, not active.
+This file also records that `max_output_tokens: 12000` is deferred, not active.
 
 Do not directly compare prompt results across model or token-budget changes without noting the policy change.
 

--- a/rules/model-policy-v1.1.md
+++ b/rules/model-policy-v1.1.md
@@ -2,14 +2,14 @@
 
 ## Purpose
 
-This policy fixes the current implementation model for Prompt Vote Lab canary execution paths.
+This policy fixes the active implementation model for Prompt Vote Lab stabilization runs.
 
-Prompt Vote Lab evaluates prompt candidates. To compare prompts fairly, the implementation model must remain fixed within the same comparison period.
+Prompt Vote Lab evaluates prompt candidates. To compare prompts fairly, the implementation model and output budget must remain fixed within the same comparison period.
 
-## Implementation model
+## Active implementation model
 
 ```text
-gpt-5.4-nano
+gpt-5-nano
 ```
 
 ## Scope
@@ -24,15 +24,16 @@ lab/style.css
 lab/app.js
 ```
 
-## Current canary paths covered
+## Active canary and weekly automation paths covered
 
-This policy applies to the currently active canary execution paths that record `model: gpt-5.4-nano`:
+This policy applies to the currently active implementation paths that are guarded by preflight checks and CI:
 
 ```text
-first-canary-005: offline context + JSON full-file replacement
-first-canary-008: selected prompt task packet container
-first-canary-009: fixed GitHub Issue -> normalized instruction packet -> /task:ro
+first-canary-run
+weekly-auto-run eligible implementation path
 ```
+
+The eligible implementation path has not yet been live-verified end-to-end. The no-eligible weekly path has been live-verified.
 
 ## Fixed comparison rule
 
@@ -52,19 +53,32 @@ manual review policy
 
 Do not run rank 1, rank 2, and rank 3 with different implementation models in the same comparison set.
 
-## Initial settings
+## Active settings
 
 ```text
-model: gpt-5.4-nano
+model: gpt-5-nano
 temperature_policy: model-default
 top_p_policy: model-default
-max_output_tokens: 12000
+max_output_tokens: 5000
 retry_count: 0
 fallback_policy: none
 auto_merge_policy: disabled
 ```
 
 The implementation runner records the temperature and top_p policies as `model-default` rather than passing unsupported or unstable sampling overrides.
+
+## Deferred settings
+
+The following settings are not active during the stabilization phase:
+
+```text
+model: gpt-5.4-nano
+max_output_tokens: 12000
+```
+
+They may be reconsidered only after the system is complete and the eligible implementation PR path has passed at least one live end-to-end run.
+
+Do not change the active model or token budget during stabilization merely to increase implementation capacity.
 
 ## Ranked candidates
 
@@ -80,7 +94,7 @@ A failed implementation should normally be recorded as a result instead of silen
 
 If retries are introduced later, they must use the same implementation model and must be recorded in the weekly log.
 
-## Model change from v1.0
+## Relationship to v1.0
 
 `model-policy-v1.0` recorded:
 
@@ -88,15 +102,15 @@ If retries are introduced later, they must use the same implementation model and
 gpt-5-nano
 ```
 
-The current implemented canary workflows and documentation use:
+`model-policy-v1.1` keeps the same active model and makes the stabilization output budget explicit:
 
 ```text
-gpt-5.4-nano
+max_output_tokens: 5000
 ```
 
-This file exists so the current comparison period has an explicit model-policy version rather than silently mutating v1.0.
+This file also records that `gpt-5.4-nano / 12000` is deferred, not active.
 
-Do not directly compare prompt results across v1.0 and v1.1 without noting the model-policy change.
+Do not directly compare prompt results across model or token-budget changes without noting the policy change.
 
 ## Separation from evaluation model
 
@@ -106,8 +120,8 @@ A stronger model may be used for analysis and blog/report writing under a separa
 
 ## Rationale
 
-If the implementation model changes between candidates, the experiment no longer evaluates only prompt quality.
+If the implementation model or output budget changes between candidates, the experiment no longer evaluates only prompt quality.
 
-The result becomes a mixture of prompt quality, model capability, context size, and retry behavior.
+The result becomes a mixture of prompt quality, model capability, context size, output budget, and retry behavior.
 
-To evaluate prompts, keep the implementation model fixed within each comparison period.
+To evaluate prompts, keep the implementation model and budget fixed within each comparison period.

--- a/scripts/openai_lab_run.py
+++ b/scripts/openai_lab_run.py
@@ -91,7 +91,7 @@ def build_prompt(args: argparse.Namespace) -> str:
     for rel in [
         "rules/static-ui-v1.0.md",
         "rules/agent-run-policy-v1.0.md",
-        "rules/model-policy-v1.0.md",
+        "rules/model-policy-v1.1.md",
         "rules/merge-policy-v1.0.md",
         "rules/operational-decisions-v1.1.md",
         "rules/no-external-resources-v1.0.md",
@@ -146,7 +146,7 @@ def main() -> int:
     parser.add_argument("--voted-prompt", required=True)
     parser.add_argument("--vote-count", default="unrecorded")
     parser.add_argument("--run-reason", default="normal-weekly-run")
-    parser.add_argument("--model", default=os.getenv("IMPLEMENTATION_MODEL", "gpt-5-nano"))
+    parser.add_argument("--model", default=os.getenv("IMPLEMENTATION_MODEL", "gpt-5.4-nano"))
     parser.add_argument("--max-output-tokens", type=int, default=int(os.getenv("MAX_OUTPUT_TOKENS", "5000")))
     parser.add_argument("--temperature-policy", default=os.getenv("TEMPERATURE_POLICY", "model-default"))
     parser.add_argument("--top-p-policy", default=os.getenv("TOP_P_POLICY", "model-default"))

--- a/scripts/pre_api_freeze_audit.py
+++ b/scripts/pre_api_freeze_audit.py
@@ -33,6 +33,10 @@ REQUIRED_FILES = [
     ".github/workflows/evidence-pipeline-dry-run.yml",
 ]
 
+ACTIVE_MODEL = "gpt-5.4-nano"
+ACTIVE_MAX_OUTPUT_TOKENS = "5000"
+DEFERRED_MAX_OUTPUT_TOKENS = "12000"
+
 REQUIRED_SUBSTRINGS: dict[str, list[str]] = {
     "docs/pre-api-freeze.md": [
         "no automatic merge",
@@ -40,13 +44,14 @@ REQUIRED_SUBSTRINGS: dict[str, list[str]] = {
         "no fallback model",
         "Weekly Auto Run no-eligible workflow",
         "Evidence Pipeline Dry Run with `source=live`",
-        "PR #81",
-        "gpt-5-nano",
+        "Support Unlock Export live path",
+        "PR #243",
+        ACTIVE_MODEL,
         "max output tokens: 5000",
         "workflow attempts to auto-merge",
     ],
     "docs/canary-policy.md": [
-        "model: gpt-5-nano",
+        f"model: {ACTIVE_MODEL}",
         "attempts per candidate: 1",
         "SDK max_retries: 0",
         "fallback model: none",
@@ -73,7 +78,7 @@ REQUIRED_SUBSTRINGS: dict[str, list[str]] = {
         "Do not run the canary unless every required item is PASS.",
         "open PRs: 0",
         "remote branches: main only",
-        "model: gpt-5-nano",
+        f"model: {ACTIVE_MODEL}",
         "SDK max_retries: 0",
         "API call limit per candidate: 1",
         "max output tokens: 5000",
@@ -96,8 +101,11 @@ REQUIRED_SUBSTRINGS: dict[str, list[str]] = {
     ],
     "docs/current-features.md": [
         "no-eligible production workflow path: verified",
+        "Support Unlock Export live path: verified",
         "real implementation-agent canary: not yet executed",
         "production autonomy: not complete",
+        ACTIVE_MODEL,
+        "max output tokens capped at 5000",
         "Evidence Pipeline Dry Run",
         "source=live",
     ],
@@ -137,7 +145,7 @@ REQUIRED_SUBSTRINGS: dict[str, list[str]] = {
         "safe_canary_no_external_publishing",
     ],
     "scripts/preflight_implementation_agent.py": [
-        "ALLOWED_MODELS = {\"gpt-5-nano\"}",
+        f"ALLOWED_MODELS = {{\"{ACTIVE_MODEL}\"}}",
         "MAX_OUTPUT_TOKENS_LIMIT = 5000",
         "if sdk_max_retries != 0",
         "api_call_limit != 1",
@@ -151,6 +159,7 @@ REQUIRED_SUBSTRINGS: dict[str, list[str]] = {
         "MAX_OUTPUT_TOKENS",
         "5000",
         "if args.max_output_tokens > MAX_OUTPUT_TOKENS_LIMIT",
+        f"gpt-5.4-nano",
         "This is one bounded implementation-agent attempt.",
         "Do not create additional files.",
     ],
@@ -196,7 +205,8 @@ REQUIRED_SUBSTRINGS: dict[str, list[str]] = {
         "no_change_baseline_candidate",
     ],
     ".github/workflows/weekly-auto-run.yml": [
-        "AUTO_IMPLEMENTATION_MODEL: \"gpt-5-nano\"",
+        f"AUTO_IMPLEMENTATION_MODEL: \"{ACTIVE_MODEL}\"",
+        f"IMPLEMENTATION_MODEL: {ACTIVE_MODEL}",
         "MAX_OUTPUT_TOKENS: \"5000\"",
         "SDK_MAX_RETRIES: \"0\"",
         "--api-call-limit-per-candidate 1",
@@ -207,7 +217,7 @@ REQUIRED_SUBSTRINGS: dict[str, list[str]] = {
     ],
     ".github/workflows/first-canary-run.yml": [
         "workflow_dispatch",
-        "IMPLEMENTATION_MODEL: gpt-5-nano",
+        f"IMPLEMENTATION_MODEL: {ACTIVE_MODEL}",
         "MAX_OUTPUT_TOKENS: \"5000\"",
         "SDK_MAX_RETRIES: \"0\"",
         "RUN_WEEK: first-canary-001",
@@ -240,6 +250,7 @@ FORBIDDEN_SUBSTRINGS: dict[str, list[str]] = {
         "SDK_MAX_RETRIES: \"2\"",
         "AUTO_IMPLEMENTATION_MODEL: \"gpt-5\"",
         "AUTO_IMPLEMENTATION_MODEL: \"gpt-5-mini\"",
+        "AUTO_IMPLEMENTATION_MODEL: \"gpt-5-nano\"",
     ],
     ".github/workflows/first-canary-run.yml": [
         "enable-auto-merge",
@@ -247,17 +258,20 @@ FORBIDDEN_SUBSTRINGS: dict[str, list[str]] = {
         "MAX_OUTPUT_TOKENS: \"12000\"",
         "SDK_MAX_RETRIES: \"1\"",
         "SDK_MAX_RETRIES: \"2\"",
+        "IMPLEMENTATION_MODEL: gpt-5-nano",
         "AUTO_IMPLEMENTATION_MODEL: \"gpt-5\"",
         "AUTO_IMPLEMENTATION_MODEL: \"gpt-5-mini\"",
     ],
     "scripts/preflight_implementation_agent.py": [
         "ALLOWED_MODELS = {\"gpt-5\"}",
         "ALLOWED_MODELS = {\"gpt-5-mini\"}",
+        "ALLOWED_MODELS = {\"gpt-5-nano\"}",
         "MAX_OUTPUT_TOKENS_LIMIT = 12000",
         "api_call_performed\": True",
         "sdk_max_retries != 1",
     ],
     "scripts/openai_lab_run.py": [
+        "os.getenv(\"IMPLEMENTATION_MODEL\", \"gpt-5-nano\")",
         "MAX_OUTPUT_TOKENS_LIMIT = 12000",
         "os.getenv(\"MAX_OUTPUT_TOKENS\", \"12000\")",
         "args.max_output_tokens > 12000",

--- a/scripts/preflight_implementation_agent.py
+++ b/scripts/preflight_implementation_agent.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 
-ALLOWED_MODELS = {"gpt-5-nano"}
+ALLOWED_MODELS = {"gpt-5.4-nano"}
 MAX_OUTPUT_TOKENS_LIMIT = 5000
 REQUIRED_RUN_REASONS = {"normal-weekly-run", "support-unlocked-run"}
 
@@ -70,7 +70,7 @@ def validate_candidate(candidate: dict[str, Any]) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--eligible", default=".tmp/eligible-candidates.json")
-    parser.add_argument("--model", default=os.getenv("IMPLEMENTATION_MODEL", "gpt-5-nano"))
+    parser.add_argument("--model", default=os.getenv("IMPLEMENTATION_MODEL", "gpt-5.4-nano"))
     parser.add_argument("--max-output-tokens", default=os.getenv("MAX_OUTPUT_TOKENS", "5000"))
     parser.add_argument("--sdk-max-retries", default=os.getenv("SDK_MAX_RETRIES", "0"))
     parser.add_argument("--api-call-limit-per-candidate", default="1")

--- a/scripts/test_canary_policy_alignment.py
+++ b/scripts/test_canary_policy_alignment.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+ACTIVE_MODEL = "gpt-5.4-nano"
 
 REQUIRED = {
     "formal/Canary.lean": [
@@ -23,7 +24,7 @@ REQUIRED = {
         "safe_canary_no_external_publishing",
     ],
     "docs/pre-api-freeze.md": [
-        "model: gpt-5-nano",
+        f"model: {ACTIVE_MODEL}",
         "one agent attempt",
         "one model",
         "no retry",
@@ -37,7 +38,7 @@ REQUIRED = {
         "workflow attempts to auto-merge",
     ],
     "docs/canary-policy.md": [
-        "model: gpt-5-nano",
+        f"model: {ACTIVE_MODEL}",
         "attempts per candidate: 1",
         "SDK max_retries: 0",
         "fallback model: none",
@@ -46,7 +47,7 @@ REQUIRED = {
         "max continuation runs per candidate: 1",
     ],
     "scripts/preflight_implementation_agent.py": [
-        "ALLOWED_MODELS = {\"gpt-5-nano\"}",
+        f"ALLOWED_MODELS = {{\"{ACTIVE_MODEL}\"}}",
         "if sdk_max_retries != 0",
         "api_call_limit != 1",
         "MAX_OUTPUT_TOKENS_LIMIT = 5000",
@@ -56,6 +57,7 @@ REQUIRED = {
         "MAX_OUTPUT_TOKENS_LIMIT = 5000",
         "os.getenv(\"MAX_OUTPUT_TOKENS\", \"5000\")",
         "if args.max_output_tokens > MAX_OUTPUT_TOKENS_LIMIT",
+        ACTIVE_MODEL,
     ],
     "scripts/create_first_canary_candidate.py": [
         "docs/first-canary-prompt.md",
@@ -65,7 +67,8 @@ REQUIRED = {
         "fixed_prompt_source",
     ],
     ".github/workflows/weekly-auto-run.yml": [
-        "AUTO_IMPLEMENTATION_MODEL: \"gpt-5-nano\"",
+        f"AUTO_IMPLEMENTATION_MODEL: \"{ACTIVE_MODEL}\"",
+        f"IMPLEMENTATION_MODEL: {ACTIVE_MODEL}",
         "MAX_OUTPUT_TOKENS: \"5000\"",
         "SDK_MAX_RETRIES: \"0\"",
         "--api-call-limit-per-candidate 1",
@@ -73,7 +76,7 @@ REQUIRED = {
     ],
     ".github/workflows/first-canary-run.yml": [
         "workflow_dispatch",
-        "IMPLEMENTATION_MODEL: gpt-5-nano",
+        f"IMPLEMENTATION_MODEL: {ACTIVE_MODEL}",
         "MAX_OUTPUT_TOKENS: \"5000\"",
         "SDK_MAX_RETRIES: \"0\"",
         "RUN_WEEK: first-canary-001",
@@ -95,23 +98,23 @@ FORBIDDEN = {
         "automatic merge: yes",
         "SDK max_retries: 1",
         "API call limit per candidate: 2",
-        "max output tokens: 12000",
     ],
     "docs/canary-policy.md": [
         "fallback model: gpt-5",
         "automatic merge: yes",
         "SDK max_retries: 1",
         "attempts per candidate: 2",
-        "max_output_tokens: 12000",
     ],
     "scripts/preflight_implementation_agent.py": [
         "ALLOWED_MODELS = {\"gpt-5\"}",
         "ALLOWED_MODELS = {\"gpt-5-mini\"}",
+        "ALLOWED_MODELS = {\"gpt-5-nano\"}",
         "sdk_max_retries != 1",
         "api_call_limit != 2",
         "MAX_OUTPUT_TOKENS_LIMIT = 12000",
     ],
     "scripts/openai_lab_run.py": [
+        "os.getenv(\"IMPLEMENTATION_MODEL\", \"gpt-5-nano\")",
         "MAX_OUTPUT_TOKENS_LIMIT = 12000",
         "os.getenv(\"MAX_OUTPUT_TOKENS\", \"12000\")",
         "args.max_output_tokens > 12000",
@@ -122,6 +125,7 @@ FORBIDDEN = {
     ".github/workflows/weekly-auto-run.yml": [
         "AUTO_IMPLEMENTATION_MODEL: \"gpt-5\"",
         "AUTO_IMPLEMENTATION_MODEL: \"gpt-5-mini\"",
+        "AUTO_IMPLEMENTATION_MODEL: \"gpt-5-nano\"",
         "MAX_OUTPUT_TOKENS: \"12000\"",
         "SDK_MAX_RETRIES: \"1\"",
         "SDK_MAX_RETRIES: \"2\"",
@@ -129,6 +133,7 @@ FORBIDDEN = {
         "gh pr merge --auto",
     ],
     ".github/workflows/first-canary-run.yml": [
+        "IMPLEMENTATION_MODEL: gpt-5-nano",
         "AUTO_IMPLEMENTATION_MODEL: \"gpt-5\"",
         "AUTO_IMPLEMENTATION_MODEL: \"gpt-5-mini\"",
         "MAX_OUTPUT_TOKENS: \"12000\"",

--- a/scripts/test_preflight_implementation_agent.py
+++ b/scripts/test_preflight_implementation_agent.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "preflight_implementation_agent.py"
+ACTIVE_MODEL = "gpt-5.4-nano"
 
 
 def run(args: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
@@ -71,17 +72,17 @@ def main() -> int:
             ],
         )
 
-        no_eligible = run(["--eligible", str(empty), "--model", "gpt-5-nano"])
+        no_eligible = run(["--eligible", str(empty), "--model", ACTIVE_MODEL])
         if no_eligible.returncode != 0:
             print(no_eligible.stdout)
             raise SystemExit("empty eligible list should pass without secret")
 
-        needs_secret = run(["--eligible", str(eligible), "--model", "gpt-5-nano"])
+        needs_secret = run(["--eligible", str(eligible), "--model", ACTIVE_MODEL])
         if needs_secret.returncode == 0:
             raise SystemExit("eligible candidates without secret should fail")
 
         with_secret = run(
-            ["--eligible", str(eligible), "--model", "gpt-5-nano"],
+            ["--eligible", str(eligible), "--model", ACTIVE_MODEL],
             env={"OPENAI_API_KEY_": "test-secret-placeholder"},
         )
         if with_secret.returncode != 0:
@@ -96,21 +97,21 @@ def main() -> int:
             raise SystemExit("wrong model should fail")
 
         too_many_tokens = run(
-            ["--eligible", str(eligible), "--model", "gpt-5-nano", "--max-output-tokens", "12001"],
+            ["--eligible", str(eligible), "--model", ACTIVE_MODEL, "--max-output-tokens", "5001"],
             env={"OPENAI_API_KEY_": "test-secret-placeholder"},
         )
         if too_many_tokens.returncode == 0:
             raise SystemExit("too many output tokens should fail")
 
         retry_enabled = run(
-            ["--eligible", str(eligible), "--model", "gpt-5-nano", "--sdk-max-retries", "1"],
+            ["--eligible", str(eligible), "--model", ACTIVE_MODEL, "--sdk-max-retries", "1"],
             env={"OPENAI_API_KEY_": "test-secret-placeholder"},
         )
         if retry_enabled.returncode == 0:
             raise SystemExit("sdk retries should fail")
 
         bad_reason = run(
-            ["--eligible", str(bad_model), "--model", "gpt-5-nano"],
+            ["--eligible", str(bad_model), "--model", ACTIVE_MODEL],
             env={"OPENAI_API_KEY_": "test-secret-placeholder"},
         )
         if bad_reason.returncode == 0:


### PR DESCRIPTION
## Summary

Reconciles implementation settings and documentation after live support-export and no-eligible weekly verification.

## Correct active condition

```text
model: gpt-5.4-nano
max_output_tokens: 5000
```

`max_output_tokens: 12000` remains deferred until after system completion and live eligible-path verification.

## Changes

- Align weekly and first-canary implementation workflows to `gpt-5.4-nano / 5000`.
- Align `openai_lab_run.py` and `preflight_implementation_agent.py` with the same active model.
- Update pre-API freeze audit to enforce the active model and token budget.
- Update README, model policy, canary docs, current features, pre-API freeze, and weekly automation docs.
- Record PR #243 and `data/support-unlocks/2026-W19.json` as the current live no-eligible support-unlock evidence.

## Scope

No lab UI changes. No generated evidence changes. No token-budget increase.