### PR TITLE
Verify uploaded public agent bundles

### DIFF
--- a/.github/workflows/codex-fixed-issue-instruction-canary-run.yml
+++ b/.github/workflows/codex-fixed-issue-instruction-canary-run.yml
@@ -206,6 +206,21 @@ jobs:
           path: .tmp/public-agent-run-bundle
           if-no-files-found: warn
 
+      - name: Download uploaded public agent run bundle
+        if: ${{ always() }}
+        uses: actions/download-artifact@v4
+        with:
+          name: codex-fixed-issue-public-agent-run-bundle-${{ github.run_number }}
+          path: .tmp/public-agent-run-bundle-uploaded
+
+      - name: Verify uploaded public agent run bundle contents
+        if: ${{ always() }}
+        run: |
+          python scripts/verify_public_agent_run_bundle.py \
+            --bundle-dir .tmp/public-agent-run-bundle-uploaded \
+            --report .tmp/public-agent-run-bundle-uploaded-verification.json
+          cp .tmp/public-agent-run-bundle-uploaded-verification.json .tmp/canary-diagnostics/public-agent-run-bundle-uploaded-verification.json
+
       - name: Upload diagnostics artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -316,6 +331,7 @@ jobs:
 
           - Redacted public agent run bundle artifact: \`codex-fixed-issue-public-agent-run-bundle-${{ github.run_number }}\`
           - Public bundle content verification report: \`public-agent-run-bundle-verification.json\` inside diagnostics
+          - Uploaded public bundle verification report: \`public-agent-run-bundle-uploaded-verification.json\` inside diagnostics
           - Observation summary files: \`observation-summary.md\`, \`observation-summary.json\`
           - Sanitized diagnostic logs directory: \`sanitized/\`
           - Sanitized exposed reasoning / CoT-like trace directory: \`reasoning-traces/\`
@@ -328,7 +344,7 @@ jobs:
 
           ## Diagnostics
 
-          Internal diagnostics artifact is uploaded for source Issue, runtime Issue safety scan, issue execution gate, instruction packet, credential presence, mount, Codex event, diff, and public bundle verification analysis.
+          Internal diagnostics artifact is uploaded for source Issue, runtime Issue safety scan, issue execution gate, instruction packet, credential presence, mount, Codex event, diff, public bundle pre-upload verification, and uploaded artifact verification analysis.
 
           A redacted public agent run bundle is also uploaded for participant analysis. It exposes allowlisted raw evidence files after secret-pattern redaction, sanitized diagnostic logs, exposed reasoning traces when present, and machine-readable verification metadata.
 

--- a/.github/workflows/codex-policy-agent-canary-run.yml
+++ b/.github/workflows/codex-policy-agent-canary-run.yml
@@ -114,6 +114,21 @@ jobs:
           path: .tmp/public-agent-run-bundle
           if-no-files-found: error
 
+      - name: Download uploaded public agent run bundle
+        if: ${{ always() }}
+        uses: actions/download-artifact@v4
+        with:
+          name: codex-policy-agent-canary-public-bundle-${{ github.run_number }}
+          path: .tmp/public-agent-run-bundle-uploaded
+
+      - name: Verify uploaded public agent run bundle contents
+        if: ${{ always() }}
+        run: |
+          python scripts/verify_public_agent_run_bundle.py \
+            --bundle-dir .tmp/public-agent-run-bundle-uploaded \
+            --report .tmp/public-agent-run-bundle-uploaded-verification.json
+          cp .tmp/public-agent-run-bundle-uploaded-verification.json .tmp/canary-diagnostics/public-agent-run-bundle-uploaded-verification.json
+
       - name: Upload diagnostics artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -210,6 +225,7 @@ jobs:
 
           - Redacted public agent run bundle artifact: \`codex-policy-agent-canary-public-bundle-${{ github.run_number }}\`
           - Public bundle content verification report: \`public-agent-run-bundle-verification.json\` inside diagnostics
+          - Uploaded public bundle verification report: \`public-agent-run-bundle-uploaded-verification.json\` inside diagnostics
           - Observation summary files: \`observation-summary.md\`, \`observation-summary.json\`
           - Sanitized diagnostic logs directory: \`sanitized/\`
           - Sanitized exposed reasoning / CoT-like trace directory: \`reasoning-traces/\`
@@ -222,7 +238,7 @@ jobs:
 
           ## Diagnostics
 
-          Internal diagnostics artifact is uploaded for mount, policy, Codex event, diff, and public bundle verification analysis. Public artifacts are redacted, sanitized, indexed, verified for required structure, and include exposed reasoning traces when present.
+          Internal diagnostics artifact is uploaded for mount, policy, Codex event, diff, public bundle pre-upload verification, and uploaded artifact verification analysis. Public artifacts are redacted, sanitized, indexed, verified for required structure, and include exposed reasoning traces when present.
 
           ## Merge policy
 

--- a/scripts/test_issue_instruction_runner_contract.py
+++ b/scripts/test_issue_instruction_runner_contract.py
@@ -66,6 +66,13 @@ REQUIRED_WORKFLOW_TEXT = [
     "python scripts/verify_public_agent_run_bundle.py",
     "--report .tmp/public-agent-run-bundle-verification.json",
     "public-agent-run-bundle-verification.json",
+    "Download uploaded public agent run bundle",
+    "actions/download-artifact@v4",
+    "path: .tmp/public-agent-run-bundle-uploaded",
+    "Verify uploaded public agent run bundle contents",
+    "--bundle-dir .tmp/public-agent-run-bundle-uploaded",
+    "--report .tmp/public-agent-run-bundle-uploaded-verification.json",
+    "public-agent-run-bundle-uploaded-verification.json",
     "--diagnostics-dir .tmp/canary-diagnostics",
     "--bundle-dir .tmp/public-agent-run-bundle",
     "--out-dir .tmp/public-agent-run-bundle",
@@ -76,6 +83,8 @@ REQUIRED_WORKFLOW_TEXT = [
     "reasoning-traces/",
     "observation-summary.md",
     "observation-summary.json",
+    "Uploaded public bundle verification report:",
+    "uploaded artifact verification analysis",
     "codex-fixed-issue-instruction-canary-diagnostics-",
     "codex-fixed-issue-instruction-canary-public-log-",
     "codex-fixed-issue-runtime-safety-scan-",
@@ -134,7 +143,13 @@ def main() -> int:
     if workflow_text.index("Enrich public agent run bundle with sanitized logs and reasoning traces") > workflow_text.index("Verify public agent run bundle contents"):
         raise SystemExit("Public agent run bundle must be verified after enrichment")
     if workflow_text.index("Verify public agent run bundle contents") > workflow_text.index("Upload redacted public agent run bundle"):
-        raise SystemExit("Public agent run bundle upload must happen after verification")
+        raise SystemExit("Public agent run bundle upload must happen after pre-upload verification")
+    if workflow_text.index("Upload redacted public agent run bundle") > workflow_text.index("Download uploaded public agent run bundle"):
+        raise SystemExit("Uploaded public agent run bundle must be downloaded after upload")
+    if workflow_text.index("Download uploaded public agent run bundle") > workflow_text.index("Verify uploaded public agent run bundle contents"):
+        raise SystemExit("Uploaded public agent run bundle must be verified after download")
+    if workflow_text.index("Verify uploaded public agent run bundle contents") > workflow_text.index("Upload diagnostics artifact"):
+        raise SystemExit("Diagnostics upload must include uploaded bundle verification")
     if runner_text.index("codex login --with-api-key") > runner_text.index("unset OPENAI_API_KEY"):
         raise SystemExit("OPENAI_API_KEY is unset before login, not after login")
     if runner_text.index("unset OPENAI_API_KEY") > runner_text.index("codex exec"):

--- a/scripts/test_policy_agent_public_bundle_contract.py
+++ b/scripts/test_policy_agent_public_bundle_contract.py
@@ -22,6 +22,13 @@ REQUIRED_WORKFLOW_TEXT = [
     "python scripts/verify_public_agent_run_bundle.py",
     "--report .tmp/public-agent-run-bundle-verification.json",
     "public-agent-run-bundle-verification.json",
+    "Download uploaded public agent run bundle",
+    "actions/download-artifact@v4",
+    "path: .tmp/public-agent-run-bundle-uploaded",
+    "Verify uploaded public agent run bundle contents",
+    "--bundle-dir .tmp/public-agent-run-bundle-uploaded",
+    "--report .tmp/public-agent-run-bundle-uploaded-verification.json",
+    "public-agent-run-bundle-uploaded-verification.json",
     "--diagnostics-dir .tmp/canary-diagnostics",
     "--bundle-dir .tmp/public-agent-run-bundle",
     "--out-dir .tmp/public-agent-run-bundle",
@@ -36,8 +43,10 @@ REQUIRED_WORKFLOW_TEXT = [
     "sanitized/",
     "Sanitized exposed reasoning / CoT-like trace directory:",
     "reasoning-traces/",
+    "Uploaded public bundle verification report:",
     "If the run artifact exposes reasoning / CoT-like trace text, it is part of the public lab evidence after sanitizer replacement.",
     "Public artifacts are redacted, sanitized, indexed, verified for required structure, and include exposed reasoning traces when present.",
+    "uploaded artifact verification analysis",
 ]
 
 REQUIRED_BUNDLE_TEXT = [
@@ -157,9 +166,13 @@ def main() -> int:
     if workflow.index("Enrich public agent run bundle with sanitized logs and reasoning traces") > workflow.index("Verify public agent run bundle contents"):
         raise SystemExit("public bundle must be verified after enrichment")
     if workflow.index("Verify public agent run bundle contents") > workflow.index("Upload redacted public agent run bundle"):
-        raise SystemExit("public bundle upload must occur after verification")
-    if workflow.index("Upload redacted public agent run bundle") > workflow.index("Upload diagnostics artifact"):
-        raise SystemExit("public bundle should be uploaded before internal diagnostics artifact")
+        raise SystemExit("public bundle upload must occur after pre-upload verification")
+    if workflow.index("Upload redacted public agent run bundle") > workflow.index("Download uploaded public agent run bundle"):
+        raise SystemExit("uploaded public bundle must be downloaded after upload")
+    if workflow.index("Download uploaded public agent run bundle") > workflow.index("Verify uploaded public agent run bundle contents"):
+        raise SystemExit("uploaded public bundle must be verified after download")
+    if workflow.index("Verify uploaded public agent run bundle contents") > workflow.index("Upload diagnostics artifact"):
+        raise SystemExit("diagnostics upload must include uploaded bundle verification")
 
     print("policy agent public bundle contract test passed")
     return 0


### PR DESCRIPTION
## Summary

Adds post-upload verification for public agent run bundles in the canonical Docker/Codex canary workflows.

## Why

#267 verifies the bundle directory before upload. That is necessary but still leaves a gap: the artifact as packaged by GitHub Actions is not re-downloaded and re-verified in the same run.

This PR narrows that gap.

## Changes

For both workflows:

- `Codex Policy Agent Canary Run`
- `Codex Fixed Issue Instruction Canary Run`

adds:

```text
Upload redacted public agent run bundle
→ Download uploaded public agent run bundle
→ Verify uploaded public agent run bundle contents
→ Upload diagnostics artifact
```

The uploaded verification report is copied into diagnostics as:

```text
public-agent-run-bundle-uploaded-verification.json
```

Contract tests now require the upload → download → verify → diagnostics order.

## Boundary

This verifies the artifact content after `actions/upload-artifact` and `actions/download-artifact` inside the same workflow run.

It still does not prove long-term artifact availability after retention expiry.

## Scope

Workflow and contract tests only.

No lab UI changes, no model/token-budget changes, no auto-merge changes.