### PR TITLE
Fix root prompt template links

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
       <nav class="nav" aria-label="Primary navigation">
         <a href="./lab/">Lab</a>
         <a href="https://github.com/Unjuno/prompt-vote-lab/issues?q=is%3Aissue+is%3Aopen+label%3Aprompt-proposal">Vote</a>
-        <a href="https://github.com/Unjuno/prompt-vote-lab/issues/new?template=prompt_proposal.yml">Submit</a>
+        <a href="https://github.com/Unjuno/prompt-vote-lab/issues/new?template=prompt.yml">Submit</a>
         <a href="https://github.com/Unjuno/prompt-vote-lab/tree/main/docs">Rules</a>
       </nav>
     </header>
@@ -123,7 +123,7 @@
           Players compete by submitting prompts. The crowd votes. If a prompt beats the 20-vote baseline, a constrained AI coding agent gets one bounded attempt. A popular prompt can still fail in public.
         </p>
         <div class="actions" aria-label="Primary actions">
-          <a class="button primary" href="https://github.com/Unjuno/prompt-vote-lab/issues/new?template=prompt_proposal.yml">Submit a prompt</a>
+          <a class="button primary" href="https://github.com/Unjuno/prompt-vote-lab/issues/new?template=prompt.yml">Submit a prompt</a>
           <a class="button" href="https://github.com/Unjuno/prompt-vote-lab/issues?q=is%3Aissue+is%3Aopen+label%3Aprompt-proposal">Vote on prompts</a>
           <a class="button ghost" href="./lab/">Watch the lab</a>
         </div>
@@ -222,7 +222,7 @@
         <p>Submit carefully. Popularity opens the gate; implementation decides whether trust was deserved.</p>
       </div>
       <div class="actions" aria-label="Final actions">
-        <a class="button primary" href="https://github.com/Unjuno/prompt-vote-lab/issues/new?template=prompt_proposal.yml">Submit a prompt</a>
+        <a class="button primary" href="https://github.com/Unjuno/prompt-vote-lab/issues/new?template=prompt.yml">Submit a prompt</a>
         <a class="button ghost" href="https://github.com/Unjuno/prompt-vote-lab/issues?q=is%3Aissue+is%3Aopen+label%3Aprompt-proposal">Vote now</a>
       </div>
     </section>


### PR DESCRIPTION
## Summary

Fixes broken prompt submission links on the root landing page.

## Problem

The root `index.html` linked to `template=prompt_proposal.yml`, but the repository issue template is `.github/ISSUE_TEMPLATE/prompt.yml`.

The `/lab/` page already uses `template=prompt.yml` correctly.

## Change

- Replace root landing page `template=prompt_proposal.yml` links with `template=prompt.yml`.

## Scope

Root landing page only. No workflow, lab, script, rule, or generated evidence changes.