### PR TITLE
Fix OpenAI key false positive in public bundle verifier

### DIFF
--- a/scripts/enrich_public_agent_run_bundle.py
+++ b/scripts/enrich_public_agent_run_bundle.py
@@ -40,7 +40,7 @@ REASONING_TRACE_FILES = [
 ]
 
 SECRET_PATTERNS = [
-    ("openai_key", re.compile(r"sk-[A-Za-z0-9_\-]{12,}")),
+    ("openai_key", re.compile(r"(?<![A-Za-z0-9])sk-[A-Za-z0-9_\-]{12,}")),
     ("github_classic_token", re.compile(r"gh[pousr]_[A-Za-z0-9_]{12,}")),
     ("github_fine_grained_token", re.compile(r"github_pat_[A-Za-z0-9_]{12,}")),
     ("authorization_bearer", re.compile(r"(?i)(authorization:\s*bearer\s+)[A-Za-z0-9_.\-]+")),

--- a/scripts/test_verify_public_agent_run_bundle.py
+++ b/scripts/test_verify_public_agent_run_bundle.py
@@ -136,6 +136,16 @@ def main() -> int:
         assert "sanitized" in result["checked_directories"]
         assert "reasoning-traces" in result["checked_directories"]
 
+        false_positive = tmp / "false-positive"
+        make_valid_bundle(false_positive)
+        index = json.loads((false_positive / "index.json").read_text(encoding="utf-8"))
+        index["included_files"] = [
+            {"path": "raw/task-static-ui-v1.0.md", "note": "task-static-ui-v1.0.md must not match sk-* secret detection inside a word"}
+        ]
+        write_json(false_positive / "index.json", index)
+        ok_false_positive = run_verify(false_positive)
+        assert ok_false_positive.returncode == 0, ok_false_positive.stdout + ok_false_positive.stderr
+
         missing = tmp / "missing"
         make_valid_bundle(missing)
         (missing / "reasoning-traces" / "codex-events.jsonl").unlink()

--- a/scripts/verify_public_agent_run_bundle.py
+++ b/scripts/verify_public_agent_run_bundle.py
@@ -23,7 +23,7 @@ REQUIRED_DIRS = [
 REDACTED_SECRET_VALUE = r"\[REDACTED_SECRET\]"
 
 FORBIDDEN_PUBLIC_PATTERNS = [
-    ("openai_key", re.compile(r"sk-[A-Za-z0-9_\-]{12,}")),
+    ("openai_key", re.compile(r"(?<![A-Za-z0-9])sk-[A-Za-z0-9_\-]{12,}")),
     ("github_classic_token", re.compile(r"gh[pousr]_[A-Za-z0-9_]{12,}")),
     ("github_fine_grained_token", re.compile(r"github_pat_[A-Za-z0-9_]{12,}")),
     ("authorization_bearer", re.compile(rf"(?i)authorization:\s*bearer\s+(?!{REDACTED_SECRET_VALUE})[A-Za-z0-9_.\-]+")),


### PR DESCRIPTION
## Summary

Fixes a false positive in the public bundle verifier and sanitizer for strings like `task-static-ui-v1.0.md`.

## Failure observed

`Codex Policy Agent Canary Run #10` failed in `verify_public_agent_run_bundle.py` with:

```text
ERROR: Forbidden public pattern openai_key found in index.json
```

Gitleaks then scanned the same bundle and reported:

```text
no leaks found
```

The custom OpenAI-key regex was too broad and matched `sk-` inside ordinary words such as `task-static...`.

## Changes

- Change OpenAI key regex from:

```text
sk-[A-Za-z0-9_\-]{12,}
```

- To a boundary-aware pattern:

```text
(?<![A-Za-z0-9])sk-[A-Za-z0-9_\-]{12,}
```

- Apply the same boundary in:
  - `scripts/verify_public_agent_run_bundle.py`
  - `scripts/enrich_public_agent_run_bundle.py`
- Add a regression test proving `task-static-ui-v1.0.md` does not trigger OpenAI key detection.
- Keep detection for actual standalone `sk-...` token-like strings.

## Scope

Verifier/sanitizer false-positive fix only.

No workflow changes, no lab UI changes, no model/token-budget changes.