### PR TITLE
Publish sanitized reasoning trace evidence

### DIFF
--- a/docs/public-agent-run-bundle.md
+++ b/docs/public-agent-run-bundle.md
@@ -11,7 +11,9 @@ The public agent run bundle exposes:
 ```text
 redacted raw evidence
 sanitized diagnostic logs
+sanitized reasoning / CoT-like trace artifacts
 agent observation summaries
+reasoning-to-behavior hypotheses
 ```
 
 for canonical Docker/Codex policy-agent runs and fixed-Issue agent runs.
@@ -19,14 +21,16 @@ for canonical Docker/Codex policy-agent runs and fixed-Issue agent runs.
 ## Core rule
 
 ```text
-Primary evidence: redacted raw files and sanitized logs
-Secondary evidence: observation summary, index, and manifest
+Primary evidence: redacted raw files, sanitized logs, and sanitized exposed reasoning traces
+Secondary evidence: observation summary, reasoning-to-behavior hypotheses, index, and manifest
 Model-written summary: not primary evidence
 ```
 
 Do not replace raw evidence with a model-written summary.
 
 Summaries can hide failure modes, reflect prompt or model bias, and make participants miss important behavior.
+
+If a run artifact exposes reasoning / CoT-like trace text, Prompt Vote Lab treats that trace as experimental evidence after sanitizer replacement.
 
 ## What is published as raw evidence
 
@@ -119,6 +123,34 @@ Examples:
 
 Sanitization is a best-effort publication guard. If a real token is discovered in a public artifact, rotate it and treat it as an incident.
 
+## What is published as reasoning / CoT-like trace evidence
+
+If the run creates reasoning-like artifacts that are visible to the workflow, they are published after sanitizer replacement under `reasoning-traces/`.
+
+Examples:
+
+```text
+reasoning-traces/codex-events.jsonl
+reasoning-traces/codex-last-message.txt
+reasoning-traces/codex-stdout.txt
+reasoning-traces/codex-stderr.txt
+reasoning-traces/policy-agent-container-stdout.txt
+reasoning-traces/policy-agent-container-stderr.txt
+reasoning-traces/issue-instruction-container-stdout.txt
+reasoning-traces/issue-instruction-container-stderr.txt
+```
+
+This is not a proxy-only policy. Exposed reasoning / CoT-like traces are evaluation targets.
+
+If provider-private reasoning exists but is not exposed to the workflow, the bundle records:
+
+```text
+unexposed_provider_private_cot_available = unknown
+unexposed_provider_private_cot_published = false
+```
+
+The project does not pretend unavailable provider-private internals are observable. It does publish exposed reasoning traces that exist in run artifacts.
+
 ## Agent observation summary
 
 The enriched bundle contains:
@@ -140,11 +172,14 @@ copied-back files
 additions and deletions by file
 hashes before and after
 sanitized logs and redaction counts
+reasoning-traces/ files and redaction counts
+reasoning-like term counts
+reasoning-to-behavior hypotheses
 agent final action summary
 known evidence limits
 ```
 
-The observation summary is a navigation index over evidence. It is not private reasoning.
+The observation summary is a navigation index over evidence. It does not replace the published reasoning traces.
 
 ## Why policy-agent files are included
 
@@ -187,7 +222,7 @@ Without them, a participant can see the diff and Codex events but cannot indepen
 
 ## Redaction
 
-The builder and enrichment step redact common secret-like patterns before publishing allowlisted or sanitized files.
+The builder and enrichment step redact common secret-like patterns before publishing allowlisted, sanitized, or reasoning-trace files.
 
 Examples:
 
@@ -217,9 +252,10 @@ observation-summary.md
 observation-summary.json
 raw/<allowlisted-file>
 sanitized/<sanitized-file>
+reasoning-traces/<sanitized-reasoning-trace-file>
 ```
 
-`index.json` is a manifest and quick index. It is not a replacement for `raw/` or `sanitized/`.
+`index.json` is a manifest and quick index. It is not a replacement for `raw/`, `sanitized/`, or `reasoning-traces/`.
 
 `README.md` is a human navigation file. It is not an interpretation layer.
 
