### PR TITLE
Publish redacted policy-agent public bundle

### DIFF
--- a/.github/workflows/codex-policy-agent-canary-run.yml
+++ b/.github/workflows/codex-policy-agent-canary-run.yml
@@ -81,6 +81,24 @@ jobs:
             --allowed-file lab/style.css \
             --allowed-file lab/app.js
 
+      - name: Build redacted public agent run bundle
+        if: ${{ always() }}
+        run: |
+          python scripts/build_public_agent_run_bundle.py \
+            --diagnostics-dir .tmp/canary-diagnostics \
+            --out-dir .tmp/public-agent-run-bundle \
+            --run-id "codex-policy-agent-canary-${{ github.run_number }}" \
+            --issue-number "0" \
+            --pr-number ""
+
+      - name: Upload redacted public agent run bundle
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-policy-agent-canary-public-bundle-${{ github.run_number }}
+          path: .tmp/public-agent-run-bundle
+          if-no-files-found: error
+
       - name: Upload diagnostics artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -173,9 +191,15 @@ jobs:
           - safety-check passed before PR creation
           - static-site-check passed before PR creation
 
+          ## Public evidence
+
+          - Redacted public agent run bundle artifact: \`codex-policy-agent-canary-public-bundle-${{ github.run_number }}\`
+          - Public run log artifact: \`codex-policy-agent-canary-public-log-${{ github.run_number }}\`
+          - Internal diagnostics artifact: \`codex-policy-agent-canary-diagnostics-${{ github.run_number }}\`
+
           ## Diagnostics
 
-          Internal diagnostics artifact is uploaded for mount, policy, Codex event, and diff analysis.
+          Internal diagnostics artifact is uploaded for mount, policy, Codex event, and diff analysis. Public artifacts are redacted and allowlisted.
 
           ## Merge policy
 

--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -166,6 +166,9 @@ jobs:
       - name: Run public agent run bundle builder test
         run: python scripts/test_build_public_agent_run_bundle.py
 
+      - name: Run policy agent public bundle contract test
+        run: python scripts/test_policy_agent_public_bundle_contract.py
+
       - name: Run comparison dashboard builder test
         run: python scripts/test_build_comparison_dashboard.py
 

--- a/docs/public-agent-run-bundle.md
+++ b/docs/public-agent-run-bundle.md
@@ -6,7 +6,7 @@ Prompt Vote Lab is an experiment where prompts influence agent behavior.
 
 Participants need inspectable behavior evidence, not only final results.
 
-The public agent run bundle exposes a redacted raw evidence bundle for each fixed-Issue 009 agent run.
+The public agent run bundle exposes a redacted raw evidence bundle for canonical Docker/Codex policy-agent runs and fixed-Issue agent runs.
 
 ## Core rule
 
@@ -30,6 +30,10 @@ Examples:
 codex-events.jsonl
 codex-last-message.txt
 codex-exit-code.txt
+policy-agent-container-exit-code.txt
+policy-agent-diff.patch
+policy-agent-diff-name-only.txt
+policy-agent-copied-files.txt
 issue-instruction-container-exit-code.txt
 issue-instruction-diff.patch
 issue-instruction-diff-name-only.txt
@@ -71,6 +75,29 @@ container-visible-files-after.txt
 
 The exact allowlist is enforced by `scripts/build_public_agent_run_bundle.py`.
 
+## Why policy-agent files are included
+
+The canonical Docker/Codex policy-agent run must publish enough evidence to let participants verify that the runner edited prepared lab files rather than the repository root.
+
+These files provide that linkage:
+
+```text
+policy-agent-container-exit-code.txt
+policy-agent-diff-name-only.txt
+policy-agent-diff.patch
+policy-agent-copied-files.txt
+policy-allowed-paths.json
+policy-denied-access.txt
+container-visible-files-before.txt
+container-visible-files-after.txt
+```
+
+The uploaded artifact name for this canonical policy-agent public bundle begins with:
+
+```text
+codex-policy-agent-canary-public-bundle-
+```
+
 ## Why runtime scan and execution-gate files are included
 
 The public bundle must let participants connect prompt text to execution behavior.
@@ -98,6 +125,8 @@ codex-login-stdout.txt
 codex-login-stderr.txt
 codex-stderr.txt
 codex-stdout.txt
+policy-agent-container-stdout.txt
+policy-agent-container-stderr.txt
 issue-instruction-container-stdout.txt
 issue-instruction-container-stderr.txt
 npm-install-codex.txt
@@ -143,6 +172,23 @@ raw/<allowlisted-file>
 
 `README.md` is a human navigation file. It is not an interpretation layer.
 
+## 007 policy-agent workflow integration
+
+The canonical policy-agent workflow builds the bundle after diagnostics collection:
+
+```text
+Collect diagnostics artifact
+→ Build redacted public agent run bundle
+→ Upload redacted public agent run bundle
+→ Upload internal diagnostics artifact
+```
+
+The uploaded artifact name begins with:
+
+```text
+codex-policy-agent-canary-public-bundle-
+```
+
 ## 009 workflow integration
 
 The fixed-Issue 009 workflow builds the bundle after diagnostics collection:
@@ -172,6 +218,7 @@ which files changed
 what diff was produced
 whether forbidden files changed
 whether the task mount was read-only
+whether the repository root was withheld from /work
 what final agent message was produced
 how many JSONL events were emitted
 whether runtime scan was clear/blocked/review

--- a/scripts/build_public_agent_run_bundle.py
+++ b/scripts/build_public_agent_run_bundle.py
@@ -18,6 +18,10 @@ PUBLIC_RAW_ALLOWLIST = [
     "codex-events.jsonl",
     "codex-last-message.txt",
     "codex-exit-code.txt",
+    "policy-agent-container-exit-code.txt",
+    "policy-agent-diff-name-only.txt",
+    "policy-agent-diff.patch",
+    "policy-agent-copied-files.txt",
     "issue-instruction-container-exit-code.txt",
     "issue-instruction-diff-name-only.txt",
     "issue-instruction-diff.patch",
@@ -57,13 +61,15 @@ PUBLIC_RAW_ALLOWLIST = [
     "container-visible-files-after.txt",
 ]
 
-# Files that can contain login flows, package manager noise, full mount paths, or stderr details.
+# Files that can contain login flows, package manager noise, full mount paths, stderr details, or environment details.
 # They remain internal diagnostics unless a later review explicitly promotes them.
 PUBLIC_RAW_DENYLIST = [
     "codex-login-stdout.txt",
     "codex-login-stderr.txt",
     "codex-stderr.txt",
     "codex-stdout.txt",
+    "policy-agent-container-stdout.txt",
+    "policy-agent-container-stderr.txt",
     "issue-instruction-container-stdout.txt",
     "issue-instruction-container-stderr.txt",
     "npm-install-codex.txt",
@@ -214,7 +220,7 @@ def build_bundle(diag: Path, out_dir: Path, run_id: str, issue_number: str, pr_n
         },
         "quick_index": {
             "codex_event_lines": event_count(diag / "codex-events.jsonl"),
-            "changed_files": check_results.get("changed_files") or line_list(diag / "issue-instruction-diff-name-only.txt"),
+            "changed_files": check_results.get("changed_files") or line_list(diag / "policy-agent-diff-name-only.txt") or line_list(diag / "issue-instruction-diff-name-only.txt"),
             "forbidden_changed_files": check_results.get("forbidden_changed_files"),
             "unsafe_instruction_count": safety.get("unsafe_instruction_count"),
             "unsafe_categories": [item.get("id") for item in safety.get("unsafe_instructions_detected", []) if isinstance(item, dict)],

--- a/scripts/test_build_public_agent_run_bundle.py
+++ b/scripts/test_build_public_agent_run_bundle.py
@@ -12,7 +12,7 @@ SCRIPT = ROOT / "scripts" / "build_public_agent_run_bundle.py"
 
 
 def write(path: Path, text: str) -> None:
-    path.parent.mkdir(parents=True)
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
 
 

--- a/scripts/test_build_public_agent_run_bundle.py
+++ b/scripts/test_build_public_agent_run_bundle.py
@@ -12,7 +12,7 @@ SCRIPT = ROOT / "scripts" / "build_public_agent_run_bundle.py"
 
 
 def write(path: Path, text: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
+    path.parent.mkdir(parents=True)
     path.write_text(text, encoding="utf-8")
 
 
@@ -30,6 +30,10 @@ def main() -> int:
         write(diag / "codex-events.jsonl", '{"type":"session.started"}\n{"type":"turn.completed"}\n')
         write(diag / "codex-last-message.txt", "Inspected /task files and changed lab/index.html only.\n")
         write(diag / "codex-exit-code.txt", "0\n")
+        write(diag / "policy-agent-container-exit-code.txt", "0\n")
+        write(diag / "policy-agent-diff-name-only.txt", "lab/index.html\n")
+        write(diag / "policy-agent-diff.patch", "diff --git a/lab/index.html b/lab/index.html\n")
+        write(diag / "policy-agent-copied-files.txt", "lab/index.html\n")
         write(diag / "issue-instruction-container-exit-code.txt", "0\n")
         write(diag / "issue-instruction-diff-name-only.txt", "lab/index.html\n")
         write(diag / "issue-instruction-diff.patch", "diff --git a/lab/index.html b/lab/index.html\n")
@@ -49,6 +53,8 @@ def main() -> int:
         write(diag / "issue-execution-gate.md", "Execution gate: PASS\n")
         write(diag / "codex-login-stderr.txt", "login noise should be omitted\n")
         write(diag / "codex-stderr.txt", "stderr should be omitted even if safe\n")
+        write(diag / "policy-agent-container-stdout.txt", "container stdout should be omitted\n")
+        write(diag / "policy-agent-container-stderr.txt", "container stderr should be omitted\n")
         write(diag / "issue-instruction-container-stderr.txt", "container stderr should be omitted\n")
 
         write_json(diag / "check-results.json", {"changed_files": ["lab/index.html"], "forbidden_changed_files": []})
@@ -120,6 +126,10 @@ def main() -> int:
         raw_names = {path.name for path in (out / "raw").iterdir()}
         assert "codex-events.jsonl" in raw_names
         assert "codex-last-message.txt" in raw_names
+        assert "policy-agent-container-exit-code.txt" in raw_names
+        assert "policy-agent-diff-name-only.txt" in raw_names
+        assert "policy-agent-diff.patch" in raw_names
+        assert "policy-agent-copied-files.txt" in raw_names
         assert "task-raw-issue-body.md" in raw_names
         assert "source-issue.raw.json" in raw_names
         assert "runtime-issue-safety-scan.json" in raw_names
@@ -128,6 +138,8 @@ def main() -> int:
         assert "issue-execution-gate.md" in raw_names
         assert "codex-login-stderr.txt" not in raw_names
         assert "codex-stderr.txt" not in raw_names
+        assert "policy-agent-container-stdout.txt" not in raw_names
+        assert "policy-agent-container-stderr.txt" not in raw_names
         assert "issue-instruction-container-stderr.txt" not in raw_names
 
         raw_issue = (out / "raw" / "task-raw-issue-body.md").read_text(encoding="utf-8")
@@ -142,6 +154,7 @@ def main() -> int:
         readme = (out / "README.md").read_text(encoding="utf-8")
         assert "redacted raw evidence" in readme
         assert "It does not replace raw evidence" in readme
+        assert "policy-agent-container-stderr.txt" in readme
         assert "codex-login-stderr.txt" in readme
 
     print("public agent run bundle builder test passed")

--- a/scripts/test_policy_agent_public_bundle_contract.py
+++ b/scripts/test_policy_agent_public_bundle_contract.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "codex-policy-agent-canary-run.yml"
+BUNDLE = ROOT / "scripts" / "build_public_agent_run_bundle.py"
+DOC = ROOT / "docs" / "public-agent-run-bundle.md"
+
+REQUIRED_WORKFLOW_TEXT = [
+    "name: Codex Policy Agent Canary Run",
+    "bash scripts/run_codex_policy_agent_canary.sh",
+    "python scripts/collect_canary_diagnostics.py",
+    "Build redacted public agent run bundle",
+    "python scripts/build_public_agent_run_bundle.py",
+    "--diagnostics-dir .tmp/canary-diagnostics",
+    "--out-dir .tmp/public-agent-run-bundle",
+    "codex-policy-agent-canary-public-bundle-",
+    "Upload redacted public agent run bundle",
+    "codex-policy-agent-canary-diagnostics-",
+    "codex-policy-agent-canary-public-log-",
+    "Redacted public agent run bundle artifact",
+    "Public artifacts are redacted and allowlisted.",
+]
+
+REQUIRED_BUNDLE_TEXT = [
+    '"policy-agent-container-exit-code.txt"',
+    '"policy-agent-diff-name-only.txt"',
+    '"policy-agent-diff.patch"',
+    '"policy-agent-copied-files.txt"',
+    '"policy-agent-container-stdout.txt"',
+    '"policy-agent-container-stderr.txt"',
+    '"policy-container-mounts.txt"',
+    'line_list(diag / "policy-agent-diff-name-only.txt")',
+]
+
+REQUIRED_DOC_TEXT = [
+    "policy-agent-container-exit-code.txt",
+    "policy-agent-diff-name-only.txt",
+    "policy-agent-diff.patch",
+    "policy-agent-copied-files.txt",
+    "codex-policy-agent-canary-public-bundle-",
+    "policy-agent-container-stdout.txt",
+    "policy-agent-container-stderr.txt",
+]
+
+FORBIDDEN_WORKFLOW_TEXT = [
+    "cat .tmp/canary-diagnostics/codex-stderr.txt",
+    "Upload raw public agent run bundle",
+]
+
+
+def require_all(text: str, required: list[str], label: str) -> None:
+    missing = [item for item in required if item not in text]
+    if missing:
+        raise SystemExit(f"Missing {label} text: {missing}")
+
+
+def reject_all(text: str, forbidden: list[str], label: str) -> None:
+    found = [item for item in forbidden if item in text]
+    if found:
+        raise SystemExit(f"Forbidden {label} text found: {found}")
+
+
+def main() -> int:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    bundle = BUNDLE.read_text(encoding="utf-8")
+    doc = DOC.read_text(encoding="utf-8")
+
+    require_all(workflow, REQUIRED_WORKFLOW_TEXT, "policy agent workflow")
+    reject_all(workflow, FORBIDDEN_WORKFLOW_TEXT, "policy agent workflow")
+    require_all(bundle, REQUIRED_BUNDLE_TEXT, "public bundle builder")
+    require_all(doc, REQUIRED_DOC_TEXT, "public agent run bundle doc")
+
+    if workflow.index("Collect diagnostics artifact") > workflow.index("Build redacted public agent run bundle"):
+        raise SystemExit("public bundle must be built after diagnostics collection")
+    if workflow.index("Build redacted public agent run bundle") > workflow.index("Upload redacted public agent run bundle"):
+        raise SystemExit("public bundle upload must occur after public bundle build")
+    if workflow.index("Upload redacted public agent run bundle") > workflow.index("Upload diagnostics artifact"):
+        raise SystemExit("public bundle should be uploaded before internal diagnostics artifact")
+
+    print("policy agent public bundle contract test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Makes the canonical Docker/Codex policy-agent workflow publish a redacted public agent run bundle in addition to internal diagnostics.

## Why

Codex logs are already collected, but most evidence currently remains internal Actions diagnostics. The project needs public, inspectable evidence where it is safe to publish it.

## Changes

- Build a redacted public agent run bundle from `.tmp/canary-diagnostics` in `Codex Policy Agent Canary Run`.
- Upload it as `codex-policy-agent-canary-public-bundle-${{ github.run_number }}`.
- Keep internal diagnostics as a separate artifact.
- Add policy-agent output files to the public bundle allowlist:
  - `policy-agent-container-exit-code.txt`
  - `policy-agent-diff-name-only.txt`
  - `policy-agent-diff.patch`
  - `policy-agent-copied-files.txt`
- Keep raw stderr/stdout, npm logs, and mount dumps out of public bundle by denylist.
- Document the public/private boundary for policy-agent bundles.
- Add and connect a contract test so this public bundle step cannot silently disappear.

## Scope

Workflow, docs, bundle builder, and tests only.

No lab UI changes, no generated evidence changes, no model/token-budget changes, and no weekly-auto-run migration in this PR.