### PR TITLE
Expand public agent observation logs

### DIFF
--- a/.github/workflows/codex-policy-agent-canary-run.yml
+++ b/.github/workflows/codex-policy-agent-canary-run.yml
@@ -91,6 +91,13 @@ jobs:
             --issue-number "0" \
             --pr-number ""
 
+      - name: Enrich public agent run bundle with sanitized logs
+        if: ${{ always() }}
+        run: |
+          python scripts/enrich_public_agent_run_bundle.py \
+            --diagnostics-dir .tmp/canary-diagnostics \
+            --bundle-dir .tmp/public-agent-run-bundle
+
       - name: Upload redacted public agent run bundle
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -194,12 +201,14 @@ jobs:
           ## Public evidence
 
           - Redacted public agent run bundle artifact: \`codex-policy-agent-canary-public-bundle-${{ github.run_number }}\`
+          - Observation summary files: \`observation-summary.md\`, \`observation-summary.json\`
+          - Sanitized diagnostic logs directory: \`sanitized/\`
           - Public run log artifact: \`codex-policy-agent-canary-public-log-${{ github.run_number }}\`
           - Internal diagnostics artifact: \`codex-policy-agent-canary-diagnostics-${{ github.run_number }}\`
 
           ## Diagnostics
 
-          Internal diagnostics artifact is uploaded for mount, policy, Codex event, and diff analysis. Public artifacts are redacted and allowlisted.
+          Internal diagnostics artifact is uploaded for mount, policy, Codex event, and diff analysis. Public artifacts are redacted, sanitized, and indexed for participant review.
 
           ## Merge policy
 

--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -166,6 +166,9 @@ jobs:
       - name: Run public agent run bundle builder test
         run: python scripts/test_build_public_agent_run_bundle.py
 
+      - name: Run public agent run bundle enrichment test
+        run: python scripts/test_enrich_public_agent_run_bundle.py
+
       - name: Run policy agent public bundle contract test
         run: python scripts/test_policy_agent_public_bundle_contract.py
 

--- a/docs/public-agent-run-bundle.md
+++ b/docs/public-agent-run-bundle.md
@@ -6,13 +6,21 @@ Prompt Vote Lab is an experiment where prompts influence agent behavior.
 
 Participants need inspectable behavior evidence, not only final results.
 
-The public agent run bundle exposes a redacted raw evidence bundle for canonical Docker/Codex policy-agent runs and fixed-Issue agent runs.
+The public agent run bundle exposes:
+
+```text
+redacted raw evidence
+sanitized diagnostic logs
+agent observation summaries
+```
+
+for canonical Docker/Codex policy-agent runs and fixed-Issue agent runs.
 
 ## Core rule
 
 ```text
-Primary evidence: redacted raw files
-Secondary evidence: index and manifest
+Primary evidence: redacted raw files and sanitized logs
+Secondary evidence: observation summary, index, and manifest
 Model-written summary: not primary evidence
 ```
 
@@ -20,7 +28,7 @@ Do not replace raw evidence with a model-written summary.
 
 Summaries can hide failure modes, reflect prompt or model bias, and make participants miss important behavior.
 
-## What is published
+## What is published as raw evidence
 
 The bundle publishes allowlisted raw diagnostic files after secret-pattern redaction.
 
@@ -75,6 +83,69 @@ container-visible-files-after.txt
 
 The exact allowlist is enforced by `scripts/build_public_agent_run_bundle.py`.
 
+## What is published as sanitized diagnostics
+
+Some logs are useful for prompt improvement but too noisy or risky to publish as raw evidence. These are published after sanitizer replacement under `sanitized/`.
+
+Examples:
+
+```text
+sanitized/codex-login-stdout.txt
+sanitized/codex-login-stderr.txt
+sanitized/codex-stderr.txt
+sanitized/codex-stdout.txt
+sanitized/policy-agent-container-stdout.txt
+sanitized/policy-agent-container-stderr.txt
+sanitized/issue-instruction-container-stdout.txt
+sanitized/issue-instruction-container-stderr.txt
+sanitized/npm-install-codex.txt
+sanitized/npm-install-codex-stderr.txt
+sanitized/policy-container-mounts.txt
+sanitized/container-runtime-files-after.txt
+sanitized/container-runtime-dirs-before.txt
+```
+
+The sanitizer replaces token-like, environment-like, and path-like strings before publication.
+
+Examples:
+
+```text
+[REDACTED_SECRET]
+[REDACTED_RUNNER_WORKDIR]
+[REDACTED_RUNNER_TEMP]
+[REDACTED_TMP_PATH]
+[REDACTED_GITHUB_WORKSPACE]
+```
+
+Sanitization is a best-effort publication guard. If a real token is discovered in a public artifact, rotate it and treat it as an incident.
+
+## Agent observation summary
+
+The enriched bundle contains:
+
+```text
+observation-summary.md
+observation-summary.json
+```
+
+These files summarize:
+
+```text
+path model
+/work, /task, and /codex-runtime roles
+whether the repository root was mounted
+visible files before and after
+changed files
+copied-back files
+additions and deletions by file
+hashes before and after
+sanitized logs and redaction counts
+agent final action summary
+known evidence limits
+```
+
+The observation summary is a navigation index over evidence. It is not private reasoning.
+
 ## Why policy-agent files are included
 
 The canonical Docker/Codex policy-agent run must publish enough evidence to let participants verify that the runner edited prepared lab files rather than the repository root.
@@ -114,33 +185,9 @@ issue-execution-gate.md
 
 Without them, a participant can see the diff and Codex events but cannot independently verify whether the Issue was clear, blocked, authorized, or stopped before execution.
 
-## What is omitted
-
-The bundle omits diagnostics that are more likely to contain credentials, package-manager noise, login flow details, raw stderr, or environment details.
-
-Examples:
-
-```text
-codex-login-stdout.txt
-codex-login-stderr.txt
-codex-stderr.txt
-codex-stdout.txt
-policy-agent-container-stdout.txt
-policy-agent-container-stderr.txt
-issue-instruction-container-stdout.txt
-issue-instruction-container-stderr.txt
-npm-install-codex.txt
-npm-install-codex-stderr.txt
-policy-container-mounts.txt
-container-runtime-files-after.txt
-container-runtime-dirs-before.txt
-```
-
-These remain internal diagnostics unless a later manual review explicitly promotes a file class.
-
 ## Redaction
 
-The builder redacts common secret-like patterns before publishing allowlisted raw files.
+The builder and enrichment step redact common secret-like patterns before publishing allowlisted or sanitized files.
 
 Examples:
 
@@ -152,33 +199,38 @@ Authorization bearer tokens
 OPENAI_API_KEY assignments
 GITHUB_TOKEN assignments
 GH_TOKEN assignments
+runner workspace paths
+temporary directory paths
+GitHub workspace paths
 ```
 
 Redaction is a safety net, not a proof that all secrets are impossible.
 