@@ -230,7 +266,7 @@ The canonical policy-agent workflow builds and enriches the bundle after diagnos
 ```text
 Collect diagnostics artifact
 → Build redacted public agent run bundle
-→ Enrich public agent run bundle with sanitized logs
+→ Enrich public agent run bundle with sanitized logs and reasoning traces
 → Upload redacted public agent run bundle
 → Upload internal diagnostics artifact
 ```
@@ -273,13 +309,15 @@ whether the task mount was read-only
 whether the repository root was withheld from /work
 what final agent message was produced
 how many JSONL events were emitted
+what reasoning / CoT-like traces were exposed
+whether reasoning traces mention copy, interaction, style, or scope terms
 what stdout/stderr/install logs looked like after sanitization
 whether runtime scan was clear/blocked/review
 whether the execution gate allowed or stopped the run
 which source Issue generated the task packet
 ```
 
-The project does not automatically explain or score these observations.
+The project does not automatically explain or score these observations as truth. It records hypotheses for participant review.
 
 ## Non-goals
 
@@ -290,13 +328,15 @@ unsanitized raw Actions logs
 unsanitized raw container stderr
 unsanitized login stdout/stderr
 unsanitized full package-manager install logs
+unredacted exposed reasoning traces
 secrets
 private data
 payment identifiers
 automatic prompt advice
-model-written causal explanation
-raw private chain-of-thought
+model-written causal explanation as primary evidence
 ```
+
+Provider-private reasoning that is not exposed to the workflow is not claimed to be available.
 
 ## Schema
 

--- a/scripts/enrich_public_agent_run_bundle.py
+++ b/scripts/enrich_public_agent_run_bundle.py
@@ -26,6 +26,19 @@ SANITIZED_PUBLIC_FILES = [
     "container-runtime-dirs-before.txt",
 ]
 
+# These are not treated as hidden/private provider internals. They are exposed run artifacts.
+# If they contain reasoning/COT-like text, that text is part of the public lab evidence after sanitization.
+REASONING_TRACE_FILES = [
+    "codex-events.jsonl",
+    "codex-last-message.txt",
+    "codex-stdout.txt",
+    "codex-stderr.txt",
+    "policy-agent-container-stdout.txt",
+    "policy-agent-container-stderr.txt",
+    "issue-instruction-container-stdout.txt",
+    "issue-instruction-container-stderr.txt",
+]
+
 SECRET_PATTERNS = [
     ("openai_key", re.compile(r"sk-[A-Za-z0-9_\-]{12,}")),
     ("github_classic_token", re.compile(r"gh[pousr]_[A-Za-z0-9_]{12,}")),
@@ -42,6 +55,31 @@ PATH_PATTERNS = [
     ("tmp_path", "[REDACTED_TMP_PATH]", re.compile(r"/tmp/[^\s:'\"]+")),
     ("github_workspace", "[REDACTED_GITHUB_WORKSPACE]", re.compile(r"/github/workspace[^\s:'\"]*")),
 ]
+
+REASONING_TERMS = [
+    "reasoning",
+    "reason",
+    "thought",
+    "think",
+    "plan",
+    "decide",
+    "decision",
+    "inspect",
+    "read",
+    "modify",
+    "change",
+    "because",
+    "therefore",
+    "step",
+    "next",
+]
+
+REASONING_KEYWORD_GROUPS = {
+    "visible_copy_terms": ["copy", "hero", "text", "wording", "visible", "explanation", "content", "label"],
+    "interaction_terms": ["state", "toggle", "click", "button", "interaction", "app.js", "javascript", "event"],
+    "style_terms": ["style", "css", "layout", "responsive", "color", "spacing"],
+    "scope_terms": ["allowed", "policy", "static", "no network", "lab/index.html", "lab/style.css", "lab/app.js"],
+}
 
 
 def utc_now() -> str:
@@ -72,6 +110,10 @@ def line_list(path: Path) -> list[str]:
     return [line.strip() for line in read_text(path).splitlines() if line.strip()]
 
 
+def event_count(path: Path) -> int:
+    return len(line_list(path))
+
+
 def redact_for_public(text: str) -> tuple[str, list[dict[str, Any]]]:
     out = text
     redactions: list[dict[str, Any]] = []
@@ -90,6 +132,16 @@ def redact_for_public(text: str) -> tuple[str, list[dict[str, Any]]]:
             redactions.append({"kind": name, "count": count})
 
     return out, redactions
+
+
+def count_terms(text: str, terms: list[str]) -> dict[str, int]:
+    lowered = text.lower()
+    return {term: lowered.count(term) for term in terms}
+
+
+def count_reasoning_keyword_groups(text: str) -> dict[str, int]:
+    lowered = text.lower()
+    return {name: sum(lowered.count(term) for term in terms) for name, terms in REASONING_KEYWORD_GROUPS.items()}
 
 
 def copy_sanitized_files(diag: Path, bundle: Path) -> list[dict[str, Any]]:
@@ -117,6 +169,37 @@ def copy_sanitized_files(diag: Path, bundle: Path) -> list[dict[str, Any]]:
             }
         )
     return manifest
