### PR TITLE
Verify public agent run bundle contents

### DIFF
--- a/.github/workflows/codex-fixed-issue-instruction-canary-run.yml
+++ b/.github/workflows/codex-fixed-issue-instruction-canary-run.yml
@@ -183,6 +183,21 @@ jobs:
             --run-id "${{ github.run_number }}" \
             --issue-number "$ISSUE_NUMBER"
 
+      - name: Enrich public agent run bundle with sanitized logs and reasoning traces
+        if: ${{ always() }}
+        run: |
+          python scripts/enrich_public_agent_run_bundle.py \
+            --diagnostics-dir .tmp/canary-diagnostics \
+            --bundle-dir .tmp/public-agent-run-bundle
+
+      - name: Verify public agent run bundle contents
+        if: ${{ always() }}
+        run: |
+          python scripts/verify_public_agent_run_bundle.py \
+            --bundle-dir .tmp/public-agent-run-bundle \
+            --report .tmp/public-agent-run-bundle-verification.json
+          cp .tmp/public-agent-run-bundle-verification.json .tmp/canary-diagnostics/public-agent-run-bundle-verification.json
+
       - name: Upload redacted public agent run bundle
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -297,11 +312,25 @@ jobs:
           - safety-check passed before PR creation
           - static-site-check passed before PR creation
 