-Therefore the allowlist remains narrow.
-
 ## Bundle structure
 
-Each bundle contains:
+Each enriched bundle contains:
 
 ```text
 index.json
 README.md
+observation-summary.md
+observation-summary.json
 raw/<allowlisted-file>
+sanitized/<sanitized-file>
 ```
 
-`index.json` is a manifest and quick index. It is not a replacement for `raw/`.
+`index.json` is a manifest and quick index. It is not a replacement for `raw/` or `sanitized/`.
 
 `README.md` is a human navigation file. It is not an interpretation layer.
 
 ## 007 policy-agent workflow integration
 
-The canonical policy-agent workflow builds the bundle after diagnostics collection:
+The canonical policy-agent workflow builds and enriches the bundle after diagnostics collection:
 
 ```text
 Collect diagnostics artifact
 → Build redacted public agent run bundle
+→ Enrich public agent run bundle with sanitized logs
 → Upload redacted public agent run bundle
 → Upload internal diagnostics artifact
 ```
@@ -221,6 +273,7 @@ whether the task mount was read-only
 whether the repository root was withheld from /work
 what final agent message was produced
 how many JSONL events were emitted
+what stdout/stderr/install logs looked like after sanitization
 whether runtime scan was clear/blocked/review
 whether the execution gate allowed or stopped the run
 which source Issue generated the task packet
@@ -230,26 +283,33 @@ The project does not automatically explain or score these observations.
 
 ## Non-goals
 
-Do not add these to the public bundle without a separate review:
+Do not publish these without sanitizer or separate review:
 
 ```text
-raw Actions logs
-raw container stderr
-raw login stdout/stderr
-full package-manager install logs
+unsanitized raw Actions logs
+unsanitized raw container stderr
+unsanitized login stdout/stderr
+unsanitized full package-manager install logs
 secrets
 private data
 payment identifiers
 automatic prompt advice
 model-written causal explanation
+raw private chain-of-thought
 ```
 
 ## Schema
 
-Current schema:
+Current raw bundle schema:
 
 ```text
 prompt-vote-lab-public-agent-run-bundle-v1
+```
+
+Current observation summary schema:
+
+```text
+prompt-vote-lab-agent-observation-summary-v1
 ```
 
 Breaking changes should use a new schema version.

--- a/scripts/enrich_public_agent_run_bundle.py
+++ b/scripts/enrich_public_agent_run_bundle.py
@@ -37,10 +37,10 @@ SECRET_PATTERNS = [
 ]
 
 PATH_PATTERNS = [
-    ("runner_workdir", re.compile(r"/home/runner/work/[^\s:'\"]+")),
-    ("runner_temp", re.compile(r"/home/runner/[^\s:'\"]+")),
-    ("tmp_path", re.compile(r"/tmp/[^\s:'\"]+")),
-    ("github_workspace", re.compile(r"/github/workspace[^\s:'\"]*")),
+    ("runner_workdir", "[REDACTED_RUNNER_WORKDIR]", re.compile(r"/home/runner/work/[^\s:'\"]+")),
+    ("runner_temp", "[REDACTED_RUNNER_TEMP]", re.compile(r"/home/runner/[^\s:'\"]+")),
+    ("tmp_path", "[REDACTED_TMP_PATH]", re.compile(r"/tmp/[^\s:'\"]+")),
+    ("github_workspace", "[REDACTED_GITHUB_WORKSPACE]", re.compile(r"/github/workspace[^\s:'\"]*")),
 ]
 
 