+
+
+def copy_reasoning_trace_files(diag: Path, bundle: Path) -> tuple[list[dict[str, Any]], str]:
+    out_dir = bundle / "reasoning-traces"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    manifest: list[dict[str, Any]] = []
+    combined = []
+    for name in REASONING_TRACE_FILES:
+        source = diag / name
+        if not source.exists() or not source.is_file():
+            manifest.append({"name": name, "included": False, "reason": "not_found"})
+            continue
+        raw = read_text(source)
+        sanitized, redactions = redact_for_public(raw)
+        dest = out_dir / name
+        dest.write_text(sanitized, encoding="utf-8")
+        combined.append(f"\n--- {name} ---\n{sanitized}")
+        term_counts = count_terms(sanitized, REASONING_TERMS)
+        manifest.append(
+            {
+                "name": name,
+                "included": True,
+                "path": f"reasoning-traces/{name}",
+                "source_size_bytes": source.stat().st_size,
+                "public_size_bytes": dest.stat().st_size,
+                "redactions": redactions,
+                "reasoning_term_counts": term_counts,
+                "contains_reasoning_like_terms": any(count > 0 for count in term_counts.values()),
+            }
+        )
+    return manifest, "\n".join(combined)
 
 
 def patch_stats(patch: str) -> dict[str, dict[str, int]]:
@@ -148,7 +231,66 @@ def first_existing(diag: Path, names: list[str]) -> Path | None:
     return None
 
 
