### PR TITLE
Document policy-agent reasoning traces in PR body

### DIFF
--- a/.github/workflows/codex-policy-agent-canary-run.yml
+++ b/.github/workflows/codex-policy-agent-canary-run.yml
@@ -91,7 +91,7 @@ jobs:
             --issue-number "0" \
             --pr-number ""
 
-      - name: Enrich public agent run bundle with sanitized logs
+      - name: Enrich public agent run bundle with sanitized logs and reasoning traces
         if: ${{ always() }}
         run: |
           python scripts/enrich_public_agent_run_bundle.py \
@@ -203,12 +203,17 @@ jobs:
           - Redacted public agent run bundle artifact: \`codex-policy-agent-canary-public-bundle-${{ github.run_number }}\`
           - Observation summary files: \`observation-summary.md\`, \`observation-summary.json\`
           - Sanitized diagnostic logs directory: \`sanitized/\`
+          - Sanitized exposed reasoning / CoT-like trace directory: \`reasoning-traces/\`
           - Public run log artifact: \`codex-policy-agent-canary-public-log-${{ github.run_number }}\`
           - Internal diagnostics artifact: \`codex-policy-agent-canary-diagnostics-${{ github.run_number }}\`
 
+          ## Reasoning trace policy
+
+          If the run artifact exposes reasoning / CoT-like trace text, it is part of the public lab evidence after sanitizer replacement. Provider-private internals that are not exposed to the workflow are not claimed to be available.
+
           ## Diagnostics
 
-          Internal diagnostics artifact is uploaded for mount, policy, Codex event, and diff analysis. Public artifacts are redacted, sanitized, and indexed for participant review.
+          Internal diagnostics artifact is uploaded for mount, policy, Codex event, and diff analysis. Public artifacts are redacted, sanitized, indexed, and include exposed reasoning traces when present.
 
           ## Merge policy
 

--- a/scripts/test_policy_agent_public_bundle_contract.py
+++ b/scripts/test_policy_agent_public_bundle_contract.py
@@ -15,7 +15,7 @@ REQUIRED_WORKFLOW_TEXT = [
     "python scripts/collect_canary_diagnostics.py",
     "Build redacted public agent run bundle",
     "python scripts/build_public_agent_run_bundle.py",
-    "Enrich public agent run bundle with sanitized logs",
+    "Enrich public agent run bundle with sanitized logs and reasoning traces",
     "python scripts/enrich_public_agent_run_bundle.py",
     "--diagnostics-dir .tmp/canary-diagnostics",
     "--bundle-dir .tmp/public-agent-run-bundle",
@@ -29,7 +29,10 @@ REQUIRED_WORKFLOW_TEXT = [
     "observation-summary.json",
     "Sanitized diagnostic logs directory:",
     "sanitized/",
-    "Public artifacts are redacted, sanitized, and indexed for participant review.",
+    "Sanitized exposed reasoning / CoT-like trace directory:",
+    "reasoning-traces/",
+    "If the run artifact exposes reasoning / CoT-like trace text, it is part of the public lab evidence after sanitizer replacement.",
+    "Public artifacts are redacted, sanitized, indexed, and include exposed reasoning traces when present.",
 ]
 
 REQUIRED_BUNDLE_TEXT = [
@@ -130,9 +133,9 @@ def main() -> int:
 
     if workflow.index("Collect diagnostics artifact") > workflow.index("Build redacted public agent run bundle"):
         raise SystemExit("public bundle must be built after diagnostics collection")
-    if workflow.index("Build redacted public agent run bundle") > workflow.index("Enrich public agent run bundle with sanitized logs"):
+    if workflow.index("Build redacted public agent run bundle") > workflow.index("Enrich public agent run bundle with sanitized logs and reasoning traces"):
         raise SystemExit("public bundle must be enriched after bundle build")
-    if workflow.index("Enrich public agent run bundle with sanitized logs") > workflow.index("Upload redacted public agent run bundle"):
+    if workflow.index("Enrich public agent run bundle with sanitized logs and reasoning traces") > workflow.index("Upload redacted public agent run bundle"):
         raise SystemExit("public bundle upload must occur after enrichment")
     if workflow.index("Upload redacted public agent run bundle") > workflow.index("Upload diagnostics artifact"):
         raise SystemExit("public bundle should be uploaded before internal diagnostics artifact")


### PR DESCRIPTION
## Summary

Updates the canonical Docker/Codex policy-agent canary workflow PR body so future generated canary PRs explicitly mention `reasoning-traces/`.

## Why

PR #263 was generated after public bundle enrichment had already gained sanitized exposed reasoning / CoT-like trace publication, but the workflow PR body template still only mentioned `sanitized/` and did not mention `reasoning-traces/`.

That creates a documentation/evidence mismatch for participants.

## Changes

- Rename the enrichment step label to mention sanitized logs and reasoning traces.
- Add `reasoning-traces/` to the generated canary PR body.
- Add a reasoning trace policy paragraph to generated PR bodies.
- Update the policy-agent public bundle contract test so this does not regress.

## Scope

Workflow body template and contract test only.

No lab UI changes, no model/token changes, no weekly-auto-run migration.