### PR TITLE
Run Script Check for all run records

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -29,6 +29,7 @@ on:
       - "data/public-results.md"
       - "data/support-unlocks/**"
       - "lab/comparisons/**"
+      - "runs/**"
       - "docs/codex-runner-contract.md"
       - "docs/canary-log-policy.md"
       - "docs/current-codex-implementation-path.md"
@@ -43,7 +44,6 @@ on:
       - "docs/canary-009-selected-issue-instructions.md"
       - "docs/usable-experiment-ops.md"
       - "rules/model-policy-v1.1.md"
-      - "runs/first-canary-009-authorized-canary-issue-170-success.md"
   workflow_dispatch:
 
 permissions:

--- a/scripts/test_script_check_workflow_contract.py
+++ b/scripts/test_script_check_workflow_contract.py
@@ -11,6 +11,7 @@ REQUIRED_TEXT = [
     "pull_request:",
     "paths:",
     "lab/comparisons/**",
+    "runs/**",
     "workflow_dispatch:",
     "contents: read",
     "Run comparison dashboard builder test",
@@ -21,6 +22,8 @@ REQUIRED_TEXT = [
     "python scripts/test_generated_comparison_dashboards.py",
     "Run public results export workflow contract test",
     "python scripts/test_public_results_export_workflow_contract.py",
+    "Run script-check workflow contract test",
+    "python scripts/test_script_check_workflow_contract.py",
     "Run lab PR scope guard self-test",
     "bash scripts/test-lab-pr-scope.sh",
 ]
@@ -52,6 +55,9 @@ def main() -> int:
     text = WORKFLOW.read_text(encoding="utf-8")
     require_all(text, REQUIRED_TEXT)
     reject_all(text, FORBIDDEN_TEXT)
+
+    if text.index("lab/comparisons/**") > text.index("runs/**"):
+        raise SystemExit("runs/** should be tracked near generated/evidence paths")
 
     if text.index("Run comparison dashboard builder test") > text.index("Run comparison dashboard decision test"):
         raise SystemExit("Comparison dashboard decision test should run after the builder test")


### PR DESCRIPTION
## Summary

Adds `runs/**` to the Script Check pull_request path filter and locks it with the script-check workflow contract test.

## Why

PR #265 added `runs/first-canary-007-policy-agent-evidence-only.md`, but Script Check did not run because only one specific run record path was included. Run records are public evidence and must trigger the same script/workflow contract checks.

## Changes

- Add `runs/**` to `.github/workflows/script-check.yml`.
- Require `runs/**` in `scripts/test_script_check_workflow_contract.py`.
- Keep Script Check read-only and without OpenAI/Codex execution.

## Scope

Workflow path filter and contract test only.

No lab UI changes, no generated evidence changes, no model/token changes.