### PR TITLE
Add live preview hub to lab page

### DIFF
--- a/lab/index.html
+++ b/lab/index.html
@@ -24,6 +24,7 @@
 
     <nav class="evidence-nav" aria-label="Primary participant navigation">
       <a class="primary-link" href="https://github.com/Unjuno/prompt-vote-lab/issues?q=is%3Aissue+label%3Aprompt-proposal">Vote on prompt Issues</a>
+      <a href="#live-previews">Live previews</a>
       <a href="https://github.com/Unjuno/prompt-vote-lab/issues/new?template=prompt.yml">Submit prompt</a>
       <a href="https://github.com/Unjuno/prompt-vote-lab/blob/main/docs/for-participants.md">Participant guide</a>
       <a href="./comparisons/2026-W20/">Latest comparison</a>
@@ -50,6 +51,40 @@
           <span>3</span>
           <strong>Watch weekly runs</strong>
           <em>See the workflow that turns votes into a vote summary or an implementation PR.</em>
+        </a>
+      </div>
+    </section>
+
+    <section class="summary-card preview-card" id="live-previews" aria-labelledby="live-preview-title">
+      <p class="eyebrow">Live previews</p>
+      <h2 id="live-preview-title">Open rendered pages, not source files.</h2>
+      <p>
+        Current lab, rank outputs, comparison dashboards, and history are all public static pages. Rank outputs show candidate implementations; dashboards and history show the evidence index around them.
+      </p>
+      <div class="preview-grid" aria-label="Live preview links">
+        <a class="preview-link preview-link--current" href="./">
+          <strong>Current accepted lab</strong>
+          <span>The live state inherited by future accepted implementation runs.</span>
+        </a>
+        <a class="preview-link" href="./comparisons/2026-W20/rank-1/">
+          <strong>2026-W20 Rank 1 output</strong>
+          <span>Issue #191 · PR #192 · accepted candidate snapshot.</span>
+        </a>
+        <a class="preview-link" href="./comparisons/2026-W20/rank-2/">
+          <strong>2026-W20 Rank 2 output</strong>
+          <span>Issue #195 · PR #214 · comparison candidate snapshot.</span>
+        </a>
+        <a class="preview-link" href="./comparisons/2026-W20/rank-3/">
+          <strong>2026-W20 Rank 3 output</strong>
+          <span>Issue #196 · PR #224 · comparison candidate snapshot.</span>
+        </a>
+        <a class="preview-link" href="./comparisons/2026-W20/">
+          <strong>2026-W20 comparison dashboard</strong>
+          <span>Rank cards, Issues, PRs, run records, and output roots.</span>
+        </a>
+        <a class="preview-link" href="./history/">
+          <strong>History</strong>
+          <span>Weekly progression generated from public results.</span>
         </a>
       </div>
     </section>

--- a/lab/style.css
+++ b/lab/style.css
@@ -96,7 +96,8 @@ noscript,
 
 .evidence-nav a:hover,
 .action-link:hover,
-.run-links a:hover {
+.run-links a:hover,
+.preview-link:hover {
   border-color: rgba(25, 25, 25, 0.38);
 }
 
@@ -114,7 +115,8 @@ noscript,
   background: var(--card);
 }
 
-.action-card {
+.action-card,
+.preview-card {
   background: var(--card-strong);
 }
 
@@ -138,14 +140,16 @@ noscript,
   margin: 0;
 }
 
-.action-grid {
+.action-grid,
+.preview-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 10px;
   margin-top: 16px;
 }
 
-.action-link {
+.action-link,
+.preview-link {
   display: grid;
   gap: 10px;
   min-height: 100%;
@@ -169,17 +173,24 @@ noscript,
   font-weight: 900;
 }
 
-.action-link strong {
+.action-link strong,
+.preview-link strong {
   font-size: 1.05rem;
   line-height: 1.15;
 }
 
-.action-link em {
+.action-link em,
+.preview-link span {
   color: var(--muted);
   font-size: 0.9rem;
   font-style: normal;
   font-weight: 650;
   line-height: 1.5;
+}
+
+.preview-link--current {
+  border-color: rgba(25, 25, 25, 0.34);
+  background: rgba(255, 255, 255, 0.82);
 }
 
 .run-links {
@@ -250,7 +261,8 @@ noscript {
 }
 
 @media (max-width: 720px) {
-  .action-grid {
+  .action-grid,
+  .preview-grid {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary

Adds a live preview hub to `/lab/` so participants can open rendered pages, not source files.

## Changes

- Add a `Live previews` nav item.
- Add a `Live previews` section linking to:
  - current accepted lab
  - 2026-W20 rank 1 output
  - 2026-W20 rank 2 output
  - 2026-W20 rank 3 output
  - 2026-W20 comparison dashboard
  - history
- Add responsive preview-card styles.

## Scope

Root lab UI only: `lab/index.html` and `lab/style.css`.

No generated evidence, scripts, workflows, docs, model, token-budget, or W0 reset changes.