@@ -84,8 +84,8 @@ def redact_for_public(text: str) -> tuple[str, list[dict[str, Any]]]:
         if count:
             redactions.append({"kind": name, "count": count})
 
-    for name, pattern in PATH_PATTERNS:
-        out, count = pattern.subn(f"[REDACTED_{name.upper()}]", out)
+    for name, token, pattern in PATH_PATTERNS:
+        out, count = pattern.subn(token, out)
         if count:
             redactions.append({"kind": name, "count": count})
 

--- a/scripts/enrich_public_agent_run_bundle.py
+++ b/scripts/enrich_public_agent_run_bundle.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+OBSERVATION_SCHEMA_VERSION = "prompt-vote-lab-agent-observation-summary-v1"
+
+SANITIZED_PUBLIC_FILES = [
+    "codex-login-stdout.txt",
+    "codex-login-stderr.txt",
+    "codex-stderr.txt",
+    "codex-stdout.txt",
+    "policy-agent-container-stdout.txt",
+    "policy-agent-container-stderr.txt",
+    "issue-instruction-container-stdout.txt",
+    "issue-instruction-container-stderr.txt",
+    "npm-install-codex.txt",
+    "npm-install-codex-stderr.txt",
+    "policy-container-mounts.txt",
+    "container-runtime-files-after.txt",
+    "container-runtime-dirs-before.txt",
+]
+
+SECRET_PATTERNS = [
+    ("openai_key", re.compile(r"sk-[A-Za-z0-9_\-]{12,}")),
+    ("github_classic_token", re.compile(r"gh[pousr]_[A-Za-z0-9_]{12,}")),
+    ("github_fine_grained_token", re.compile(r"github_pat_[A-Za-z0-9_]{12,}")),
+    ("authorization_bearer", re.compile(r"(?i)(authorization:\s*bearer\s+)[A-Za-z0-9_.\-]+")),
+    ("openai_env_assignment", re.compile(r"(?i)(OPENAI_API_KEY\s*[:=]\s*)[^\s]+")),
+    ("github_token_env_assignment", re.compile(r"(?i)(GITHUB_TOKEN\s*[:=]\s*)[^\s]+")),
+    ("gh_token_env_assignment", re.compile(r"(?i)(GH_TOKEN\s*[:=]\s*)[^\s]+")),
+]
+
+PATH_PATTERNS = [
+    ("runner_workdir", re.compile(r"/home/runner/work/[^\s:'\"]+")),
+    ("runner_temp", re.compile(r"/home/runner/[^\s:'\"]+")),
+    ("tmp_path", re.compile(r"/tmp/[^\s:'\"]+")),
+    ("github_workspace", re.compile(r"/github/workspace[^\s:'\"]*")),
+]
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def read_text(path: Path) -> str:
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def read_json(path: Path, fallback: Any) -> Any:
+    if not path.exists():
+        return fallback
+    try:
+        return json.loads(path.read_text(encoding="utf-8", errors="replace") or json.dumps(fallback))
+    except json.JSONDecodeError:
+        return fallback
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def line_list(path: Path) -> list[str]:
+    return [line.strip() for line in read_text(path).splitlines() if line.strip()]
+
+
+def redact_for_public(text: str) -> tuple[str, list[dict[str, Any]]]:
+    out = text
+    redactions: list[dict[str, Any]] = []
+
+    for name, pattern in SECRET_PATTERNS:
+        if name.endswith("_assignment") or name == "authorization_bearer":
+            out, count = pattern.subn(lambda match: f"{match.group(1)}[REDACTED_SECRET]", out)
+        else:
+            out, count = pattern.subn("[REDACTED_SECRET]", out)
+        if count:
+            redactions.append({"kind": name, "count": count})
+
+    for name, pattern in PATH_PATTERNS:
+        out, count = pattern.subn(f"[REDACTED_{name.upper()}]", out)
+        if count:
+            redactions.append({"kind": name, "count": count})
+
+    return out, redactions
+
+
+def copy_sanitized_files(diag: Path, bundle: Path) -> list[dict[str, Any]]:
+    out_dir = bundle / "sanitized"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    manifest: list[dict[str, Any]] = []
+    for name in SANITIZED_PUBLIC_FILES:
+        source = diag / name
+        if not source.exists() or not source.is_file():
+            manifest.append({"name": name, "included": False, "reason": "not_found"})
+            continue
+        raw = read_text(source)
+        sanitized, redactions = redact_for_public(raw)
+        dest = out_dir / name
+        dest.write_text(sanitized, encoding="utf-8")
+        manifest.append(
+            {
+                "name": name,
+                "included": True,
+                "path": f"sanitized/{name}",
+                "source_size_bytes": source.stat().st_size,
+                "public_size_bytes": dest.stat().st_size,
+                "redactions": redactions,
+                "quarantined": False,
+            }
+        )
+    return manifest
+
+
+def patch_stats(patch: str) -> dict[str, dict[str, int]]:
+    stats: dict[str, dict[str, int]] = {}
+    current: str | None = None
+    for line in patch.splitlines():
+        if line.startswith("diff --git "):
+            parts = line.split()
+            current = parts[-1][2:] if len(parts) >= 4 and parts[-1].startswith("b/") else None
+            if current:
+                stats.setdefault(current, {"additions": 0, "deletions": 0})
+            continue
+        if not current:
+            continue
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if line.startswith("+"):
+            stats[current]["additions"] += 1
+        elif line.startswith("-"):
+            stats[current]["deletions"] += 1
+    return stats
+
+
+def first_existing(diag: Path, names: list[str]) -> Path | None:
+    for name in names:
+        p = diag / name
+        if p.exists():
+            return p
+    return None
+
+
+def build_observation_summary(diag: Path, bundle: Path, sanitized_manifest: list[dict[str, Any]]) -> dict[str, Any]:
+    index = read_json(bundle / "index.json", {})
+    policy = read_json(diag / "policy-allowed-paths.json", {})
+    check_results = read_json(diag / "check-results.json", {})
+    before_hashes = read_json(diag / "file-hashes-before.json", {})
+    after_hashes = read_json(diag / "file-hashes-after.json", {})
+
+    changed_files = check_results.get("changed_files") or line_list(diag / "policy-agent-diff-name-only.txt") or line_list(diag / "issue-instruction-diff-name-only.txt") or line_list(diag / "git-diff-name-only.txt")
+    copied_files = line_list(diag / "policy-agent-copied-files.txt") or line_list(diag / "issue-instruction-copied-files.txt")
+    visible_before = line_list(diag / "container-visible-files-before.txt")
+    visible_after = line_list(diag / "container-visible-files-after.txt")
+    task_visible = line_list(diag / "task-visible-files-container.txt") or line_list(diag / "task-visible-files.txt")
+    denied_access = line_list(diag / "policy-denied-access.txt")
+
+    patch_path = first_existing(diag, ["policy-agent-diff.patch", "issue-instruction-diff.patch", "git-diff.patch"])
+    stats = patch_stats(read_text(patch_path)) if patch_path else {}
+    final_paths = policy.get("final_copyback_paths") or ["lab/index.html", "lab/style.css", "lab/app.js"]
+    normalized_final_paths = [str(path).removeprefix("/work/") for path in final_paths]
+
+    file_set = sorted(set(normalized_final_paths) | set(changed_files) | set(copied_files))
+    file_activity = []
+    for name in file_set:
+        container_path = name if name.startswith("/work/") else f"/work/{name}"
+        before = before_hashes.get(name, {}) if isinstance(before_hashes, dict) else {}
+        after = after_hashes.get(name, {}) if isinstance(after_hashes, dict) else {}
+        file_activity.append(
+            {
+                "file": name,
+                "container_path": container_path,
+                "visible_before": container_path in visible_before or name in visible_before,
+                "visible_after": container_path in visible_after or name in visible_after,
+                "changed": name in changed_files,
+                "copied_back": name in copied_files,
+                "additions": stats.get(name, {}).get("additions", 0),
+                "deletions": stats.get(name, {}).get("deletions", 0),
+                "sha256_before": before.get("sha256") if isinstance(before, dict) else None,
+                "sha256_after": after.get("sha256") if isinstance(after, dict) else None,
+                "size_before_bytes": before.get("size_bytes") if isinstance(before, dict) else None,
+                "size_after_bytes": after.get("size_bytes") if isinstance(after, dict) else None,
+            }
+        )
+
+    final_summary, final_summary_redactions = redact_for_public(read_text(diag / "codex-last-message.txt"))
+    return {
+        "schema_version": OBSERVATION_SCHEMA_VERSION,
+        "generated_at": utc_now(),
+        "run_id": index.get("run_id"),
+        "issue_number": index.get("issue_number"),
+        "pr_number": index.get("pr_number"),
+        "path_model": {
+            "repo_root_mounted": policy.get("repo_root_mounted"),
+            "work_root": policy.get("container_work_root") or "/work",
+            "task_root": "/task" if task_visible else None,
+            "task_mount_mode": "read-only" if task_visible else None,
+            "runtime_root": policy.get("container_runtime_root") or "/codex-runtime",
+            "final_copyback_paths": normalized_final_paths,
+        },
+        "agent_observation": {
+            "visible_files_before": visible_before,
+            "visible_files_after": visible_after,
+            "task_visible_files": task_visible,
+            "denied_access_paths": denied_access,
+            "codex_event_lines": index.get("quick_index", {}).get("codex_event_lines"),
+            "agent_final_action_summary": final_summary[:4000],
+            "agent_final_action_summary_redactions": final_summary_redactions,
+        },
+        "file_activity": file_activity,
+        "sanitized_logs": sanitized_manifest,
+        "limits": {
+            "exact_read_order_observed": False,
+            "exact_read_order_reason": "This summary records visible files, changed files, copied files, diffs, hashes, and event counts. Exact file read sequence is not guaranteed unless the Codex event schema exposes it and is reviewed separately.",
+            "raw_private_reasoning_collected": False,
+            "raw_private_reasoning_policy": "Raw private chain-of-thought is not collected or published. The public record uses final action summary plus objective artifacts.",
+            "sanitizer_guarantee": "Best-effort pattern redaction before publication. A public leak must still be treated as an incident and rotated if a real token is found.",
+        },
+    }
+
+
+def render_table(headers: list[str], rows: list[list[Any]]) -> str:
+    lines = ["| " + " | ".join(headers) + " |", "| " + " | ".join(["---"] * len(headers)) + " |"]
+    for row in rows:
+        lines.append("| " + " | ".join(str(cell).replace("\n", " ") for cell in row) + " |")
+    return "\n".join(lines)
+
+
+def render_observation_md(summary: dict[str, Any]) -> str:
+    path_model = summary["path_model"]
+    agent = summary["agent_observation"]
+    files = summary["file_activity"]
+    sanitized = summary["sanitized_logs"]
+    return "\n".join(
+        [
+            "# Agent observation summary",
+            "",
+            "This is a participant-facing observation index. It describes visible files, changed files, copied files, sanitized logs, and the agent final action summary.",
+            "It is not raw private reasoning.",
+            "",
+            "## Path model",
+            "",
+            render_table(
+                ["field", "value"],
+                [
+                    ["repo_root_mounted", path_model.get("repo_root_mounted")],
+                    ["work_root", path_model.get("work_root")],
+                    ["task_root", path_model.get("task_root")],
+                    ["task_mount_mode", path_model.get("task_mount_mode")],
+                    ["runtime_root", path_model.get("runtime_root")],
+                    ["final_copyback_paths", ", ".join(path_model.get("final_copyback_paths") or [])],
+                ],
+            ),
+            "",
+            "## File activity",
+            "",
+            render_table(
+                ["file", "visible_before", "visible_after", "changed", "copied_back", "+", "-"],
+                [[item.get("file"), item.get("visible_before"), item.get("visible_after"), item.get("changed"), item.get("copied_back"), item.get("additions"), item.get("deletions")] for item in files],
+            ),
+            "",
+            "## Sanitized logs",
+            "",
+            render_table(
+                ["file", "included", "redactions"],
+                [[item.get("name"), item.get("included"), ", ".join(f"{r.get('kind')}:{r.get('count')}" for r in item.get("redactions", []))] for item in sanitized],
+            ),
+            "",
+            "## Agent final action summary",
+            "",
+            agent.get("agent_final_action_summary") or "No final action summary captured.",
+            "",
+            "## Evidence limits",
+            "",
+            "- Exact file read order is not guaranteed by this summary.",
+            "- Raw private chain-of-thought is not collected or published.",
+            "- Sanitization is best-effort. Real token discovery still requires rotation.",
+            "- Use raw/codex-events.jsonl and sanitized/* logs for deeper inspection.",
+            "",
+        ]
+    )
+
+
+def append_readme(bundle: Path) -> None:
+    readme = bundle / "README.md"
+    existing = read_text(readme)
+    addition = "\n".join(
+        [
+            "",
+            "## Agent observation summary",
+            "",
+            "Start with `observation-summary.md` to see:",
+            "",
+            "```text",
+            "path model",
+            "file activity",
+            "sanitized logs",
+            "agent final action summary",
+            "evidence limits",
+            "```",
+            "",
+            "Use `observation-summary.json` for machine-readable analysis.",
+            "Sanitized diagnostic logs are under `sanitized/`.",
+            "",
+        ]
+    )
+    readme.write_text(existing + addition, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--diagnostics-dir", required=True)
+    parser.add_argument("--bundle-dir", required=True)
+    args = parser.parse_args()
+
+    diag = Path(args.diagnostics_dir)
+    bundle = Path(args.bundle_dir)
+    if not bundle.exists():
+        raise SystemExit(f"bundle dir not found: {bundle}")
+
+    sanitized_manifest = copy_sanitized_files(diag, bundle)
+    summary = build_observation_summary(diag, bundle, sanitized_manifest)
+    write_json(bundle / "observation-summary.json", summary)
+    (bundle / "observation-summary.md").write_text(render_observation_md(summary), encoding="utf-8")
+
+    index_path = bundle / "index.json"
+    index = read_json(index_path, {})
+    index["sanitized_files"] = sanitized_manifest
+    index["observation_summary"] = {
+        "json": "observation-summary.json",
+        "markdown": "observation-summary.md",
+        "schema_version": OBSERVATION_SCHEMA_VERSION,
+    }
+    policy = index.setdefault("policy", {})
+    policy["sanitized_diagnostic_logs_included"] = True
+    policy["sanitizer_guarantee"] = "best_effort_pattern_redaction"
+    write_json(index_path, index)
+    append_readme(bundle)
+    print(str(bundle))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_enrich_public_agent_run_bundle.py
+++ b/scripts/test_enrich_public_agent_run_bundle.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "enrich_public_agent_run_bundle.py"
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def write_json(path: Path, value: object) -> None:
+    write(path, json.dumps(value, indent=2, sort_keys=True) + "\n")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        diag = tmp / "diag"
+        bundle = tmp / "bundle"
+        diag.mkdir()
+        bundle.mkdir()
+        (bundle / "raw").mkdir()
+
+        write_json(
+            bundle / "index.json",
+            {
+                "schema_version": "prompt-vote-lab-public-agent-run-bundle-v1",
+                "run_id": "fixture-run",
+                "issue_number": "12",
+                "pr_number": "34",
+                "policy": {"primary_artifact": "redacted raw files"},
+                "quick_index": {"codex_event_lines": 2},
+                "included_files": [],
+                "omitted_files": [],
+            },
+        )
+        write(bundle / "README.md", "# Public agent run bundle\n")
+
+        write_json(
+            diag / "policy-allowed-paths.json",
+            {
+                "repo_root_mounted": False,
+                "container_work_root": "/work",
+                "container_runtime_root": "/codex-runtime",
+                "final_copyback_paths": ["lab/index.html", "lab/style.css", "lab/app.js"],
+            },
+        )
+        write_json(diag / "check-results.json", {"changed_files": ["lab/index.html"], "forbidden_changed_files": []})
+        write_json(
+            diag / "file-hashes-before.json",
+            {"lab/index.html": {"sha256": "old-index", "size_bytes": 10}, "lab/style.css": {"sha256": "old-css", "size_bytes": 20}},
+        )
+        write_json(
+            diag / "file-hashes-after.json",
+            {"lab/index.html": {"sha256": "new-index", "size_bytes": 30}, "lab/style.css": {"sha256": "old-css", "size_bytes": 20}},
+        )
+        write(diag / "container-visible-files-before.txt", "/work/lab/index.html\n/work/lab/style.css\n/work/lab/app.js\n")
+        write(diag / "container-visible-files-after.txt", "/work/lab/index.html\n/work/lab/style.css\n/work/lab/app.js\n")
+        write(diag / "task-visible-files-container.txt", "/task/execution-policy.md\n/task/instruction-brief.md\n")
+        write(diag / "policy-agent-copied-files.txt", "lab/index.html\n")
+        write(diag / "policy-denied-access.txt", "/repo/private-file.txt\n")
+        write(
+            diag / "policy-agent-diff.patch",
+            "diff --git a/lab/index.html b/lab/index.html\n--- a/lab/index.html\n+++ b/lab/index.html\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
+        )
+        write(diag / "codex-last-message.txt", "I changed lab/index.html and did not touch app.js. token sk-FAKEFAKEFAKEFAKE should redact.\n")
+        write(diag / "codex-stderr.txt", "stderr path /home/runner/work/prompt-vote-lab/prompt-vote-lab and key sk-FAKEFAKEFAKEFAKEFAKEFAKEFAKE\n")
+        write(diag / "policy-agent-container-stderr.txt", "container stderr from /tmp/pvl-secret\n")
+        write(diag / "npm-install-codex.txt", "npm installed in /github/workspace with GH_TOKEN=ghp_FAKEFAKEFAKEFAKEFAKE\n")
+        write(diag / "policy-container-mounts.txt", "/home/runner/work/prompt-vote-lab/prompt-vote-lab/.tmp/work /work rw\n")
+
+        subprocess.run(
+            [sys.executable, str(SCRIPT), "--diagnostics-dir", str(diag), "--bundle-dir", str(bundle)],
+            cwd=ROOT,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        index = json.loads((bundle / "index.json").read_text(encoding="utf-8"))
+        assert index["policy"]["sanitized_diagnostic_logs_included"] is True
+        assert index["policy"]["sanitizer_guarantee"] == "best_effort_pattern_redaction"
+        assert index["observation_summary"]["json"] == "observation-summary.json"
+        assert index["observation_summary"]["markdown"] == "observation-summary.md"
+
+        sanitized_stderr = (bundle / "sanitized" / "codex-stderr.txt").read_text(encoding="utf-8")
+        assert "sk-FAKE" not in sanitized_stderr
+        assert "/home/runner/work" not in sanitized_stderr
+        assert "[REDACTED_SECRET]" in sanitized_stderr
+        assert "[REDACTED_RUNNER_WORKDIR]" in sanitized_stderr
+
+        npm_log = (bundle / "sanitized" / "npm-install-codex.txt").read_text(encoding="utf-8")
+        assert "ghp_FAKE" not in npm_log
+        assert "/github/workspace" not in npm_log
+        assert "[REDACTED_SECRET]" in npm_log
+        assert "[REDACTED_GITHUB_WORKSPACE]" in npm_log
+
+        summary = json.loads((bundle / "observation-summary.json").read_text(encoding="utf-8"))
+        assert summary["schema_version"] == "prompt-vote-lab-agent-observation-summary-v1"
+        assert summary["path_model"]["repo_root_mounted"] is False
+        assert summary["path_model"]["work_root"] == "/work"
+        assert summary["path_model"]["task_root"] == "/task"
+        assert summary["path_model"]["task_mount_mode"] == "read-only"
+        assert summary["agent_observation"]["denied_access_paths"] == ["/repo/private-file.txt"]
+        assert "sk-FAKE" not in summary["agent_observation"]["agent_final_action_summary"]
+        assert "[REDACTED_SECRET]" in summary["agent_observation"]["agent_final_action_summary"]
+        assert summary["limits"]["raw_private_reasoning_collected"] is False
+        assert summary["limits"]["exact_read_order_observed"] is False
+
+        by_file = {item["file"]: item for item in summary["file_activity"]}
+        assert by_file["lab/index.html"]["changed"] is True
+        assert by_file["lab/index.html"]["copied_back"] is True
+        assert by_file["lab/index.html"]["additions"] == 2
+        assert by_file["lab/index.html"]["deletions"] == 1
+        assert by_file["lab/style.css"]["changed"] is False
+
+        md = (bundle / "observation-summary.md").read_text(encoding="utf-8")
+        assert "Agent observation summary" in md
+        assert "Sanitized logs" in md
+        assert "Exact file read order is not guaranteed" in md
+
+        readme = (bundle / "README.md").read_text(encoding="utf-8")
+        assert "Agent observation summary" in readme
+        assert "Sanitized diagnostic logs" in readme
+
+    print("public agent run bundle enrichment test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_policy_agent_public_bundle_contract.py
+++ b/scripts/test_policy_agent_public_bundle_contract.py
@@ -24,8 +24,11 @@ REQUIRED_WORKFLOW_TEXT = [
     "Upload redacted public agent run bundle",
     "codex-policy-agent-canary-diagnostics-",
     "codex-policy-agent-canary-public-log-",
-    "Observation summary files: `observation-summary.md`, `observation-summary.json`",
-    "Sanitized diagnostic logs directory: `sanitized/`",
+    "Observation summary files:",
+    "observation-summary.md",
+    "observation-summary.json",
+    "Sanitized diagnostic logs directory:",
+    "sanitized/",
     "Public artifacts are redacted, sanitized, and indexed for participant review.",
 ]
 

--- a/scripts/test_policy_agent_public_bundle_contract.py
+++ b/scripts/test_policy_agent_public_bundle_contract.py
@@ -6,6 +6,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "codex-policy-agent-canary-run.yml"
 BUNDLE = ROOT / "scripts" / "build_public_agent_run_bundle.py"
+ENRICH = ROOT / "scripts" / "enrich_public_agent_run_bundle.py"
 DOC = ROOT / "docs" / "public-agent-run-bundle.md"
 
 REQUIRED_WORKFLOW_TEXT = [
@@ -14,14 +15,18 @@ REQUIRED_WORKFLOW_TEXT = [
     "python scripts/collect_canary_diagnostics.py",
     "Build redacted public agent run bundle",
     "python scripts/build_public_agent_run_bundle.py",
+    "Enrich public agent run bundle with sanitized logs",
+    "python scripts/enrich_public_agent_run_bundle.py",
     "--diagnostics-dir .tmp/canary-diagnostics",
+    "--bundle-dir .tmp/public-agent-run-bundle",
     "--out-dir .tmp/public-agent-run-bundle",
     "codex-policy-agent-canary-public-bundle-",
     "Upload redacted public agent run bundle",
     "codex-policy-agent-canary-diagnostics-",
     "codex-policy-agent-canary-public-log-",
-    "Redacted public agent run bundle artifact",
-    "Public artifacts are redacted and allowlisted.",
+    "Observation summary files: `observation-summary.md`, `observation-summary.json`",
+    "Sanitized diagnostic logs directory: `sanitized/`",
+    "Public artifacts are redacted, sanitized, and indexed for participant review.",
 ]
 
 REQUIRED_BUNDLE_TEXT = [
@@ -35,14 +40,35 @@ REQUIRED_BUNDLE_TEXT = [
     'line_list(diag / "policy-agent-diff-name-only.txt")',
 ]
 
+REQUIRED_ENRICH_TEXT = [
+    "SANITIZED_PUBLIC_FILES",
+    '"codex-stderr.txt"',
+    '"codex-stdout.txt"',
+    '"policy-agent-container-stdout.txt"',
+    '"policy-agent-container-stderr.txt"',
+    '"npm-install-codex.txt"',
+    '"policy-container-mounts.txt"',
+    "observation-summary.json",
+    "observation-summary.md",
+    "[REDACTED_SECRET]",
+    "[REDACTED_RUNNER_WORKDIR]",
+    "raw_private_reasoning_collected",
+    "exact_read_order_observed",
+]
+
 REQUIRED_DOC_TEXT = [
-    "policy-agent-container-exit-code.txt",
-    "policy-agent-diff-name-only.txt",
-    "policy-agent-diff.patch",
-    "policy-agent-copied-files.txt",
-    "codex-policy-agent-canary-public-bundle-",
-    "policy-agent-container-stdout.txt",
-    "policy-agent-container-stderr.txt",
+    "redacted raw evidence",
+    "sanitized diagnostic logs",
+    "agent observation summaries",
+    "sanitized/codex-stderr.txt",
+    "sanitized/policy-agent-container-stderr.txt",
+    "sanitized/npm-install-codex.txt",
+    "observation-summary.md",
+    "observation-summary.json",
+    "[REDACTED_SECRET]",
+    "[REDACTED_RUNNER_WORKDIR]",
+    "Sanitization is a best-effort publication guard.",
+    "raw private chain-of-thought",
 ]
 
 FORBIDDEN_WORKFLOW_TEXT = [
@@ -66,17 +92,21 @@ def reject_all(text: str, forbidden: list[str], label: str) -> None:
 def main() -> int:
     workflow = WORKFLOW.read_text(encoding="utf-8")
     bundle = BUNDLE.read_text(encoding="utf-8")
+    enrich = ENRICH.read_text(encoding="utf-8")
     doc = DOC.read_text(encoding="utf-8")
 
     require_all(workflow, REQUIRED_WORKFLOW_TEXT, "policy agent workflow")
     reject_all(workflow, FORBIDDEN_WORKFLOW_TEXT, "policy agent workflow")
     require_all(bundle, REQUIRED_BUNDLE_TEXT, "public bundle builder")
+    require_all(enrich, REQUIRED_ENRICH_TEXT, "public bundle enrichment script")
     require_all(doc, REQUIRED_DOC_TEXT, "public agent run bundle doc")
 
     if workflow.index("Collect diagnostics artifact") > workflow.index("Build redacted public agent run bundle"):
         raise SystemExit("public bundle must be built after diagnostics collection")
-    if workflow.index("Build redacted public agent run bundle") > workflow.index("Upload redacted public agent run bundle"):
-        raise SystemExit("public bundle upload must occur after public bundle build")
+    if workflow.index("Build redacted public agent run bundle") > workflow.index("Enrich public agent run bundle with sanitized logs"):
+        raise SystemExit("public bundle must be enriched after bundle build")
+    if workflow.index("Enrich public agent run bundle with sanitized logs") > workflow.index("Upload redacted public agent run bundle"):
+        raise SystemExit("public bundle upload must occur after enrichment")
     if workflow.index("Upload redacted public agent run bundle") > workflow.index("Upload diagnostics artifact"):
         raise SystemExit("public bundle should be uploaded before internal diagnostics artifact")
 


### PR DESCRIPTION
## Summary

Expands canonical Docker/Codex public evidence so participants can inspect sanitized diagnostic logs and an observation summary, not only a narrow raw allowlist.

## Why

Prompt Vote Lab participants need to see enough behavior evidence to improve future prompts:

- what files were visible
- which files changed
- which files were copied back
- what path model was used
- what sanitized stdout/stderr/install/mount logs showed
- what final action summary Codex gave

Publishing unsanitized logs is still unsafe, so this PR adds a publication sanitizer and observation index.

## Changes

- Add `scripts/enrich_public_agent_run_bundle.py`.
- Add `sanitized/` diagnostic log publication after pattern redaction.
- Add `observation-summary.md` and `observation-summary.json`.
- Update `Codex Policy Agent Canary Run` to enrich public bundles before upload.
- Update public bundle documentation.
- Add execution test for enrichment.
- Update policy-agent public bundle contract test.
- Connect enrichment test to Script Check.

## Safety boundary

This does not publish raw private chain-of-thought.

It publishes sanitized stdout/stderr/install/mount diagnostics using best-effort redaction for:

- token-like strings
- environment assignment strings
- authorization bearer strings
- runner workspace paths
- temp paths
- GitHub workspace paths

If a real token is ever found in a public artifact, it must still be treated as an incident and rotated.

## Scope

Workflow, docs, scripts, and tests only.

No lab UI changes, no generated evidence changes, no model/token-budget changes, and no weekly-auto-run migration in this PR.