### PR TITLE
Add actionlint to Script Check

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Run actionlint
+        uses: raven-actions/actionlint@v2
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/weekly-auto-run.yml
+++ b/.github/workflows/weekly-auto-run.yml
@@ -30,9 +30,11 @@ jobs:
 
       - name: Prepare weekly variables
         run: |
-          echo "RUN_WEEK=week-$(date -u +%G-W%V)" >> "$GITHUB_ENV"
-          echo "NO_CHANGE_BASELINE=${PROMPT_VOTE_LAB_NO_CHANGE_BASELINE:-$DEFAULT_NO_CHANGE_BASELINE}" >> "$GITHUB_ENV"
-          echo "SUPPORT_USD=${PROMPT_VOTE_LAB_SUPPORT_USD:-$DEFAULT_SUPPORT_USD}" >> "$GITHUB_ENV"
+          {
+            echo "RUN_WEEK=week-$(date -u +%G-W%V)"
+            echo "NO_CHANGE_BASELINE=${PROMPT_VOTE_LAB_NO_CHANGE_BASELINE:-$DEFAULT_NO_CHANGE_BASELINE}"
+            echo "SUPPORT_USD=${PROMPT_VOTE_LAB_SUPPORT_USD:-$DEFAULT_SUPPORT_USD}"
+          } >> "$GITHUB_ENV"
         env:
           PROMPT_VOTE_LAB_NO_CHANGE_BASELINE: ${{ vars.PROMPT_VOTE_LAB_NO_CHANGE_BASELINE }}
           PROMPT_VOTE_LAB_SUPPORT_USD: ${{ vars.PROMPT_VOTE_LAB_SUPPORT_USD }}

--- a/.github/workflows/weekly-vote-run.yml
+++ b/.github/workflows/weekly-vote-run.yml
@@ -85,18 +85,19 @@ jobs:
         run: |
           mkdir -p "runs"
           cp .tmp/weekly-vote-summary.md "runs/${{ inputs.week }}-vote-summary.md"
-          echo "" >> "runs/${{ inputs.week }}-vote-summary.md"
-          echo "## Manual weekly support total" >> "runs/${{ inputs.week }}-vote-summary.md"
-          echo "" >> "runs/${{ inputs.week }}-vote-summary.md"
-          echo "${{ inputs.support_usd }} USD" >> "runs/${{ inputs.week }}-vote-summary.md"
-          echo "" >> "runs/${{ inputs.week }}-vote-summary.md"
-          echo "## No-change baseline" >> "runs/${{ inputs.week }}-vote-summary.md"
-          echo "" >> "runs/${{ inputs.week }}-vote-summary.md"
-          echo "${{ inputs.no_change_baseline }} virtual votes" >> "runs/${{ inputs.week }}-vote-summary.md"
-          echo "" >> "runs/${{ inputs.week }}-vote-summary.md"
-          echo "## Eligible implementation ranks" >> "runs/${{ inputs.week }}-vote-summary.md"
-          echo "" >> "runs/${{ inputs.week }}-vote-summary.md"
-          python - <<'PY' >> "runs/${{ inputs.week }}-vote-summary.md"
+          {
+            echo ""
+            echo "## Manual weekly support total"
+            echo ""
+            echo "${{ inputs.support_usd }} USD"
+            echo ""
+            echo "## No-change baseline"
+            echo ""
+            echo "${{ inputs.no_change_baseline }} virtual votes"
+            echo ""
+            echo "## Eligible implementation ranks"
+            echo ""
+            python - <<'PY'
           import json
           from pathlib import Path
           items = json.loads(Path('.tmp/eligible-candidates.json').read_text())
@@ -105,6 +106,7 @@ jobs:
           for item in items:
               print(f"- rank {item['rank']}: issue #{item['issue_number']} ({item['run_reason']})")
           PY
+          } >> "runs/${{ inputs.week }}-vote-summary.md"
 
       - name: Commit vote report
         run: |

--- a/scripts/test_script_check_workflow_contract.py
+++ b/scripts/test_script_check_workflow_contract.py
@@ -14,6 +14,8 @@ REQUIRED_TEXT = [
     "runs/**",
     "workflow_dispatch:",
     "contents: read",
+    "Run actionlint",
+    "raven-actions/actionlint@v2",
     "Run comparison dashboard builder test",
     "python scripts/test_build_comparison_dashboard.py",
     "Run comparison dashboard decision test",
@@ -59,6 +61,12 @@ def main() -> int:
     text = WORKFLOW.read_text(encoding="utf-8")
     require_all(text, REQUIRED_TEXT)
     reject_all(text, FORBIDDEN_TEXT)
+
+    if text.index("Checkout") > text.index("Run actionlint"):
+        raise SystemExit("actionlint should run after checkout")
+
+    if text.index("Run actionlint") > text.index("Setup Node"):
+        raise SystemExit("actionlint should run before language-specific script checks")
 
     if text.index("lab/comparisons/**") > text.index("runs/**"):
         raise SystemExit("runs/** should be tracked near generated/evidence paths")


### PR DESCRIPTION
## Summary

Adds `actionlint` to `Script Check` and locks it with the script-check workflow contract test.

## Why

The repository now relies heavily on GitHub Actions workflow contracts. Existing tests check project-specific invariants, but they do not statically validate workflow syntax, expressions, and action inputs.

`actionlint` adds a generic GitHub Actions workflow lint layer before language-specific script checks.

## Changes

- Add `raven-actions/actionlint@v2` after checkout in `Script Check`.
- Require the actionlint step in `scripts/test_script_check_workflow_contract.py`.
- Require actionlint to run before Node/Python/Shell checks.

## Scope

Workflow linting only.

No lab UI changes, no public evidence changes, no Codex/model/token changes.