+          ## Public evidence
+
+          - Redacted public agent run bundle artifact: \`codex-fixed-issue-public-agent-run-bundle-${{ github.run_number }}\`
+          - Public bundle content verification report: \`public-agent-run-bundle-verification.json\` inside diagnostics
+          - Observation summary files: \`observation-summary.md\`, \`observation-summary.json\`
+          - Sanitized diagnostic logs directory: \`sanitized/\`
+          - Sanitized exposed reasoning / CoT-like trace directory: \`reasoning-traces/\`
+          - Public run log artifact: \`codex-fixed-issue-instruction-canary-public-log-${{ github.run_number }}\`
+          - Internal diagnostics artifact: \`codex-fixed-issue-instruction-canary-diagnostics-${{ github.run_number }}\`
+
+          ## Reasoning trace policy
+
+          If the run artifact exposes reasoning / CoT-like trace text, it is part of the public lab evidence after sanitizer replacement. Provider-private internals that are not exposed to the workflow are not claimed to be available.
+
           ## Diagnostics
 
-          Internal diagnostics artifact is uploaded for source Issue, runtime Issue safety scan, issue execution gate, instruction packet, credential presence, mount, Codex event, and diff analysis.
+          Internal diagnostics artifact is uploaded for source Issue, runtime Issue safety scan, issue execution gate, instruction packet, credential presence, mount, Codex event, diff, and public bundle verification analysis.
 
-          A redacted public agent run bundle is also uploaded for participant analysis. It exposes allowlisted raw evidence files after secret-pattern redaction and omits denylisted diagnostics such as login stderr/stdout and raw container stderr.
+          A redacted public agent run bundle is also uploaded for participant analysis. It exposes allowlisted raw evidence files after secret-pattern redaction, sanitized diagnostic logs, exposed reasoning traces when present, and machine-readable verification metadata.
 
           ## Merge policy
 

--- a/.github/workflows/codex-policy-agent-canary-run.yml
+++ b/.github/workflows/codex-policy-agent-canary-run.yml
@@ -98,6 +98,14 @@ jobs:
             --diagnostics-dir .tmp/canary-diagnostics \
             --bundle-dir .tmp/public-agent-run-bundle
 
+      - name: Verify public agent run bundle contents
+        if: ${{ always() }}
+        run: |
+          python scripts/verify_public_agent_run_bundle.py \
+            --bundle-dir .tmp/public-agent-run-bundle \
+            --report .tmp/public-agent-run-bundle-verification.json
+          cp .tmp/public-agent-run-bundle-verification.json .tmp/canary-diagnostics/public-agent-run-bundle-verification.json
+
       - name: Upload redacted public agent run bundle
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -201,6 +209,7 @@ jobs:
           ## Public evidence
 
           - Redacted public agent run bundle artifact: \`codex-policy-agent-canary-public-bundle-${{ github.run_number }}\`
+          - Public bundle content verification report: \`public-agent-run-bundle-verification.json\` inside diagnostics
           - Observation summary files: \`observation-summary.md\`, \`observation-summary.json\`
           - Sanitized diagnostic logs directory: \`sanitized/\`
           - Sanitized exposed reasoning / CoT-like trace directory: \`reasoning-traces/\`
@@ -213,7 +222,7 @@ jobs:
 
           ## Diagnostics
 
-          Internal diagnostics artifact is uploaded for mount, policy, Codex event, and diff analysis. Public artifacts are redacted, sanitized, indexed, and include exposed reasoning traces when present.
+          Internal diagnostics artifact is uploaded for mount, policy, Codex event, diff, and public bundle verification analysis. Public artifacts are redacted, sanitized, indexed, verified for required structure, and include exposed reasoning traces when present.
 
           ## Merge policy
 

--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -169,6 +169,9 @@ jobs:
       - name: Run public agent run bundle enrichment test
         run: python scripts/test_enrich_public_agent_run_bundle.py
 
+      - name: Run public agent run bundle verifier test
+        run: python scripts/test_verify_public_agent_run_bundle.py
+
       - name: Run policy agent public bundle contract test
         run: python scripts/test_policy_agent_public_bundle_contract.py
 

--- a/scripts/test_issue_instruction_runner_contract.py
+++ b/scripts/test_issue_instruction_runner_contract.py
@@ -62,11 +62,20 @@ REQUIRED_WORKFLOW_TEXT = [
     "--runner-mode codex-cli-fixed-issue-instruction-packet-container",
     "--sandbox-mode docker-workdir-plus-readonly-issue-instruction-packet",
     "python scripts/build_public_agent_run_bundle.py",
+    "python scripts/enrich_public_agent_run_bundle.py",
+    "python scripts/verify_public_agent_run_bundle.py",
+    "--report .tmp/public-agent-run-bundle-verification.json",
+    "public-agent-run-bundle-verification.json",
     "--diagnostics-dir .tmp/canary-diagnostics",
+    "--bundle-dir .tmp/public-agent-run-bundle",
     "--out-dir .tmp/public-agent-run-bundle",
     "codex-fixed-issue-public-agent-run-bundle-",
     "redacted public agent run bundle",
     "allowlisted raw evidence files",
+    "sanitized diagnostic logs",
+    "reasoning-traces/",
+    "observation-summary.md",
+    "observation-summary.json",
     "codex-fixed-issue-instruction-canary-diagnostics-",
     "codex-fixed-issue-instruction-canary-public-log-",
     "codex-fixed-issue-runtime-safety-scan-",
@@ -120,8 +129,12 @@ def main() -> int:
         raise SystemExit("Issue execution gate must run before Codex execution")
     if workflow_text.index("Collect diagnostics artifact") > workflow_text.index("Build redacted public agent run bundle"):
         raise SystemExit("Public agent run bundle must be built after diagnostics are collected")
-    if workflow_text.index("Build redacted public agent run bundle") > workflow_text.index("Upload redacted public agent run bundle"):
-        raise SystemExit("Public agent run bundle upload must happen after the bundle is built")
+    if workflow_text.index("Build redacted public agent run bundle") > workflow_text.index("Enrich public agent run bundle with sanitized logs and reasoning traces"):
+        raise SystemExit("Public agent run bundle must be enriched after it is built")
+    if workflow_text.index("Enrich public agent run bundle with sanitized logs and reasoning traces") > workflow_text.index("Verify public agent run bundle contents"):
+        raise SystemExit("Public agent run bundle must be verified after enrichment")
+    if workflow_text.index("Verify public agent run bundle contents") > workflow_text.index("Upload redacted public agent run bundle"):
+        raise SystemExit("Public agent run bundle upload must happen after verification")
     if runner_text.index("codex login --with-api-key") > runner_text.index("unset OPENAI_API_KEY"):
         raise SystemExit("OPENAI_API_KEY is unset before login, not after login")
     if runner_text.index("unset OPENAI_API_KEY") > runner_text.index("codex exec"):

--- a/scripts/test_policy_agent_public_bundle_contract.py
+++ b/scripts/test_policy_agent_public_bundle_contract.py
@@ -7,6 +7,7 @@ ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "codex-policy-agent-canary-run.yml"
 BUNDLE = ROOT / "scripts" / "build_public_agent_run_bundle.py"
 ENRICH = ROOT / "scripts" / "enrich_public_agent_run_bundle.py"
+VERIFY = ROOT / "scripts" / "verify_public_agent_run_bundle.py"
 DOC = ROOT / "docs" / "public-agent-run-bundle.md"
 
 REQUIRED_WORKFLOW_TEXT = [
@@ -17,6 +18,10 @@ REQUIRED_WORKFLOW_TEXT = [
     "python scripts/build_public_agent_run_bundle.py",
     "Enrich public agent run bundle with sanitized logs and reasoning traces",
     "python scripts/enrich_public_agent_run_bundle.py",
+    "Verify public agent run bundle contents",
+    "python scripts/verify_public_agent_run_bundle.py",
+    "--report .tmp/public-agent-run-bundle-verification.json",
+    "public-agent-run-bundle-verification.json",
     "--diagnostics-dir .tmp/canary-diagnostics",
     "--bundle-dir .tmp/public-agent-run-bundle",
     "--out-dir .tmp/public-agent-run-bundle",
@@ -32,7 +37,7 @@ REQUIRED_WORKFLOW_TEXT = [
     "Sanitized exposed reasoning / CoT-like trace directory:",
     "reasoning-traces/",
     "If the run artifact exposes reasoning / CoT-like trace text, it is part of the public lab evidence after sanitizer replacement.",
-    "Public artifacts are redacted, sanitized, indexed, and include exposed reasoning traces when present.",
+    "Public artifacts are redacted, sanitized, indexed, verified for required structure, and include exposed reasoning traces when present.",
 ]
 
 REQUIRED_BUNDLE_TEXT = [
@@ -69,6 +74,18 @@ REQUIRED_ENRICH_TEXT = [
     "[REDACTED_SECRET]",
     "[REDACTED_RUNNER_WORKDIR]",
     "exact_read_order_observed",
+]
+
+REQUIRED_VERIFY_TEXT = [
+    "REQUIRED_ROOT_FILES",
+    "REQUIRED_DIRS",
+    "observation-summary.md",
+    "observation-summary.json",
+    "reasoning-traces",
+    "sanitized",
+    "FORBIDDEN_PUBLIC_PATTERNS",
+    "verify_public_agent_run_bundle",
+    "public agent run bundle verification passed",
 ]
 
 REQUIRED_DOC_TEXT = [
@@ -122,12 +139,14 @@ def main() -> int:
     workflow = WORKFLOW.read_text(encoding="utf-8")
     bundle = BUNDLE.read_text(encoding="utf-8")
     enrich = ENRICH.read_text(encoding="utf-8")
+    verify = VERIFY.read_text(encoding="utf-8")
     doc = DOC.read_text(encoding="utf-8")
 
     require_all(workflow, REQUIRED_WORKFLOW_TEXT, "policy agent workflow")
     reject_all(workflow, FORBIDDEN_WORKFLOW_TEXT, "policy agent workflow")
     require_all(bundle, REQUIRED_BUNDLE_TEXT, "public bundle builder")
     require_all(enrich, REQUIRED_ENRICH_TEXT, "public bundle enrichment script")
+    require_all(verify, REQUIRED_VERIFY_TEXT, "public bundle verifier")
     require_all(doc, REQUIRED_DOC_TEXT, "public agent run bundle doc")
     reject_all(doc, FORBIDDEN_DOC_TEXT, "public agent run bundle doc")
 
@@ -135,8 +154,10 @@ def main() -> int:
         raise SystemExit("public bundle must be built after diagnostics collection")
     if workflow.index("Build redacted public agent run bundle") > workflow.index("Enrich public agent run bundle with sanitized logs and reasoning traces"):
         raise SystemExit("public bundle must be enriched after bundle build")
-    if workflow.index("Enrich public agent run bundle with sanitized logs and reasoning traces") > workflow.index("Upload redacted public agent run bundle"):
-        raise SystemExit("public bundle upload must occur after enrichment")
+    if workflow.index("Enrich public agent run bundle with sanitized logs and reasoning traces") > workflow.index("Verify public agent run bundle contents"):
+        raise SystemExit("public bundle must be verified after enrichment")
+    if workflow.index("Verify public agent run bundle contents") > workflow.index("Upload redacted public agent run bundle"):
+        raise SystemExit("public bundle upload must occur after verification")
     if workflow.index("Upload redacted public agent run bundle") > workflow.index("Upload diagnostics artifact"):
         raise SystemExit("public bundle should be uploaded before internal diagnostics artifact")
 

--- a/scripts/test_script_check_workflow_contract.py
+++ b/scripts/test_script_check_workflow_contract.py
@@ -24,6 +24,10 @@ REQUIRED_TEXT = [
     "python scripts/test_public_results_export_workflow_contract.py",
     "Run script-check workflow contract test",
     "python scripts/test_script_check_workflow_contract.py",
+    "Run public agent run bundle verifier test",
+    "python scripts/test_verify_public_agent_run_bundle.py",
+    "Run policy agent public bundle contract test",
+    "python scripts/test_policy_agent_public_bundle_contract.py",
     "Run lab PR scope guard self-test",
     "bash scripts/test-lab-pr-scope.sh",
 ]
@@ -58,6 +62,12 @@ def main() -> int:
 
     if text.index("lab/comparisons/**") > text.index("runs/**"):
         raise SystemExit("runs/** should be tracked near generated/evidence paths")
+
+    if text.index("Run public agent run bundle enrichment test") > text.index("Run public agent run bundle verifier test"):
+        raise SystemExit("Public bundle verifier test should run after enrichment test")
+
+    if text.index("Run public agent run bundle verifier test") > text.index("Run policy agent public bundle contract test"):
+        raise SystemExit("Policy agent public bundle contract test should run after verifier test")
 
     if text.index("Run comparison dashboard builder test") > text.index("Run comparison dashboard decision test"):
         raise SystemExit("Comparison dashboard decision test should run after the builder test")

--- a/scripts/test_verify_public_agent_run_bundle.py
+++ b/scripts/test_verify_public_agent_run_bundle.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "verify_public_agent_run_bundle.py"
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def write_json(path: Path, value: object) -> None:
+    write(path, json.dumps(value, indent=2, sort_keys=True) + "\n")
+
+
+def make_valid_bundle(bundle: Path) -> None:
+    write_json(
+        bundle / "index.json",
+        {
+            "schema_version": "prompt-vote-lab-public-agent-run-bundle-v1",
+            "run_id": "fixture-run",
+            "issue_number": "0",
+            "pr_number": None,
+            "policy": {
+                "sanitized_diagnostic_logs_included": True,
+                "sanitized_reasoning_traces_included": True,
+                "sanitizer_guarantee": "best_effort_pattern_redaction",
+            },
+            "observation_summary": {
+                "json": "observation-summary.json",
+                "markdown": "observation-summary.md",
+                "schema_version": "prompt-vote-lab-agent-observation-summary-v1",
+            },
+            "reasoning_trace_files": [
+                {
+                    "name": "codex-events.jsonl",
+                    "included": True,
+                    "path": "reasoning-traces/codex-events.jsonl",
+                    "redactions": [],
+                }
+            ],
+            "sanitized_files": [
+                {
+                    "name": "codex-stderr.txt",
+                    "included": True,
+                    "path": "sanitized/codex-stderr.txt",
+                    "redactions": [{"kind": "openai_key", "count": 1}],
+                }
+            ],
+            "included_files": [],
+            "omitted_files": [],
+        },
+    )
+    write(
+        bundle / "README.md",
+        "# Public agent run bundle\n\n## Agent observation summary\n\nSee sanitized/ and reasoning-traces/.\n",
+    )
+    write(
+        bundle / "observation-summary.md",
+        "# Agent observation summary\n\n"
+        "## Reasoning / CoT-like trace evidence\n\n"
+        "## Reasoning effect hypotheses\n\n"
+        "## Sanitized logs\n\n"
+        "## Evidence limits\n",
+    )
+    write_json(
+        bundle / "observation-summary.json",
+        {
+            "schema_version": "prompt-vote-lab-agent-observation-summary-v1",
+            "reasoning_trace": {
+                "available": True,
+                "public_trace_available": True,
+                "sanitized": True,
+                "published_directory": "reasoning-traces/",
+                "used_for_behavior_evaluation": True,
+                "exposed_reasoning_trace_published": True,
+                "unexposed_provider_private_cot_available": "unknown",
+                "unexposed_provider_private_cot_published": False,
+                "files": [
+                    {
+                        "name": "codex-events.jsonl",
+                        "included": True,
+                        "path": "reasoning-traces/codex-events.jsonl",
+                        "redactions": [],
+                    }
+                ],
+            },
+            "reasoning_effect_hypotheses": [
+                {
+                    "hypothesis": "fixture",
+                    "confidence": "low",
+                    "participant_prompt_adjustment": "inspect traces",
+                }
+            ],
+            "file_activity": [],
+            "sanitized_logs": [
+                {
+                    "name": "codex-stderr.txt",
+                    "included": True,
+                    "path": "sanitized/codex-stderr.txt",
+                    "redactions": [{"kind": "openai_key", "count": 1}],
+                }
+            ],
+        },
+    )
+    write(bundle / "raw" / "codex-events.jsonl", '{"type":"event"}\n')
+    write(bundle / "sanitized" / "codex-stderr.txt", "OPENAI_API_KEY=[REDACTED_SECRET]\n")
+    write(bundle / "reasoning-traces" / "codex-events.jsonl", '{"type":"reasoning","message":"inspect visible copy"}\n')
+
+
+def run_verify(bundle: Path, report: Path | None = None) -> subprocess.CompletedProcess[str]:
+    cmd = [sys.executable, str(SCRIPT), "--bundle-dir", str(bundle)]
+    if report:
+        cmd += ["--report", str(report)]
+    return subprocess.run(cmd, cwd=ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        valid = tmp / "valid"
+        make_valid_bundle(valid)
+        report = tmp / "report.json"
+        ok = run_verify(valid, report)
+        assert ok.returncode == 0, ok.stdout + ok.stderr
+        result = json.loads(report.read_text(encoding="utf-8"))
+        assert result["ok"] is True
+        assert "raw" in result["checked_directories"]
+        assert "sanitized" in result["checked_directories"]
+        assert "reasoning-traces" in result["checked_directories"]
+
+        missing = tmp / "missing"
+        make_valid_bundle(missing)
+        (missing / "reasoning-traces" / "codex-events.jsonl").unlink()
+        bad_missing = run_verify(missing)
+        assert bad_missing.returncode == 1
+        assert "Required directory has no files: reasoning-traces" in bad_missing.stdout
+
+        leaked = tmp / "leaked"
+        make_valid_bundle(leaked)
+        write(leaked / "sanitized" / "codex-stderr.txt", "leaked sk-FAKEFAKEFAKEFAKEFAKE\n")
+        bad_secret = run_verify(leaked)
+        assert bad_secret.returncode == 1
+        assert "Forbidden public pattern openai_key" in bad_secret.stdout
+
+        broken_summary = tmp / "broken-summary"
+        make_valid_bundle(broken_summary)
+        summary = json.loads((broken_summary / "observation-summary.json").read_text(encoding="utf-8"))
+        summary["reasoning_trace"]["published_directory"] = "traces/"
+        write_json(broken_summary / "observation-summary.json", summary)
+        bad_summary = run_verify(broken_summary)
+        assert bad_summary.returncode == 1
+        assert "published_directory must be reasoning-traces/" in bad_summary.stdout
+
+    print("public agent run bundle verifier test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_public_agent_run_bundle.py
+++ b/scripts/verify_public_agent_run_bundle.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+REQUIRED_ROOT_FILES = [
+    "index.json",
+    "README.md",
+    "observation-summary.md",
+    "observation-summary.json",
+]
+
+REQUIRED_DIRS = [
+    "raw",
+    "sanitized",
+    "reasoning-traces",
+]
+
+FORBIDDEN_PUBLIC_PATTERNS = [
+    ("openai_key", re.compile(r"sk-[A-Za-z0-9_\-]{12,}")),
+    ("github_classic_token", re.compile(r"gh[pousr]_[A-Za-z0-9_]{12,}")),
+    ("github_fine_grained_token", re.compile(r"github_pat_[A-Za-z0-9_]{12,}")),
+    ("authorization_bearer", re.compile(r"(?i)authorization:\s*bearer\s+[A-Za-z0-9_.\-]+")),
+    ("openai_env_assignment", re.compile(r"(?i)OPENAI_API_KEY\s*[:=]\s*[^\s]+")),
+    ("github_token_env_assignment", re.compile(r"(?i)GITHUB_TOKEN\s*[:=]\s*[^\s]+")),
+    ("gh_token_env_assignment", re.compile(r"(?i)GH_TOKEN\s*[:=]\s*[^\s]+")),
+]
+
+EXPECTED_REDACTION_MARKERS = [
+    "[REDACTED_SECRET]",
+    "[REDACTED_RUNNER_WORKDIR]",
+    "[REDACTED_RUNNER_TEMP]",
+    "[REDACTED_TMP_PATH]",
+    "[REDACTED_GITHUB_WORKSPACE]",
+]
+
+EXPECTED_OBSERVATION_SCHEMA = "prompt-vote-lab-agent-observation-summary-v1"
+EXPECTED_BUNDLE_SCHEMA = "prompt-vote-lab-public-agent-run-bundle-v1"
+
+
+def read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Invalid JSON: {path}: {exc}") from exc
+
+
+def text_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        try:
+            path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        files.append(path)
+    return files
+
+
+def rel(path: Path, root: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def add_error(errors: list[str], message: str) -> None:
+    errors.append(message)
+
+
+def assert_file(path: Path, errors: list[str], label: str) -> None:
+    if not path.exists() or not path.is_file():
+        add_error(errors, f"Missing required file: {label}")
+    elif path.stat().st_size <= 0:
+        add_error(errors, f"Required file is empty: {label}")
+
+
+def assert_dir(path: Path, errors: list[str], label: str) -> None:
+    if not path.exists() or not path.is_dir():
+        add_error(errors, f"Missing required directory: {label}")
+
+
+def verify_index(bundle: Path, errors: list[str]) -> dict[str, Any]:
+    index = read_json(bundle / "index.json")
+    if index.get("schema_version") != EXPECTED_BUNDLE_SCHEMA:
+        add_error(errors, f"Unexpected index schema_version: {index.get('schema_version')}")
+    policy = index.get("policy") if isinstance(index.get("policy"), dict) else {}
+    if policy.get("sanitized_diagnostic_logs_included") is not True:
+        add_error(errors, "index.policy.sanitized_diagnostic_logs_included must be true")
+    if policy.get("sanitized_reasoning_traces_included") is not True:
+        add_error(errors, "index.policy.sanitized_reasoning_traces_included must be true")
+    observation = index.get("observation_summary") if isinstance(index.get("observation_summary"), dict) else {}
+    if observation.get("json") != "observation-summary.json":
+        add_error(errors, "index.observation_summary.json must point to observation-summary.json")
+    if observation.get("markdown") != "observation-summary.md":
+        add_error(errors, "index.observation_summary.markdown must point to observation-summary.md")
+    if "reasoning_trace_files" not in index:
+        add_error(errors, "index.reasoning_trace_files is required")
+    if not isinstance(index.get("sanitized_files"), list):
+        add_error(errors, "index.sanitized_files must be a list")
+    return index
+
+
+def verify_observation_summary(bundle: Path, errors: list[str]) -> dict[str, Any]:
+    summary = read_json(bundle / "observation-summary.json")
+    if summary.get("schema_version") != EXPECTED_OBSERVATION_SCHEMA:
+        add_error(errors, f"Unexpected observation summary schema_version: {summary.get('schema_version')}")
+
+    reasoning = summary.get("reasoning_trace") if isinstance(summary.get("reasoning_trace"), dict) else {}
+    if reasoning.get("sanitized") is not True:
+        add_error(errors, "observation.reasoning_trace.sanitized must be true")
+    if reasoning.get("published_directory") != "reasoning-traces/":
+        add_error(errors, "observation.reasoning_trace.published_directory must be reasoning-traces/")
+    if reasoning.get("used_for_behavior_evaluation") is not True:
+        add_error(errors, "observation.reasoning_trace.used_for_behavior_evaluation must be true")
+    if reasoning.get("unexposed_provider_private_cot_published") is not False:
+        add_error(errors, "observation.reasoning_trace.unexposed_provider_private_cot_published must be false")
+    if not isinstance(reasoning.get("files"), list):
+        add_error(errors, "observation.reasoning_trace.files must be a list")
+
+    hypotheses = summary.get("reasoning_effect_hypotheses")
+    if not isinstance(hypotheses, list) or not hypotheses:
+        add_error(errors, "observation.reasoning_effect_hypotheses must be a non-empty list")
+
+    file_activity = summary.get("file_activity")
+    if not isinstance(file_activity, list):
+        add_error(errors, "observation.file_activity must be a list")
+
+    sanitized_logs = summary.get("sanitized_logs")
+    if not isinstance(sanitized_logs, list):
+        add_error(errors, "observation.sanitized_logs must be a list")
+
+    return summary
+
+
+def verify_dirs_have_content(bundle: Path, errors: list[str]) -> None:
+    for directory in REQUIRED_DIRS:
+        path = bundle / directory
+        assert_dir(path, errors, directory)
+        if path.exists() and path.is_dir() and not any(item.is_file() for item in path.rglob("*")):
+            add_error(errors, f"Required directory has no files: {directory}")
+
+
+def verify_markdown(bundle: Path, errors: list[str]) -> None:
+    readme = (bundle / "README.md").read_text(encoding="utf-8", errors="replace")
+    observation = (bundle / "observation-summary.md").read_text(encoding="utf-8", errors="replace")
+    required_readme = [
+        "Agent observation summary",
+        "sanitized/",
+        "reasoning-traces/",
+    ]
+    required_observation = [
+        "Agent observation summary",
+        "Reasoning / CoT-like trace evidence",
+        "Reasoning effect hypotheses",
+        "Sanitized logs",
+        "Evidence limits",
+    ]
+    for item in required_readme:
+        if item not in readme:
+            add_error(errors, f"README.md missing text: {item}")
+    for item in required_observation:
+        if item not in observation:
+            add_error(errors, f"observation-summary.md missing text: {item}")
+
+
+def verify_no_forbidden_public_patterns(bundle: Path, errors: list[str]) -> None:
+    for path in text_files(bundle):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for name, pattern in FORBIDDEN_PUBLIC_PATTERNS:
+            if pattern.search(text):
+                add_error(errors, f"Forbidden public pattern {name} found in {rel(path, bundle)}")
+
+
+def verify_marker_accounting(bundle: Path, errors: list[str]) -> None:
+    public_text = "\n".join(path.read_text(encoding="utf-8", errors="replace") for path in text_files(bundle))
+    if "[REDACTED" in public_text:
+        if not any(marker in public_text for marker in EXPECTED_REDACTION_MARKERS):
+            add_error(errors, "Unknown redaction marker family found")
+
+
+def verify_public_agent_run_bundle(bundle: Path) -> dict[str, Any]:
+    errors: list[str] = []
+    if not bundle.exists() or not bundle.is_dir():
+        raise SystemExit(f"Bundle directory not found: {bundle}")
+
+    for name in REQUIRED_ROOT_FILES:
+        assert_file(bundle / name, errors, name)
+    verify_dirs_have_content(bundle, errors)
+
+    if not errors:
+        verify_index(bundle, errors)
+        verify_observation_summary(bundle, errors)
+        verify_markdown(bundle, errors)
+        verify_no_forbidden_public_patterns(bundle, errors)
+        verify_marker_accounting(bundle, errors)
+
+    result = {
+        "bundle": str(bundle),
+        "ok": not errors,
+        "errors": errors,
+        "checked_root_files": REQUIRED_ROOT_FILES,
+        "checked_directories": REQUIRED_DIRS,
+        "forbidden_pattern_count": len(FORBIDDEN_PUBLIC_PATTERNS),
+    }
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bundle-dir", required=True)
+    parser.add_argument("--report", default="")
+    args = parser.parse_args()
+
+    result = verify_public_agent_run_bundle(Path(args.bundle_dir))
+    if args.report:
+        report = Path(args.report)
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if not result["ok"]:
+        for error in result["errors"]:
+            print(f"ERROR: {error}")
+        return 1
+    print("public agent run bundle verification passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_public_agent_run_bundle.py
+++ b/scripts/verify_public_agent_run_bundle.py
@@ -20,14 +20,16 @@ REQUIRED_DIRS = [
     "reasoning-traces",
 ]
 
+REDACTED_SECRET_VALUE = r"\[REDACTED_SECRET\]"
+
 FORBIDDEN_PUBLIC_PATTERNS = [
     ("openai_key", re.compile(r"sk-[A-Za-z0-9_\-]{12,}")),
     ("github_classic_token", re.compile(r"gh[pousr]_[A-Za-z0-9_]{12,}")),
     ("github_fine_grained_token", re.compile(r"github_pat_[A-Za-z0-9_]{12,}")),
-    ("authorization_bearer", re.compile(r"(?i)authorization:\s*bearer\s+[A-Za-z0-9_.\-]+")),
-    ("openai_env_assignment", re.compile(r"(?i)OPENAI_API_KEY\s*[:=]\s*[^\s]+")),
-    ("github_token_env_assignment", re.compile(r"(?i)GITHUB_TOKEN\s*[:=]\s*[^\s]+")),
-    ("gh_token_env_assignment", re.compile(r"(?i)GH_TOKEN\s*[:=]\s*[^\s]+")),
+    ("authorization_bearer", re.compile(rf"(?i)authorization:\s*bearer\s+(?!{REDACTED_SECRET_VALUE})[A-Za-z0-9_.\-]+")),
+    ("openai_env_assignment", re.compile(rf"(?i)OPENAI_API_KEY\s*[:=]\s*(?!{REDACTED_SECRET_VALUE})[^\s]+")),
+    ("github_token_env_assignment", re.compile(rf"(?i)GITHUB_TOKEN\s*[:=]\s*(?!{REDACTED_SECRET_VALUE})[^\s]+")),
+    ("gh_token_env_assignment", re.compile(rf"(?i)GH_TOKEN\s*[:=]\s*(?!{REDACTED_SECRET_VALUE})[^\s]+")),
 ]
 
 EXPECTED_REDACTION_MARKERS = [


### PR DESCRIPTION
## Summary

Adds a public agent run bundle verifier and wires it into the canonical Docker/Codex public bundle workflows.

## Why

The previous check proved that artifacts existed, but it did not prove the uploaded public bundle contained the required participant evidence structure:

- `index.json`
- `README.md`
- `observation-summary.md`
- `observation-summary.json`
- `raw/`
- `sanitized/`
- `reasoning-traces/`

It also did not check public bundle text for common unredacted token-like strings.

## Changes

- Add `scripts/verify_public_agent_run_bundle.py`.
- Add `scripts/test_verify_public_agent_run_bundle.py`.
- Verify required bundle files and directories.
- Verify observation summary schema and reasoning-trace fields.
- Verify `reasoning_effect_hypotheses` exists.
- Verify public text does not contain common token-like strings.
- Allow already-redacted env assignments such as `OPENAI_API_KEY=[REDACTED_SECRET]`.
- Add verifier step to `Codex Policy Agent Canary Run` before public bundle upload.
- Add enrichment and verifier steps to `Codex Fixed Issue Instruction Canary Run` before public bundle upload.
- Add verifier test to Script Check.
- Lock workflow order and verifier requirements in contract tests.

## Boundary

This verifies the bundle directory before upload. It does not download and re-verify the uploaded ZIP after GitHub artifact packaging.

## Scope

Workflow verification and tests only.

No lab UI changes, no model/token-budget changes, no auto-merge changes.