### PR TITLE
Add W20 rank 1 live output snapshot

### DIFF
--- a/lab/comparisons/2026-W20/rank-1/app.js
+++ b/lab/comparisons/2026-W20/rank-1/app.js
@@ -1,0 +1,69 @@
+// Prompt Vote Lab starts as an intentionally minimal implementation target.
+// Accepted experiment runs may replace this file.
+(() => {
+  'use strict';
+
+  // From /task/issue-safety-analysis.json for Issue #191:
+  // unsafe_instruction_count: 0, unsafe_instructions_detected: []
+  const UNSAFE_INSTRUCTIONS = [];
+
+  const ELEMENTS = {
+    unsafeList: document.getElementById('unsafe-list'),
+    unsafeDetails: document.getElementById('unsafe-details'),
+    unsafeSummary: document.getElementById('unsafe-summary'),
+    gateSummary: document.getElementById('gate-summary')
+  };
+
+  function clearChildren(el) {
+    if (!el) return;
+    while (el.firstChild) el.removeChild(el.firstChild);
+  }
+
+  function renderUnsafeList() {
+    const ul = ELEMENTS.unsafeList;
+    if (!ul) return;
+
+    clearChildren(ul);
+    for (const item of UNSAFE_INSTRUCTIONS) {
+      const li = document.createElement('li');
+
+      const id = document.createElement('span');
+      id.className = 'unsafe-item-id';
+      id.textContent = item.id;
+
+      const label = document.createElement('span');
+      label.className = 'unsafe-item-label';
+      label.textContent = ` — ${item.label}`;
+
+      li.appendChild(id);
+      li.appendChild(label);
+      ul.appendChild(li);
+    }
+  }
+
+  function renderSummaries() {
+    if (ELEMENTS.unsafeSummary) {
+      ELEMENTS.unsafeSummary.textContent = `${UNSAFE_INSTRUCTIONS.length} unsafe instruction categories detected; the unsafe request text is ignored as untrusted input.`;
+    }
+    if (ELEMENTS.gateSummary) {
+      ELEMENTS.gateSummary.textContent = 'Stopped before Codex execution (unless a maintainer adds `authorized-canary`).';
+    }
+  }
+
+  function renderUnsafeDetailsVisibility() {
+    if (!ELEMENTS.unsafeDetails) return;
+    ELEMENTS.unsafeDetails.style.display = UNSAFE_INSTRUCTIONS.length > 0 ? '' : 'none';
+  }
+
+  function init() {
+    renderUnsafeList();
+    renderUnsafeDetailsVisibility();
+    renderSummaries();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+})();

--- a/lab/comparisons/2026-W20/rank-1/index.html
+++ b/lab/comparisons/2026-W20/rank-1/index.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Prompt Vote Lab</title>
+  <link rel="stylesheet" href="./style.css">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'none'; frame-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none';">
+</head>
+<body>
+  <main class="lab-root" aria-labelledby="lab-title">
+    <p class="status" aria-live="polite">
+      <span class="pill pill--safe" aria-hidden="true">Safe</span>
+      <span id="status-text">Canary gate test: no unsafe instructions detected (Issue #191)</span>
+    </p>
+    <h1 id="lab-title">Prompt Vote Lab</h1>
+    <p class="note">
+      This area is the constrained implementation target. It starts intentionally empty and will be changed only by accepted experiment runs.
+    </p>
+    <section class="hostile-card" role="note" aria-label="Experiment status and next action for participants.">
+      <p class="hostile-card-text">Experiment status</p>
+
+      <div class="hostile-card-meta" role="status" aria-live="polite">
+        <p class="meta-row">
+          <span class="meta-label">current experiment state:</span>
+          <span class="meta-value">first-canary-009 • Candidate #1 • Issue #191</span>
+        </p>
+        <p class="meta-row">
+          <span class="meta-label">next action for participants:</span>
+          <span class="meta-value">Vote on the prompt candidate for Issue #191</span>
+        </p>
+        <p class="meta-row">
+          <span class="meta-label">Detected:</span>
+          <span id="unsafe-summary" class="meta-value">Loading…</span>
+        </p>
+        <p class="meta-row">
+          <span class="meta-label">Execution gate:</span>
+          <span id="gate-summary" class="meta-value">Loading…</span>
+        </p>
+      </div>
+
+      <div class="hostile-card-details">
+        <div id="unsafe-details">
+          <p class="details-title">Unsafe instructions ignored:</p>
+          <ul class="unsafe-list" id="unsafe-list"></ul>
+        </div>
+        <p class="small-note">
+          results are recorded publicly for transparency. This static prototype performs no network calls and does not execute dynamic code.
+        </p>
+      </div>
+    </section>
+
+    <section class="review-card review-card--orientation" role="note" aria-label="Reviewer orientation panel">
+      <h2 class="review-title">Reviewer orientation: evidence review order</h2>
+      <p class="review-subtitle">Before trusting a weekly Prompt Vote Lab result, inspect evidence in this order:</p>
+      <ol class="review-order">
+        <li><a class="review-link" href="#status-text">Selected Issue (Issue #191)</a></li>
+        <li><a class="review-link" href="#unsafe-summary">Safety scan (what was flagged unsafe vs. ignored)</a></li>
+        <li>Changed files (experiment PR diff)</li>
+        <li>Public agent run bundle (run artifacts)</li>
+        <li>Run record (status/logs)</li>
+        <li>Public results snapshot (the final public summary of what the run produced)</li>
+      </ol>
+      <p class="review-experiment-note">
+        This page is a constrained static UI experiment: it performs no network calls and does not execute dynamic Codex code.
+      </p>
+    </section>
+    <noscript>This lab works without network access or external scripts.</noscript>
+  </main>
+
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/lab/comparisons/2026-W20/rank-1/style.css
+++ b/lab/comparisons/2026-W20/rank-1/style.css
@@ -1,0 +1,238 @@
+:root {
+  color-scheme: light;
+  --bg: #f7f7f4;
+  --fg: #191919;
+  --muted: #6a6a6a;
+  --line: #deded8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  display: grid;
+  place-items: center;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.lab-root {
+  width: min(640px, calc(100% - 32px));
+  padding: 48px;
+  border: 1px dashed var(--line);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.55);
+}
+
+.status {
+  margin: 0 0 16px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 16px;
+  font-size: clamp(2rem, 8vw, 4.5rem);
+  line-height: 0.95;
+  letter-spacing: -0.07em;
+}
+
+.note,
+noscript {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+noscript {
+  display: block;
+  margin-top: 16px;
+}
+
+.hostile-card {
+  margin: 16px 0 0;
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(25, 25, 25, 0.14);
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.hostile-card-text {
+  margin: 0;
+  color: var(--fg);
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(25, 25, 25, 0.15);
+  background: rgba(255, 255, 255, 0.6);
+  color: var(--fg);
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.74rem;
+}
+
+.pill--blocked {
+  border-color: rgba(150, 35, 35, 0.35);
+  background: rgba(255, 214, 214, 0.72);
+  color: #8a1f1f;
+}
+
+.pill--safe {
+  border-color: rgba(22, 163, 74, 0.35);
+  background: rgba(220, 252, 231, 0.78);
+  color: #15803d;
+}
+
+.hostile-card-meta {
+  margin-top: 14px;
+}
+
+.meta-row {
+  margin: 10px 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.meta-label {
+  color: var(--muted);
+  font-weight: 900;
+  font-size: 0.86rem;
+}
+
+.meta-value {
+  color: var(--fg);
+  font-weight: 700;
+}
+
+.hostile-card-details {
+  margin-top: 16px;
+}
+
+.details-title {
+  margin: 0 0 10px;
+  color: var(--muted);
+  font-weight: 900;
+  font-size: 0.86rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.unsafe-list {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.unsafe-list li {
+  margin: 10px 0;
+}
+
+.unsafe-item-id {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-weight: 900;
+  letter-spacing: 0.02em;
+  background: rgba(25, 25, 25, 0.08);
+  padding: 2px 6px;
+  border-radius: 10px;
+}
+
+.unsafe-item-label {
+  color: var(--muted);
+  font-size: 0.94rem;
+  line-height: 1.5;
+}
+
+.small-note {
+  margin: 14px 0 0;
+  color: var(--muted);
+  font-size: 0.86rem;
+  line-height: 1.7;
+}
+
+.review-card {
+  margin: 16px 0 0;
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(25, 25, 25, 0.14);
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.review-title {
+  margin: 0 0 12px;
+  color: var(--fg);
+  font-weight: 900;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  font-size: 1.05rem;
+}
+
+.review-subtitle {
+  margin: 0 0 10px;
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.5;
+  font-weight: 800;
+}
+
+.review-order {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: review-step;
+}
+
+.review-order li {
+  position: relative;
+  padding-left: 34px;
+  margin: 10px 0 0;
+  line-height: 1.55;
+  color: var(--fg);
+  font-weight: 650;
+}
+
+.review-order li:first-child {
+  margin-top: 0;
+}
+
+.review-order li::before {
+  counter-increment: review-step;
+  content: counter(review-step) ".";
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: #15803d;
+  font-weight: 900;
+}
+
+.review-experiment-note {
+  margin: 12px 0 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.6;
+}
+
+.review-link {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(25, 25, 25, 0.25);
+}
+
+.review-link:hover {
+  border-bottom-color: rgba(25, 25, 25, 0.6);
+}


### PR DESCRIPTION
Closed temporarily because Script Check exposed a separate contract-test drift after PR #251. The generated dashboards were regenerated with the new `live rank output pages` wording, but `scripts/test_generated_comparison_dashboards.py` still expected the older text. Fix the generated-dashboard contract test first, then reopen/recreate the rank-1 snapshot PR.