### PR TITLE
Scan public agent bundles with Gitleaks

### DIFF
--- a/.github/workflows/codex-fixed-issue-instruction-canary-run.yml
+++ b/.github/workflows/codex-fixed-issue-instruction-canary-run.yml
@@ -198,6 +198,19 @@ jobs:
             --report .tmp/public-agent-run-bundle-verification.json
           cp .tmp/public-agent-run-bundle-verification.json .tmp/canary-diagnostics/public-agent-run-bundle-verification.json
 
+      - name: Scan public agent run bundle with Gitleaks
+        if: ${{ always() }}
+        run: |
+          set +e
+          bash scripts/run_gitleaks_public_bundle_scan.sh \
+            --bundle-dir .tmp/public-agent-run-bundle \
+            --report .tmp/public-agent-run-bundle-gitleaks.json \
+            --findings .tmp/public-agent-run-bundle-gitleaks-findings.json
+          rc=$?
+          cp .tmp/public-agent-run-bundle-gitleaks.json .tmp/canary-diagnostics/public-agent-run-bundle-gitleaks.json 2>/dev/null || true
+          cp .tmp/public-agent-run-bundle-gitleaks-findings.json .tmp/canary-diagnostics/public-agent-run-bundle-gitleaks-findings.json 2>/dev/null || true
+          exit "$rc"
+
       - name: Upload redacted public agent run bundle
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -220,6 +233,19 @@ jobs:
             --bundle-dir .tmp/public-agent-run-bundle-uploaded \
             --report .tmp/public-agent-run-bundle-uploaded-verification.json
           cp .tmp/public-agent-run-bundle-uploaded-verification.json .tmp/canary-diagnostics/public-agent-run-bundle-uploaded-verification.json
+
+      - name: Scan uploaded public agent run bundle with Gitleaks
+        if: ${{ always() }}
+        run: |
+          set +e
+          bash scripts/run_gitleaks_public_bundle_scan.sh \
+            --bundle-dir .tmp/public-agent-run-bundle-uploaded \
+            --report .tmp/public-agent-run-bundle-uploaded-gitleaks.json \
+            --findings .tmp/public-agent-run-bundle-uploaded-gitleaks-findings.json
+          rc=$?
+          cp .tmp/public-agent-run-bundle-uploaded-gitleaks.json .tmp/canary-diagnostics/public-agent-run-bundle-uploaded-gitleaks.json 2>/dev/null || true
+          cp .tmp/public-agent-run-bundle-uploaded-gitleaks-findings.json .tmp/canary-diagnostics/public-agent-run-bundle-uploaded-gitleaks-findings.json 2>/dev/null || true
+          exit "$rc"
 
       - name: Upload diagnostics artifact
         if: ${{ always() }}