-def build_observation_summary(diag: Path, bundle: Path, sanitized_manifest: list[dict[str, Any]]) -> dict[str, Any]:
+def build_reasoning_effect_hypotheses(reasoning_group_counts: dict[str, int], changed_files: list[str], file_activity: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    hypotheses: list[dict[str, Any]] = []
+    changed = set(changed_files)
+    app_changed = "lab/app.js" in changed
+    css_changed = "lab/style.css" in changed
+    index_changed = "lab/index.html" in changed
+
+    if index_changed and not app_changed and reasoning_group_counts.get("visible_copy_terms", 0) > reasoning_group_counts.get("interaction_terms", 0):
+        hypotheses.append(
+            {
+                "hypothesis": "The exposed reasoning trace emphasizes visible copy/content more than interaction behavior, matching an index.html-only or index-heavy change.",
+                "evidence": [
+                    "visible_copy_terms > interaction_terms",
+                    "lab/index.html changed",
+                    "lab/app.js did not change",
+                ],
+                "confidence": "medium",
+                "participant_prompt_adjustment": "If interaction was desired, explicitly require app.js behavior/state changes and define the expected user action.",
+            }
+        )
+    if reasoning_group_counts.get("interaction_terms", 0) > 0 and not app_changed:
+        hypotheses.append(
+            {
+                "hypothesis": "The exposed reasoning trace mentions interaction-related concepts, but app.js did not change.",
+                "evidence": [
+                    "interaction_terms > 0",
+                    "lab/app.js changed=false",
+                ],
+                "confidence": "low",
+                "participant_prompt_adjustment": "Make the required JavaScript behavior explicit and state that copy-only changes are insufficient.",
+            }
+        )
+    if reasoning_group_counts.get("style_terms", 0) > 0 and css_changed:
+        hypotheses.append(
+            {
+                "hypothesis": "The exposed reasoning trace mentions styling/layout and style.css changed.",
+                "evidence": [
+                    "style_terms > 0",
+                    "lab/style.css changed=true",
+                ],
+                "confidence": "medium",
+                "participant_prompt_adjustment": "If layout quality matters, add responsive acceptance criteria and failure examples.",
+            }
+        )
+    if not hypotheses:
+        hypotheses.append(
+            {
+                "hypothesis": "No strong reasoning-to-behavior hypothesis was inferred from the exposed trace and file activity.",
+                "evidence": [
+                    f"changed_files={sorted(changed)}",
+                    f"reasoning_group_counts={reasoning_group_counts}",
+                ],
+                "confidence": "low",
+                "participant_prompt_adjustment": "Inspect reasoning-traces/ and diff files directly before revising the prompt.",
+            }
+        )
+    return hypotheses
+
+
+def build_observation_summary(diag: Path, bundle: Path, sanitized_manifest: list[dict[str, Any]], reasoning_manifest: list[dict[str, Any]], reasoning_text: str) -> dict[str, Any]:
     index = read_json(bundle / "index.json", {})
     policy = read_json(diag / "policy-allowed-paths.json", {})
     check_results = read_json(diag / "check-results.json", {})
@@ -191,6 +333,9 @@ def build_observation_summary(diag: Path, bundle: Path, sanitized_manifest: list
         )
 
     final_summary, final_summary_redactions = redact_for_public(read_text(diag / "codex-last-message.txt"))
+    reasoning_group_counts = count_reasoning_keyword_groups(reasoning_text)
+    reasoning_available = any(item.get("included") for item in reasoning_manifest)
+    reasoning_contains_terms = any(item.get("contains_reasoning_like_terms") for item in reasoning_manifest if item.get("included"))
     return {
         "schema_version": OBSERVATION_SCHEMA_VERSION,
         "generated_at": utc_now(),
@@ -214,13 +359,27 @@ def build_observation_summary(diag: Path, bundle: Path, sanitized_manifest: list
             "agent_final_action_summary": final_summary[:4000],
             "agent_final_action_summary_redactions": final_summary_redactions,
         },
+        "reasoning_trace": {
+            "available": reasoning_available,
+            "public_trace_available": reasoning_available,
+            "sanitized": True,
+            "published_directory": "reasoning-traces/",
+            "files": reasoning_manifest,
+            "contains_reasoning_like_terms": reasoning_contains_terms,
+            "keyword_group_counts": reasoning_group_counts,
+            "used_for_behavior_evaluation": True,
+            "exposed_reasoning_trace_published": reasoning_available,
+            "unexposed_provider_private_cot_available": "unknown",
+            "unexposed_provider_private_cot_published": False,
+        },
+        "reasoning_effect_hypotheses": build_reasoning_effect_hypotheses(reasoning_group_counts, changed_files, file_activity),
         "file_activity": file_activity,
         "sanitized_logs": sanitized_manifest,
         "limits": {
             "exact_read_order_observed": False,
-            "exact_read_order_reason": "This summary records visible files, changed files, copied files, diffs, hashes, and event counts. Exact file read sequence is not guaranteed unless the Codex event schema exposes it and is reviewed separately.",
-            "raw_private_reasoning_collected": False,
-            "raw_private_reasoning_policy": "Raw private chain-of-thought is not collected or published. The public record uses final action summary plus objective artifacts.",
+            "exact_read_order_reason": "This summary records visible files, changed files, copied files, diffs, hashes, event counts, and exposed reasoning trace artifacts. Exact file read sequence is not guaranteed unless the event schema exposes it and is reviewed separately.",
+            "unexposed_provider_private_cot_collected": False,
+            "unexposed_provider_private_cot_policy": "Do not pretend unavailable provider-private internals are observable. Publish exposed reasoning/COT-like traces that appear in run artifacts after sanitization.",
             "sanitizer_guarantee": "Best-effort pattern redaction before publication. A public leak must still be treated as an incident and rotated if a real token is found.",
         },
     }
@@ -236,14 +395,16 @@ def render_table(headers: list[str], rows: list[list[Any]]) -> str:
 def render_observation_md(summary: dict[str, Any]) -> str:
     path_model = summary["path_model"]
     agent = summary["agent_observation"]
+    reasoning = summary["reasoning_trace"]
     files = summary["file_activity"]
     sanitized = summary["sanitized_logs"]
+    hypotheses = summary["reasoning_effect_hypotheses"]
     return "\n".join(
         [
             "# Agent observation summary",
             "",
-            "This is a participant-facing observation index. It describes visible files, changed files, copied files, sanitized logs, and the agent final action summary.",
-            "It is not raw private reasoning.",
+            "This is a participant-facing observation index. It describes visible files, changed files, copied files, sanitized logs, exposed reasoning traces, and the agent final action summary.",
+            "It does not invent hidden provider-private CoT. It publishes exposed reasoning/COT-like run artifacts when they exist.",
             "",
             "## Path model",
             "",
@@ -266,6 +427,32 @@ def render_observation_md(summary: dict[str, Any]) -> str:
                 [[item.get("file"), item.get("visible_before"), item.get("visible_after"), item.get("changed"), item.get("copied_back"), item.get("additions"), item.get("deletions")] for item in files],
             ),
             "",
+            "## Reasoning / CoT-like trace evidence",
+            "",
+            render_table(
+                ["field", "value"],
+                [
+                    ["available", reasoning.get("available")],
+                    ["published_directory", reasoning.get("published_directory")],
+                    ["contains_reasoning_like_terms", reasoning.get("contains_reasoning_like_terms")],
+                    ["used_for_behavior_evaluation", reasoning.get("used_for_behavior_evaluation")],
+                    ["unexposed_provider_private_cot_available", reasoning.get("unexposed_provider_private_cot_available")],
+                    ["unexposed_provider_private_cot_published", reasoning.get("unexposed_provider_private_cot_published")],
+                ],
+            ),
+            "",
+            render_table(
+                ["trace file", "included", "reasoning-like", "redactions"],
+                [[item.get("name"), item.get("included"), item.get("contains_reasoning_like_terms"), ", ".join(f"{r.get('kind')}:{r.get('count')}" for r in item.get("redactions", []))] for item in reasoning.get("files", [])],
+            ),
+            "",
+            "## Reasoning effect hypotheses",
+            "",
+            render_table(
+                ["hypothesis", "confidence", "prompt adjustment"],
+                [[item.get("hypothesis"), item.get("confidence"), item.get("participant_prompt_adjustment")] for item in hypotheses],
+            ),
+            "",
             "## Sanitized logs",
             "",
             render_table(
@@ -280,9 +467,10 @@ def render_observation_md(summary: dict[str, Any]) -> str:
             "## Evidence limits",
             "",
             "- Exact file read order is not guaranteed by this summary.",
-            "- Raw private chain-of-thought is not collected or published.",
+            "- Exposed reasoning/COT-like trace files are published under reasoning-traces/ after sanitization when present.",
+            "- Unexposed provider-private internals are not claimed to be available.",
             "- Sanitization is best-effort. Real token discovery still requires rotation.",
-            "- Use raw/codex-events.jsonl and sanitized/* logs for deeper inspection.",
+            "- Use reasoning-traces/, raw/codex-events.jsonl, sanitized/* logs, and diff files for deeper inspection.",
             "",
         ]
     )
@@ -301,6 +489,8 @@ def append_readme(bundle: Path) -> None:
             "```text",
             "path model",
             "file activity",
+            "reasoning / CoT-like trace evidence",
+            "reasoning effect hypotheses",
             "sanitized logs",
             "agent final action summary",
             "evidence limits",
@@ -308,6 +498,7 @@ def append_readme(bundle: Path) -> None:
             "",
             "Use `observation-summary.json` for machine-readable analysis.",
             "Sanitized diagnostic logs are under `sanitized/`.",
+            "Sanitized exposed reasoning/COT-like traces are under `reasoning-traces/` when present.",
             "",
         ]
     )
