### PR TITLE
Harden selected-prompt workflow input handling

### DIFF
--- a/.github/workflows/codex-selected-prompt-run.yml
+++ b/.github/workflows/codex-selected-prompt-run.yml
@@ -51,6 +51,13 @@ jobs:
     env:
       CODEX_MODEL: gpt-5.4-nano
       RUN_WEEK: manual-selected-prompt
+      INPUT_PROMPT_BODY: ${{ inputs.prompt_body }}
+      INPUT_ISSUE_NUMBER: ${{ inputs.issue_number }}
+      INPUT_ISSUE_TITLE: ${{ inputs.issue_title }}
+      INPUT_ISSUE_URL: ${{ inputs.issue_url }}
+      INPUT_CANDIDATE_RANK: ${{ inputs.candidate_rank }}
+      INPUT_VOTE_COUNT: ${{ inputs.vote_count }}
+      INPUT_SELECTION_POLICY: ${{ inputs.selection_policy }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -60,15 +67,15 @@ jobs:
       - name: Validate dispatch inputs
         run: |
           set -euo pipefail
-          case "${{ inputs.candidate_rank }}" in
+          case "$INPUT_CANDIDATE_RANK" in
             1|2|3) ;;
             *) echo "candidate_rank must be 1, 2, or 3"; exit 1 ;;
           esac
-          case "${{ inputs.vote_count }}" in
+          case "$INPUT_VOTE_COUNT" in
             ''|*[!0-9]*) echo "vote_count must be a non-negative integer"; exit 1 ;;
             *) ;;
           esac
-          case "${{ inputs.issue_number }}" in
+          case "$INPUT_ISSUE_NUMBER" in
             ''|*[!0-9]*) echo "issue_number must be a non-negative integer"; exit 1 ;;
             *) ;;
           esac
@@ -97,13 +104,13 @@ jobs:
           bash scripts/run_codex_selected_prompt.sh \
             --canary-id manual-selected-prompt \
             --run-week "$RUN_WEEK" \
-            --issue-number "${{ inputs.issue_number }}" \
-            --issue-title "${{ inputs.issue_title }}" \
-            --issue-url "${{ inputs.issue_url }}" \
-            --candidate-rank "${{ inputs.candidate_rank }}" \
-            --vote-count "${{ inputs.vote_count }}" \
-            --selection-policy "${{ inputs.selection_policy }}" \
-            --prompt-body "${{ inputs.prompt_body }}" \
+            --issue-number "$INPUT_ISSUE_NUMBER" \
+            --issue-title "$INPUT_ISSUE_TITLE" \
+            --issue-url "$INPUT_ISSUE_URL" \
+            --candidate-rank "$INPUT_CANDIDATE_RANK" \
+            --vote-count "$INPUT_VOTE_COUNT" \
+            --selection-policy "$INPUT_SELECTION_POLICY" \
+            --prompt-body "$INPUT_PROMPT_BODY" \
             --work-label selected-prompt
           rc=$?
           echo "$rc" > .tmp/codex-exit-code.txt
@@ -148,7 +155,7 @@ jobs:
             --diagnostics-dir .tmp/canary-diagnostics \
             --out-dir .tmp/public-agent-run-bundle \
             --run-id "codex-selected-prompt-${{ github.run_number }}" \
-            --issue-number "${{ inputs.issue_number }}" \
+            --issue-number "$INPUT_ISSUE_NUMBER" \
             --pr-number ""
 
       - name: Enrich public agent run bundle with sanitized logs and reasoning traces
@@ -239,9 +246,9 @@ jobs:
             --workflow "Codex Selected Prompt Run" \
             --run-number "${{ github.run_number }}" \
             --week "$RUN_WEEK" \
-            --candidate-rank "${{ inputs.candidate_rank }}" \
-            --issue-number "${{ inputs.issue_number }}" \
-            --vote-count "${{ inputs.vote_count }}" \
+            --candidate-rank "$INPUT_CANDIDATE_RANK" \
+            --issue-number "$INPUT_ISSUE_NUMBER" \
+            --vote-count "$INPUT_VOTE_COUNT" \
             --base-sha "$base_sha" \
             --branch "manual-selected-prompt-${{ github.run_number }}" \
             --attempt-count 1 \