@@ -331,7 +357,9 @@ jobs:
 
           - Redacted public agent run bundle artifact: \`codex-fixed-issue-public-agent-run-bundle-${{ github.run_number }}\`
           - Public bundle content verification report: \`public-agent-run-bundle-verification.json\` inside diagnostics
+          - Public bundle Gitleaks report: \`public-agent-run-bundle-gitleaks.json\` inside diagnostics
           - Uploaded public bundle verification report: \`public-agent-run-bundle-uploaded-verification.json\` inside diagnostics
+          - Uploaded public bundle Gitleaks report: \`public-agent-run-bundle-uploaded-gitleaks.json\` inside diagnostics
           - Observation summary files: \`observation-summary.md\`, \`observation-summary.json\`
           - Sanitized diagnostic logs directory: \`sanitized/\`
           - Sanitized exposed reasoning / CoT-like trace directory: \`reasoning-traces/\`
@@ -344,9 +372,9 @@ jobs:
 
           ## Diagnostics
 
-          Internal diagnostics artifact is uploaded for source Issue, runtime Issue safety scan, issue execution gate, instruction packet, credential presence, mount, Codex event, diff, public bundle pre-upload verification, and uploaded artifact verification analysis.
+          Internal diagnostics artifact is uploaded for source Issue, runtime Issue safety scan, issue execution gate, instruction packet, credential presence, mount, Codex event, diff, public bundle pre-upload verification, public bundle Gitleaks scan, uploaded artifact verification, and uploaded artifact Gitleaks scan analysis.
 
-          A redacted public agent run bundle is also uploaded for participant analysis. It exposes allowlisted raw evidence files after secret-pattern redaction, sanitized diagnostic logs, exposed reasoning traces when present, and machine-readable verification metadata.
+          A redacted public agent run bundle is also uploaded for participant analysis. It exposes allowlisted raw evidence files after secret-pattern redaction, sanitized diagnostic logs, exposed reasoning traces when present, machine-readable verification metadata, and Gitleaks scan metadata.
 
           ## Merge policy
 

--- a/.github/workflows/codex-policy-agent-canary-run.yml
+++ b/.github/workflows/codex-policy-agent-canary-run.yml
@@ -106,6 +106,19 @@ jobs:
             --report .tmp/public-agent-run-bundle-verification.json
           cp .tmp/public-agent-run-bundle-verification.json .tmp/canary-diagnostics/public-agent-run-bundle-verification.json
 
+      - name: Scan public agent run bundle with Gitleaks
+        if: ${{ always() }}
+        run: |
+          set +e
+          bash scripts/run_gitleaks_public_bundle_scan.sh \
+            --bundle-dir .tmp/public-agent-run-bundle \
+            --report .tmp/public-agent-run-bundle-gitleaks.json \
+            --findings .tmp/public-agent-run-bundle-gitleaks-findings.json
+          rc=$?
+          cp .tmp/public-agent-run-bundle-gitleaks.json .tmp/canary-diagnostics/public-agent-run-bundle-gitleaks.json 2>/dev/null || true
+          cp .tmp/public-agent-run-bundle-gitleaks-findings.json .tmp/canary-diagnostics/public-agent-run-bundle-gitleaks-findings.json 2>/dev/null || true
+          exit "$rc"
+
       - name: Upload redacted public agent run bundle
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -128,6 +141,19 @@ jobs:
             --bundle-dir .tmp/public-agent-run-bundle-uploaded \
             --report .tmp/public-agent-run-bundle-uploaded-verification.json
           cp .tmp/public-agent-run-bundle-uploaded-verification.json .tmp/canary-diagnostics/public-agent-run-bundle-uploaded-verification.json
+
+      - name: Scan uploaded public agent run bundle with Gitleaks
+        if: ${{ always() }}
+        run: |
+          set +e
+          bash scripts/run_gitleaks_public_bundle_scan.sh \
+            --bundle-dir .tmp/public-agent-run-bundle-uploaded \
+            --report .tmp/public-agent-run-bundle-uploaded-gitleaks.json \
+            --findings .tmp/public-agent-run-bundle-uploaded-gitleaks-findings.json
+          rc=$?
+          cp .tmp/public-agent-run-bundle-uploaded-gitleaks.json .tmp/canary-diagnostics/public-agent-run-bundle-uploaded-gitleaks.json 2>/dev/null || true
+          cp .tmp/public-agent-run-bundle-uploaded-gitleaks-findings.json .tmp/canary-diagnostics/public-agent-run-bundle-uploaded-gitleaks-findings.json 2>/dev/null || true
+          exit "$rc"
 
       - name: Upload diagnostics artifact
         if: ${{ always() }}
@@ -225,7 +251,9 @@ jobs:
 
           - Redacted public agent run bundle artifact: \`codex-policy-agent-canary-public-bundle-${{ github.run_number }}\`
           - Public bundle content verification report: \`public-agent-run-bundle-verification.json\` inside diagnostics
+          - Public bundle Gitleaks report: \`public-agent-run-bundle-gitleaks.json\` inside diagnostics
           - Uploaded public bundle verification report: \`public-agent-run-bundle-uploaded-verification.json\` inside diagnostics
+          - Uploaded public bundle Gitleaks report: \`public-agent-run-bundle-uploaded-gitleaks.json\` inside diagnostics
           - Observation summary files: \`observation-summary.md\`, \`observation-summary.json\`
           - Sanitized diagnostic logs directory: \`sanitized/\`
           - Sanitized exposed reasoning / CoT-like trace directory: \`reasoning-traces/\`
@@ -238,7 +266,7 @@ jobs:
 
           ## Diagnostics
 
-          Internal diagnostics artifact is uploaded for mount, policy, Codex event, diff, public bundle pre-upload verification, and uploaded artifact verification analysis. Public artifacts are redacted, sanitized, indexed, verified for required structure, and include exposed reasoning traces when present.
+          Internal diagnostics artifact is uploaded for mount, policy, Codex event, diff, public bundle pre-upload verification, public bundle Gitleaks scan, uploaded artifact verification, and uploaded artifact Gitleaks scan analysis. Public artifacts are redacted, sanitized, indexed, verified for required structure, scanned for secret-like strings, and include exposed reasoning traces when present.
 
           ## Merge policy
 

--- a/scripts/run_gitleaks_public_bundle_scan.sh
+++ b/scripts/run_gitleaks_public_bundle_scan.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bundle_dir=""
+report_path=""
+findings_path=""
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/run_gitleaks_public_bundle_scan.sh --bundle-dir DIR --report REPORT_JSON [--findings FINDINGS_JSON]
+
+Scans a generated public agent run bundle directory with Gitleaks. This is deliberately
+scoped to the public bundle directory, not the whole repository, to avoid false positives
+from intentional test fixtures.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --bundle-dir)
+      bundle_dir="${2:-}"
+      shift 2
+      ;;
+    --report)
+      report_path="${2:-}"
+      shift 2
+      ;;
+    --findings)
+      findings_path="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$bundle_dir" ] || [ -z "$report_path" ]; then
+  usage >&2
+  exit 2
+fi
+
+if [ ! -d "$bundle_dir" ]; then
+  echo "Bundle directory not found: $bundle_dir" >&2
+  exit 2
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required for the public bundle Gitleaks scan" >&2
+  exit 2
+fi
+
+GITLEAKS_IMAGE="${GITLEAKS_IMAGE:-ghcr.io/gitleaks/gitleaks:v8.30.1}"
+
+report_dir="$(dirname "$report_path")"
+mkdir -p "$report_dir"
+
+if [ -z "$findings_path" ]; then
+  findings_path="${report_path%.json}.findings.json"
+fi
+findings_dir="$(dirname "$findings_path")"
+mkdir -p "$findings_dir"
+
+bundle_abs="$(cd "$bundle_dir" && pwd -P)"
+report_dir_abs="$(cd "$report_dir" && pwd -P)"
+findings_dir_abs="$(cd "$findings_dir" && pwd -P)"
+findings_base="$(basename "$findings_path")"
+
+# Gitleaks returns exit code 1 by default when leaks are found. We set a distinct
+# exit code so this wrapper can distinguish findings from runtime errors.
+set +e
+docker run --rm \
+  -v "$bundle_abs:/scan:ro" \
+  -v "$findings_dir_abs:/findings:rw" \
+  "$GITLEAKS_IMAGE" detect \
+    --no-git \
+    --redact \
+    --source=/scan \
+    --report-format=json \
+    --report-path="/findings/$findings_base" \
+    --exit-code=2
+scan_rc=$?
+set -e
+
+if [ ! -f "$findings_path" ]; then
+  printf '[]\n' > "$findings_path"
+fi
+
+python - "$report_path" "$findings_path" "$bundle_abs" "$GITLEAKS_IMAGE" "$scan_rc" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+report_path = Path(sys.argv[1])
+findings_path = Path(sys.argv[2])
+bundle_dir = sys.argv[3]
+image = sys.argv[4]
+scan_rc = int(sys.argv[5])
+
+try:
+    findings = json.loads(findings_path.read_text(encoding="utf-8"))
+except json.JSONDecodeError:
+    findings = []
+
+if not isinstance(findings, list):
+    findings = []
+
+report = {
+    "schema_version": "prompt-vote-lab-public-bundle-gitleaks-scan-v1",
+    "ok": scan_rc == 0 and len(findings) == 0,
+    "scanner": "gitleaks",
+    "scanner_image": image,
+    "bundle_dir": bundle_dir,
+    "gitleaks_exit_code": scan_rc,
+    "finding_count": len(findings),
+    "findings_file": str(findings_path),
+    "scan_scope": "public-agent-run-bundle-only",
+    "repo_wide_scan": False,
+}
+report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+
+if [ "$scan_rc" -eq 0 ]; then
+  echo "public bundle Gitleaks scan passed"
+  exit 0
+fi
+
+if [ "$scan_rc" -eq 2 ]; then
+  echo "public bundle Gitleaks scan found potential secrets" >&2
+  exit 1
+fi
+
+echo "public bundle Gitleaks scan failed with exit code $scan_rc" >&2
+exit "$scan_rc"

--- a/scripts/test_issue_instruction_runner_contract.py
+++ b/scripts/test_issue_instruction_runner_contract.py
@@ -6,6 +6,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 RUNNER = ROOT / "scripts" / "run_codex_issue_instruction_canary.sh"
 WORKFLOW = ROOT / ".github" / "workflows" / "codex-fixed-issue-instruction-canary-run.yml"
+GITLEAKS = ROOT / "scripts" / "run_gitleaks_public_bundle_scan.sh"
 
 REQUIRED_RUNNER_TEXT = [
     "python scripts/create_codex_issue_instruction_packet.py",
@@ -66,6 +67,11 @@ REQUIRED_WORKFLOW_TEXT = [
     "python scripts/verify_public_agent_run_bundle.py",
     "--report .tmp/public-agent-run-bundle-verification.json",
     "public-agent-run-bundle-verification.json",
+    "Scan public agent run bundle with Gitleaks",
+    "bash scripts/run_gitleaks_public_bundle_scan.sh",
+    "--report .tmp/public-agent-run-bundle-gitleaks.json",
+    "public-agent-run-bundle-gitleaks.json",
+    "public-agent-run-bundle-gitleaks-findings.json",
     "Download uploaded public agent run bundle",
     "actions/download-artifact@v4",
     "path: .tmp/public-agent-run-bundle-uploaded",
@@ -73,6 +79,10 @@ REQUIRED_WORKFLOW_TEXT = [
     "--bundle-dir .tmp/public-agent-run-bundle-uploaded",
     "--report .tmp/public-agent-run-bundle-uploaded-verification.json",
     "public-agent-run-bundle-uploaded-verification.json",
+    "Scan uploaded public agent run bundle with Gitleaks",
+    "--report .tmp/public-agent-run-bundle-uploaded-gitleaks.json",
+    "public-agent-run-bundle-uploaded-gitleaks.json",
+    "public-agent-run-bundle-uploaded-gitleaks-findings.json",
     "--diagnostics-dir .tmp/canary-diagnostics",
     "--bundle-dir .tmp/public-agent-run-bundle",
     "--out-dir .tmp/public-agent-run-bundle",
@@ -83,8 +93,11 @@ REQUIRED_WORKFLOW_TEXT = [
     "reasoning-traces/",
     "observation-summary.md",
     "observation-summary.json",
+    "Public bundle Gitleaks report:",
     "Uploaded public bundle verification report:",
-    "uploaded artifact verification analysis",
+    "Uploaded public bundle Gitleaks report:",
+    "uploaded artifact Gitleaks scan analysis",
+    "Gitleaks scan metadata",
     "codex-fixed-issue-instruction-canary-diagnostics-",
     "codex-fixed-issue-instruction-canary-public-log-",
     "codex-fixed-issue-runtime-safety-scan-",
@@ -95,6 +108,18 @@ REQUIRED_WORKFLOW_TEXT = [
     "--retry-policy none",
     "--fallback-policy none",
     "--auto-merge-policy disabled",
+]
+
+REQUIRED_GITLEAKS_TEXT = [
+    "scan_scope",
+    "public-agent-run-bundle-only",
+    "repo_wide_scan",
+    "False",
+    "ghcr.io/gitleaks/gitleaks:v8.30.1",
+    "--no-git",
+    "--redact",
+    "--report-format=json",
+    "public bundle Gitleaks scan passed",
 ]
 
 FORBIDDEN_RUNNER_TEXT = [
@@ -126,11 +151,13 @@ def reject_all(text: str, forbidden: list[str], label: str) -> None:
 def main() -> int:
     runner_text = RUNNER.read_text(encoding="utf-8")
     workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    gitleaks_text = GITLEAKS.read_text(encoding="utf-8")
 
     require_all(runner_text, REQUIRED_RUNNER_TEXT, "runner")
     reject_all(runner_text, FORBIDDEN_RUNNER_TEXT, "runner")
     require_all(workflow_text, REQUIRED_WORKFLOW_TEXT, "workflow")
     reject_all(workflow_text, FORBIDDEN_WORKFLOW_TEXT, "workflow")
+    require_all(gitleaks_text, REQUIRED_GITLEAKS_TEXT, "public bundle Gitleaks scanner")
 
     if workflow_text.index("Validate dispatch inputs") > workflow_text.index("Capture diagnostics baseline"):
         raise SystemExit("Dispatch inputs must be validated before diagnostics baseline")
@@ -142,14 +169,18 @@ def main() -> int:
         raise SystemExit("Public agent run bundle must be enriched after it is built")
     if workflow_text.index("Enrich public agent run bundle with sanitized logs and reasoning traces") > workflow_text.index("Verify public agent run bundle contents"):
         raise SystemExit("Public agent run bundle must be verified after enrichment")
-    if workflow_text.index("Verify public agent run bundle contents") > workflow_text.index("Upload redacted public agent run bundle"):
-        raise SystemExit("Public agent run bundle upload must happen after pre-upload verification")
+    if workflow_text.index("Verify public agent run bundle contents") > workflow_text.index("Scan public agent run bundle with Gitleaks"):
+        raise SystemExit("Public agent run bundle must be scanned after pre-upload verification")
+    if workflow_text.index("Scan public agent run bundle with Gitleaks") > workflow_text.index("Upload redacted public agent run bundle"):
+        raise SystemExit("Public agent run bundle upload must happen after pre-upload Gitleaks scan")
     if workflow_text.index("Upload redacted public agent run bundle") > workflow_text.index("Download uploaded public agent run bundle"):
         raise SystemExit("Uploaded public agent run bundle must be downloaded after upload")
     if workflow_text.index("Download uploaded public agent run bundle") > workflow_text.index("Verify uploaded public agent run bundle contents"):
         raise SystemExit("Uploaded public agent run bundle must be verified after download")
-    if workflow_text.index("Verify uploaded public agent run bundle contents") > workflow_text.index("Upload diagnostics artifact"):
-        raise SystemExit("Diagnostics upload must include uploaded bundle verification")
+    if workflow_text.index("Verify uploaded public agent run bundle contents") > workflow_text.index("Scan uploaded public agent run bundle with Gitleaks"):
+        raise SystemExit("Uploaded public agent run bundle must be scanned after uploaded verification")
+    if workflow_text.index("Scan uploaded public agent run bundle with Gitleaks") > workflow_text.index("Upload diagnostics artifact"):
+        raise SystemExit("Diagnostics upload must include uploaded bundle Gitleaks report")
     if runner_text.index("codex login --with-api-key") > runner_text.index("unset OPENAI_API_KEY"):
         raise SystemExit("OPENAI_API_KEY is unset before login, not after login")
     if runner_text.index("unset OPENAI_API_KEY") > runner_text.index("codex exec"):

--- a/scripts/test_policy_agent_public_bundle_contract.py
+++ b/scripts/test_policy_agent_public_bundle_contract.py
@@ -8,6 +8,7 @@ WORKFLOW = ROOT / ".github" / "workflows" / "codex-policy-agent-canary-run.yml"
 BUNDLE = ROOT / "scripts" / "build_public_agent_run_bundle.py"
 ENRICH = ROOT / "scripts" / "enrich_public_agent_run_bundle.py"
 VERIFY = ROOT / "scripts" / "verify_public_agent_run_bundle.py"
+GITLEAKS = ROOT / "scripts" / "run_gitleaks_public_bundle_scan.sh"
 DOC = ROOT / "docs" / "public-agent-run-bundle.md"
 
 REQUIRED_WORKFLOW_TEXT = [
@@ -22,6 +23,11 @@ REQUIRED_WORKFLOW_TEXT = [
     "python scripts/verify_public_agent_run_bundle.py",
     "--report .tmp/public-agent-run-bundle-verification.json",
     "public-agent-run-bundle-verification.json",
+    "Scan public agent run bundle with Gitleaks",
+    "bash scripts/run_gitleaks_public_bundle_scan.sh",
+    "--report .tmp/public-agent-run-bundle-gitleaks.json",
+    "public-agent-run-bundle-gitleaks.json",
+    "public-agent-run-bundle-gitleaks-findings.json",
     "Download uploaded public agent run bundle",
     "actions/download-artifact@v4",
     "path: .tmp/public-agent-run-bundle-uploaded",
@@ -29,6 +35,10 @@ REQUIRED_WORKFLOW_TEXT = [
     "--bundle-dir .tmp/public-agent-run-bundle-uploaded",
     "--report .tmp/public-agent-run-bundle-uploaded-verification.json",
     "public-agent-run-bundle-uploaded-verification.json",
+    "Scan uploaded public agent run bundle with Gitleaks",
+    "--report .tmp/public-agent-run-bundle-uploaded-gitleaks.json",
+    "public-agent-run-bundle-uploaded-gitleaks.json",
+    "public-agent-run-bundle-uploaded-gitleaks-findings.json",
     "--diagnostics-dir .tmp/canary-diagnostics",
     "--bundle-dir .tmp/public-agent-run-bundle",
     "--out-dir .tmp/public-agent-run-bundle",
@@ -43,34 +53,36 @@ REQUIRED_WORKFLOW_TEXT = [
     "sanitized/",
     "Sanitized exposed reasoning / CoT-like trace directory:",
     "reasoning-traces/",
+    "Public bundle Gitleaks report:",
     "Uploaded public bundle verification report:",
+    "Uploaded public bundle Gitleaks report:",
     "If the run artifact exposes reasoning / CoT-like trace text, it is part of the public lab evidence after sanitizer replacement.",
-    "Public artifacts are redacted, sanitized, indexed, verified for required structure, and include exposed reasoning traces when present.",
-    "uploaded artifact verification analysis",
+    "Public artifacts are redacted, sanitized, indexed, verified for required structure, scanned for secret-like strings, and include exposed reasoning traces when present.",
+    "uploaded artifact Gitleaks scan analysis",
 ]
 
 REQUIRED_BUNDLE_TEXT = [
-    '"policy-agent-container-exit-code.txt"',
-    '"policy-agent-diff-name-only.txt"',
-    '"policy-agent-diff.patch"',
-    '"policy-agent-copied-files.txt"',
-    '"policy-agent-container-stdout.txt"',
-    '"policy-agent-container-stderr.txt"',
-    '"policy-container-mounts.txt"',
-    'line_list(diag / "policy-agent-diff-name-only.txt")',
+    '\"policy-agent-container-exit-code.txt\"',
+    '\"policy-agent-diff-name-only.txt\"',
+    '\"policy-agent-diff.patch\"',
+    '\"policy-agent-copied-files.txt\"',
+    '\"policy-agent-container-stdout.txt\"',
+    '\"policy-agent-container-stderr.txt\"',
+    '\"policy-container-mounts.txt\"',
+    'line_list(diag / \"policy-agent-diff-name-only.txt\")',
 ]
 
 REQUIRED_ENRICH_TEXT = [
     "SANITIZED_PUBLIC_FILES",
     "REASONING_TRACE_FILES",
-    '"codex-events.jsonl"',
-    '"codex-last-message.txt"',
-    '"codex-stderr.txt"',
-    '"codex-stdout.txt"',
-    '"policy-agent-container-stdout.txt"',
-    '"policy-agent-container-stderr.txt"',
-    '"npm-install-codex.txt"',
-    '"policy-container-mounts.txt"',
+    '\"codex-events.jsonl\"',
+    '\"codex-last-message.txt\"',
+    '\"codex-stderr.txt\"',
+    '\"codex-stdout.txt\"',
+    '\"policy-agent-container-stdout.txt\"',
+    '\"policy-agent-container-stderr.txt\"',
+    '\"npm-install-codex.txt\"',
+    '\"policy-container-mounts.txt\"',
     "reasoning-traces/",
     "copy_reasoning_trace_files",
     "reasoning_trace_files",
@@ -95,6 +107,18 @@ REQUIRED_VERIFY_TEXT = [
     "FORBIDDEN_PUBLIC_PATTERNS",
     "verify_public_agent_run_bundle",
     "public agent run bundle verification passed",
+]
+
+REQUIRED_GITLEAKS_TEXT = [
+    "scan_scope",
+    "public-agent-run-bundle-only",
+    "repo_wide_scan",
+    "False",
+    "ghcr.io/gitleaks/gitleaks:v8.30.1",
+    "--no-git",
+    "--redact",
+    "--report-format=json",
+    "public bundle Gitleaks scan passed",
 ]
 
 REQUIRED_DOC_TEXT = [
@@ -149,6 +173,7 @@ def main() -> int:
     bundle = BUNDLE.read_text(encoding="utf-8")
     enrich = ENRICH.read_text(encoding="utf-8")
     verify = VERIFY.read_text(encoding="utf-8")
+    gitleaks = GITLEAKS.read_text(encoding="utf-8")
     doc = DOC.read_text(encoding="utf-8")
 
     require_all(workflow, REQUIRED_WORKFLOW_TEXT, "policy agent workflow")
@@ -156,6 +181,7 @@ def main() -> int:
     require_all(bundle, REQUIRED_BUNDLE_TEXT, "public bundle builder")
     require_all(enrich, REQUIRED_ENRICH_TEXT, "public bundle enrichment script")
     require_all(verify, REQUIRED_VERIFY_TEXT, "public bundle verifier")
+    require_all(gitleaks, REQUIRED_GITLEAKS_TEXT, "public bundle Gitleaks scanner")
     require_all(doc, REQUIRED_DOC_TEXT, "public agent run bundle doc")
     reject_all(doc, FORBIDDEN_DOC_TEXT, "public agent run bundle doc")
 
@@ -165,14 +191,18 @@ def main() -> int:
         raise SystemExit("public bundle must be enriched after bundle build")
     if workflow.index("Enrich public agent run bundle with sanitized logs and reasoning traces") > workflow.index("Verify public agent run bundle contents"):
         raise SystemExit("public bundle must be verified after enrichment")
-    if workflow.index("Verify public agent run bundle contents") > workflow.index("Upload redacted public agent run bundle"):
-        raise SystemExit("public bundle upload must occur after pre-upload verification")
+    if workflow.index("Verify public agent run bundle contents") > workflow.index("Scan public agent run bundle with Gitleaks"):
+        raise SystemExit("public bundle must be scanned after pre-upload verification")
+    if workflow.index("Scan public agent run bundle with Gitleaks") > workflow.index("Upload redacted public agent run bundle"):
+        raise SystemExit("public bundle upload must occur after pre-upload Gitleaks scan")
     if workflow.index("Upload redacted public agent run bundle") > workflow.index("Download uploaded public agent run bundle"):
         raise SystemExit("uploaded public bundle must be downloaded after upload")
     if workflow.index("Download uploaded public agent run bundle") > workflow.index("Verify uploaded public agent run bundle contents"):
         raise SystemExit("uploaded public bundle must be verified after download")
-    if workflow.index("Verify uploaded public agent run bundle contents") > workflow.index("Upload diagnostics artifact"):
-        raise SystemExit("diagnostics upload must include uploaded bundle verification")
+    if workflow.index("Verify uploaded public agent run bundle contents") > workflow.index("Scan uploaded public agent run bundle with Gitleaks"):
+        raise SystemExit("uploaded public bundle must be scanned after uploaded verification")
+    if workflow.index("Scan uploaded public agent run bundle with Gitleaks") > workflow.index("Upload diagnostics artifact"):
+        raise SystemExit("diagnostics upload must include uploaded bundle Gitleaks report")
 
     print("policy agent public bundle contract test passed")
     return 0


### PR DESCRIPTION
## Summary

Adds a Gitleaks-based secret-like string scan for generated public agent run bundles.

## Why

The repository already has a custom sanitizer and verifier for public bundles. That is necessary, but it is still a custom regex layer.

This adds a second defense layer using Gitleaks, scoped only to generated public agent run bundles.

## Design choice

This intentionally does **not** scan the whole repository. The repo contains intentional fake-token fixtures for verifier tests, so repo-wide scans would likely create false positives. The risk being controlled here is public evidence artifact leakage, so the scan scope is the generated bundle directory only.

## Changes

- Add `scripts/run_gitleaks_public_bundle_scan.sh`.
- Scan the pre-upload public bundle directory.
- Scan the uploaded-and-downloaded public bundle directory.
- Store scan reports and findings in diagnostics:
  - `public-agent-run-bundle-gitleaks.json`
  - `public-agent-run-bundle-gitleaks-findings.json`
  - `public-agent-run-bundle-uploaded-gitleaks.json`
  - `public-agent-run-bundle-uploaded-gitleaks-findings.json`
- Apply the scan to:
  - `Codex Policy Agent Canary Run`
  - `Codex Fixed Issue Instruction Canary Run`
- Update contract tests to lock the scan order.

## Boundary

Gitleaks is a second defense layer, not a proof of no secrets. The custom sanitizer/verifier remains in place.

## Scope

Workflow and public bundle leak-scan hardening only.

No lab UI changes, no model/token-budget changes, no auto-merge changes.