@@ -326,13 +517,15 @@ def main() -> int:
         raise SystemExit(f"bundle dir not found: {bundle}")
 
     sanitized_manifest = copy_sanitized_files(diag, bundle)
-    summary = build_observation_summary(diag, bundle, sanitized_manifest)
+    reasoning_manifest, reasoning_text = copy_reasoning_trace_files(diag, bundle)
+    summary = build_observation_summary(diag, bundle, sanitized_manifest, reasoning_manifest, reasoning_text)
     write_json(bundle / "observation-summary.json", summary)
     (bundle / "observation-summary.md").write_text(render_observation_md(summary), encoding="utf-8")
 
     index_path = bundle / "index.json"
     index = read_json(index_path, {})
     index["sanitized_files"] = sanitized_manifest
+    index["reasoning_trace_files"] = reasoning_manifest
     index["observation_summary"] = {
         "json": "observation-summary.json",
         "markdown": "observation-summary.md",
@@ -340,6 +533,7 @@ def main() -> int:
     }
     policy = index.setdefault("policy", {})
     policy["sanitized_diagnostic_logs_included"] = True
+    policy["sanitized_reasoning_traces_included"] = True
     policy["sanitizer_guarantee"] = "best_effort_pattern_redaction"
     write_json(index_path, index)
     append_readme(bundle)