--- a/scripts/test_selected_prompt_workflow_contract.py
+++ b/scripts/test_selected_prompt_workflow_contract.py
@@ -19,12 +19,21 @@ REQUIRED_TEXT = [
     "contents: read",
     "concurrency:",
     "codex-selected-prompt-run",
+    "INPUT_PROMPT_BODY: ${{ inputs.prompt_body }}",
+    "INPUT_ISSUE_NUMBER: ${{ inputs.issue_number }}",
+    "INPUT_ISSUE_TITLE: ${{ inputs.issue_title }}",
+    "INPUT_ISSUE_URL: ${{ inputs.issue_url }}",
+    "INPUT_CANDIDATE_RANK: ${{ inputs.candidate_rank }}",
+    "INPUT_VOTE_COUNT: ${{ inputs.vote_count }}",
+    "INPUT_SELECTION_POLICY: ${{ inputs.selection_policy }}",
     "OPENAI_API_KEY:",
     "scripts/run_codex_selected_prompt.sh",
-    "--prompt-body",
-    "--candidate-rank",
-    "--vote-count",
-    "--selection-policy",
+    "--prompt-body \"$INPUT_PROMPT_BODY\"",
+    "--issue-title \"$INPUT_ISSUE_TITLE\"",
+    "--issue-url \"$INPUT_ISSUE_URL\"",
+    "--candidate-rank \"$INPUT_CANDIDATE_RANK\"",
+    "--vote-count \"$INPUT_VOTE_COUNT\"",
+    "--selection-policy \"$INPUT_SELECTION_POLICY\"",
     "scripts/safety-check.sh",
     "scripts/static-site-check.sh",
     "scripts/collect_canary_diagnostics.py",
@@ -56,6 +65,16 @@ FORBIDDEN_TEXT = [
     "workflow_run:",
 ]
 
+FORBIDDEN_RUN_TEXT = [
+    "${{ inputs.prompt_body }}",
+    "${{ inputs.issue_title }}",
+    "${{ inputs.issue_url }}",
+    "${{ inputs.issue_number }}",
+    "${{ inputs.candidate_rank }}",
+    "${{ inputs.vote_count }}",
+    "${{ inputs.selection_policy }}",
+]
+
 
 def require_all(text: str, required: list[str]) -> None:
     missing = [item for item in required if item not in text]
@@ -69,10 +88,43 @@ def reject_all(text: str, forbidden: list[str]) -> None:
         raise SystemExit(f"Forbidden selected prompt workflow text found: {found}")
 
 
+def run_blocks(text: str) -> list[str]:
+    blocks: list[str] = []
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.strip() == "run: |":
+            indent = len(line) - len(line.lstrip())
+            block: list[str] = []
+            i += 1
+            while i < len(lines):
+                child = lines[i]
+                if child.strip() and len(child) - len(child.lstrip()) <= indent:
+                    break
+                block.append(child)
+                i += 1
+            blocks.append("\n".join(block))
+            continue
+        i += 1
+    return blocks
+
+
+def reject_inputs_in_run_blocks(text: str) -> None:
+    found: list[str] = []
+    for block in run_blocks(text):
+        for item in FORBIDDEN_RUN_TEXT:
+            if item in block:
+                found.append(item)
+    if found:
+        raise SystemExit(f"Unsafe workflow input interpolation inside run blocks: {sorted(set(found))}")
+
+
 def main() -> int:
     text = WORKFLOW.read_text(encoding="utf-8")
     require_all(text, REQUIRED_TEXT)
     reject_all(text, FORBIDDEN_TEXT)
+    reject_inputs_in_run_blocks(text)
 
     if text.index("scripts/run_codex_selected_prompt.sh") > text.index("scripts/safety-check.sh"):
         raise SystemExit("safety check should run after the selected prompt runner")


### PR DESCRIPTION
## Summary
- Move manual selected-prompt workflow inputs out of shell script interpolation and into workflow environment variables.
- Use quoted `$INPUT_*` shell variables in `run:` blocks instead of direct `${{ inputs.* }}` expansion.
- Strengthen the selected-prompt workflow contract test so future direct input interpolation inside `run:` blocks fails CI.

## Security reason
Codex review flagged that direct `${{ inputs.* }}` interpolation inside `run:` can be parsed by bash after GitHub expression substitution. A malicious selected prompt or title could therefore break quoting and execute arbitrary commands in the runner before the Docker/Codex sandbox starts. The Codex runner step also has `OPENAI_API_KEY` in its environment, so this must be fixed before any manual dispatch execution.

## Boundary preserved
- Still `workflow_dispatch` only.
- Still `contents: read`.
- Still no PR creation, no merge, no push, no commit from the workflow.
- Still bounded changed-file validation for:
  - `lab/index.html`
  - `lab/style.css`
  - `lab/app.js`

## Verification expected
- actionlint
- shell syntax
- selected prompt workflow contract test
- Script Check