--- a/scripts/test_enrich_public_agent_run_bundle.py
+++ b/scripts/test_enrich_public_agent_run_bundle.py
@@ -71,7 +71,13 @@ def main() -> int:
             diag / "policy-agent-diff.patch",
             "diff --git a/lab/index.html b/lab/index.html\n--- a/lab/index.html\n+++ b/lab/index.html\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
         )
+        write(
+            diag / "codex-events.jsonl",
+            '{"type":"reasoning","message":"I will inspect visible copy, then change lab/index.html because the prompt asks for hero wording."}\n'
+            '{"type":"action","message":"modify lab/index.html"}\n',
+        )
         write(diag / "codex-last-message.txt", "I changed lab/index.html and did not touch app.js. token sk-FAKEFAKEFAKEFAKE should redact.\n")
+        write(diag / "codex-stdout.txt", "reasoning trace says inspect visible copy and change index.html because content is requested\n")
         write(diag / "codex-stderr.txt", "stderr path /home/runner/work/prompt-vote-lab/prompt-vote-lab and key sk-FAKEFAKEFAKEFAKEFAKEFAKEFAKE\n")
         write(diag / "policy-agent-container-stderr.txt", "container stderr from /tmp/pvl-secret\n")
         write(diag / "npm-install-codex.txt", "npm installed in /github/workspace with GH_TOKEN=ghp_FAKEFAKEFAKEFAKEFAKE\n")
@@ -88,9 +94,11 @@ def main() -> int:
 
         index = json.loads((bundle / "index.json").read_text(encoding="utf-8"))
         assert index["policy"]["sanitized_diagnostic_logs_included"] is True
+        assert index["policy"]["sanitized_reasoning_traces_included"] is True
         assert index["policy"]["sanitizer_guarantee"] == "best_effort_pattern_redaction"
         assert index["observation_summary"]["json"] == "observation-summary.json"
         assert index["observation_summary"]["markdown"] == "observation-summary.md"
+        assert "reasoning_trace_files" in index
 
         sanitized_stderr = (bundle / "sanitized" / "codex-stderr.txt").read_text(encoding="utf-8")
         assert "sk-FAKE" not in sanitized_stderr
@@ -104,6 +112,13 @@ def main() -> int:
         assert "[REDACTED_SECRET]" in npm_log
         assert "[REDACTED_GITHUB_WORKSPACE]" in npm_log
 
+        reasoning_events = (bundle / "reasoning-traces" / "codex-events.jsonl").read_text(encoding="utf-8")
+        assert "reasoning" in reasoning_events
+        assert "hero wording" in reasoning_events
+        reasoning_stderr = (bundle / "reasoning-traces" / "codex-stderr.txt").read_text(encoding="utf-8")
+        assert "sk-FAKE" not in reasoning_stderr
+        assert "[REDACTED_SECRET]" in reasoning_stderr
+
         summary = json.loads((bundle / "observation-summary.json").read_text(encoding="utf-8"))
         assert summary["schema_version"] == "prompt-vote-lab-agent-observation-summary-v1"
         assert summary["path_model"]["repo_root_mounted"] is False
@@ -113,8 +128,23 @@ def main() -> int:
         assert summary["agent_observation"]["denied_access_paths"] == ["/repo/private-file.txt"]
         assert "sk-FAKE" not in summary["agent_observation"]["agent_final_action_summary"]
         assert "[REDACTED_SECRET]" in summary["agent_observation"]["agent_final_action_summary"]
-        assert summary["limits"]["raw_private_reasoning_collected"] is False
-        assert summary["limits"]["exact_read_order_observed"] is False
+
+        reasoning = summary["reasoning_trace"]
+        assert reasoning["available"] is True
+        assert reasoning["public_trace_available"] is True
+        assert reasoning["sanitized"] is True
+        assert reasoning["published_directory"] == "reasoning-traces/"
+        assert reasoning["used_for_behavior_evaluation"] is True
+        assert reasoning["exposed_reasoning_trace_published"] is True
+        assert reasoning["unexposed_provider_private_cot_available"] == "unknown"
+        assert reasoning["unexposed_provider_private_cot_published"] is False
+        assert reasoning["contains_reasoning_like_terms"] is True
+        assert reasoning["keyword_group_counts"]["visible_copy_terms"] > reasoning["keyword_group_counts"]["interaction_terms"]
+        assert any(item["name"] == "codex-events.jsonl" and item["included"] for item in reasoning["files"])
+        assert any(item["name"] == "codex-stdout.txt" and item["included"] for item in reasoning["files"])
+        assert summary["reasoning_effect_hypotheses"]
+        assert "visible copy" in summary["reasoning_effect_hypotheses"][0]["hypothesis"]
+        assert summary["limits"]["unexposed_provider_private_cot_collected"] is False
 
         by_file = {item["file"]: item for item in summary["file_activity"]}
         assert by_file["lab/index.html"]["changed"] is True
@@ -125,12 +155,16 @@ def main() -> int:
 
         md = (bundle / "observation-summary.md").read_text(encoding="utf-8")
         assert "Agent observation summary" in md
+        assert "Reasoning / CoT-like trace evidence" in md
+        assert "reasoning-traces/" in md
+        assert "Reasoning effect hypotheses" in md
         assert "Sanitized logs" in md
-        assert "Exact file read order is not guaranteed" in md
+        assert "Unexposed provider-private internals are not claimed to be available" in md
 
         readme = (bundle / "README.md").read_text(encoding="utf-8")
         assert "Agent observation summary" in readme
-        assert "Sanitized diagnostic logs" in readme
+        assert "reasoning / CoT-like trace evidence" in readme
+        assert "reasoning-traces/" in readme
 
     print("public agent run bundle enrichment test passed")
     return 0

--- a/scripts/test_policy_agent_public_bundle_contract.py
+++ b/scripts/test_policy_agent_public_bundle_contract.py
@@ -45,38 +45,60 @@ REQUIRED_BUNDLE_TEXT = [
 
 REQUIRED_ENRICH_TEXT = [
     "SANITIZED_PUBLIC_FILES",
+    "REASONING_TRACE_FILES",
+    '"codex-events.jsonl"',
+    '"codex-last-message.txt"',
     '"codex-stderr.txt"',
     '"codex-stdout.txt"',
     '"policy-agent-container-stdout.txt"',
     '"policy-agent-container-stderr.txt"',
     '"npm-install-codex.txt"',
     '"policy-container-mounts.txt"',
+    "reasoning-traces/",
+    "copy_reasoning_trace_files",
+    "reasoning_trace_files",
+    "reasoning_effect_hypotheses",
+    "exposed_reasoning_trace_published",
+    "unexposed_provider_private_cot_available",
+    "unexposed_provider_private_cot_published",
     "observation-summary.json",
     "observation-summary.md",
     "[REDACTED_SECRET]",
     "[REDACTED_RUNNER_WORKDIR]",
-    "raw_private_reasoning_collected",
     "exact_read_order_observed",
 ]
 
 REQUIRED_DOC_TEXT = [
     "redacted raw evidence",
     "sanitized diagnostic logs",
-    "agent observation summaries",
+    "sanitized reasoning / CoT-like trace artifacts",
     "sanitized/codex-stderr.txt",
     "sanitized/policy-agent-container-stderr.txt",
     "sanitized/npm-install-codex.txt",
+    "reasoning-traces/codex-events.jsonl",
+    "reasoning-traces/codex-last-message.txt",
+    "reasoning-traces/codex-stdout.txt",
+    "reasoning-traces/codex-stderr.txt",
+    "This is not a proxy-only policy. Exposed reasoning / CoT-like traces are evaluation targets.",
+    "unexposed_provider_private_cot_available = unknown",
+    "unexposed_provider_private_cot_published = false",
+    "reasoning-to-behavior hypotheses",
     "observation-summary.md",
     "observation-summary.json",
     "[REDACTED_SECRET]",
     "[REDACTED_RUNNER_WORKDIR]",
     "Sanitization is a best-effort publication guard.",
-    "raw private chain-of-thought",
 ]
 
 FORBIDDEN_WORKFLOW_TEXT = [
     "cat .tmp/canary-diagnostics/codex-stderr.txt",
     "Upload raw public agent run bundle",
+]
+
+FORBIDDEN_DOC_TEXT = [
+    "raw private chain-of-thought",
+    "CoTそのものではなく",
+    "proxy-only",
 ]
 
 
@@ -103,6 +125,7 @@ def main() -> int:
     require_all(bundle, REQUIRED_BUNDLE_TEXT, "public bundle builder")
     require_all(enrich, REQUIRED_ENRICH_TEXT, "public bundle enrichment script")
     require_all(doc, REQUIRED_DOC_TEXT, "public agent run bundle doc")
+    reject_all(doc, FORBIDDEN_DOC_TEXT, "public agent run bundle doc")
 
     if workflow.index("Collect diagnostics artifact") > workflow.index("Build redacted public agent run bundle"):
         raise SystemExit("public bundle must be built after diagnostics collection")

--- a/scripts/test_policy_agent_public_bundle_contract.py
+++ b/scripts/test_policy_agent_public_bundle_contract.py
@@ -98,7 +98,8 @@ FORBIDDEN_WORKFLOW_TEXT = [
 FORBIDDEN_DOC_TEXT = [
     "raw private chain-of-thought",
     "CoTそのものではなく",
-    "proxy-only",
+    "Only proxy behavior is evaluated",
+    "Reasoning traces are not evaluation targets",
 ]
 
 


### PR DESCRIPTION
## Summary

Publishes exposed reasoning / CoT-like trace artifacts as sanitized public evidence when they exist in Docker/Codex run diagnostics.

## Correction

This PR intentionally avoids weakening the lab requirement into a proxy-only policy. If reasoning / CoT-like text is exposed in run artifacts, it is part of the experiment and should be available for participant analysis after sanitizer replacement.

## Changes

- Add `reasoning-traces/` output in `enrich_public_agent_run_bundle.py`.
- Publish sanitized copies of exposed trace-bearing artifacts such as:
  - `codex-events.jsonl`
  - `codex-last-message.txt`
  - `codex-stdout.txt`
  - `codex-stderr.txt`
  - `policy-agent-container-stdout.txt`
  - `policy-agent-container-stderr.txt`
  - `issue-instruction-container-stdout.txt`
  - `issue-instruction-container-stderr.txt`
- Add `reasoning_trace` to `observation-summary.json`.
- Add `reasoning_effect_hypotheses` to connect exposed trace terms with file behavior.
- Update `observation-summary.md` with a Reasoning / CoT-like trace evidence section.
- Update docs and contract tests so exposed reasoning traces remain publication targets.

## Boundary

This does not claim unexposed provider-private internals are observable.

It does publish exposed reasoning / CoT-like traces that exist in run artifacts after sanitizer replacement.

## Scope

Docs and public bundle enrichment scripts/tests only.

No lab UI changes, no workflow changes, no generated evidence changes, no weekly-auto-run migration, and no model/token-budget changes.