### PR TITLE
Add weekly canonical selected-prompt runner feature flag

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -209,6 +209,9 @@ jobs:
       - name: Run selected prompt workflow contract test
         run: python scripts/test_selected_prompt_workflow_contract.py
 
+      - name: Run weekly auto-run workflow contract test
+        run: python scripts/test_weekly_auto_run_workflow_contract.py
+
       - name: Run fixed Issue instruction packet generator test
         run: python scripts/test_create_codex_issue_instruction_packet.py
 

--- a/.github/workflows/weekly-auto-run.yml
+++ b/.github/workflows/weekly-auto-run.yml
@@ -13,6 +13,7 @@ permissions:
 env:
   DEFAULT_NO_CHANGE_BASELINE: "20"
   DEFAULT_SUPPORT_USD: "0"
+  DEFAULT_USE_CANONICAL_SELECTED_PROMPT_RUNNER: "false"
   AUTO_IMPLEMENTATION_MODEL: "gpt-5.4-nano"
 
 concurrency:
@@ -29,15 +30,25 @@ jobs:
           fetch-depth: 0
 
       - name: Prepare weekly variables
+        id: weekly-vars
         run: |
+          set -euo pipefail
+          use_canonical="${PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER:-$DEFAULT_USE_CANONICAL_SELECTED_PROMPT_RUNNER}"
+          case "$use_canonical" in
+            true|false) ;;
+            *) echo "PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER must be true or false"; exit 1 ;;
+          esac
           {
             echo "RUN_WEEK=week-$(date -u +%G-W%V)"
             echo "NO_CHANGE_BASELINE=${PROMPT_VOTE_LAB_NO_CHANGE_BASELINE:-$DEFAULT_NO_CHANGE_BASELINE}"
             echo "SUPPORT_USD=${PROMPT_VOTE_LAB_SUPPORT_USD:-$DEFAULT_SUPPORT_USD}"
+            echo "USE_CANONICAL_SELECTED_PROMPT_RUNNER=$use_canonical"
           } >> "$GITHUB_ENV"
+          echo "use_canonical=$use_canonical" >> "$GITHUB_OUTPUT"
         env:
           PROMPT_VOTE_LAB_NO_CHANGE_BASELINE: ${{ vars.PROMPT_VOTE_LAB_NO_CHANGE_BASELINE }}
           PROMPT_VOTE_LAB_SUPPORT_USD: ${{ vars.PROMPT_VOTE_LAB_SUPPORT_USD }}
+          PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER: ${{ vars.PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER }}
 
       - name: Resolve automated support unlocks
         run: |
@@ -88,6 +99,10 @@ jobs:
             echo "## No-change baseline"
             echo ""
             echo "${NO_CHANGE_BASELINE} virtual votes"
+            echo ""
+            echo "## Canonical selected-prompt runner"
+            echo ""
+            echo "${USE_CANONICAL_SELECTED_PROMPT_RUNNER}"
             echo ""
             echo "## Eligible implementation ranks"
             echo ""
@@ -160,7 +175,7 @@ jobs:
             --api-call-limit-per-candidate 1
 
       - name: Install Python dependency
-        if: ${{ steps.eligibility.outputs.has_eligible == 'true' }}
+        if: ${{ steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical != 'true' }}
         run: |
           python -m pip install --upgrade pip
           python -m pip install openai
@@ -176,22 +191,67 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           export OPENAI_API_KEY_="${OPENAI_API_KEY_TRAILING:-${OPENAI_API_KEY_PRIMARY:-$OPENAI_API_KEY_IMPLEMENTATION}}"
+          export OPENAI_API_KEY="$OPENAI_API_KEY_"
           python - <<'PY'
           import json
+          import os
+          import shutil
           import subprocess
           from pathlib import Path
-          import os
 
           week = os.environ['RUN_WEEK']
           run_number = "${{ github.run_number }}"
+          use_canonical = os.environ.get('USE_CANONICAL_SELECTED_PROMPT_RUNNER') == 'true'
           candidates = json.loads(Path('.tmp/eligible-candidates.json').read_text())
           if not candidates:
               print('No eligible candidates to implement')
               raise SystemExit(0)
 
-          def sh(cmd):
-              print('+', ' '.join(cmd))
+          def sh(cmd, *, display=None):
+              print('+', display or ' '.join(cmd))
               subprocess.run(cmd, check=True)
+
+          def copy_rank_diagnostics(rank):
+              src = Path('.tmp/canary-diagnostics')
+              dst = Path(f'.tmp/weekly-selected-prompt-diagnostics/rank-{rank}')
+              if dst.exists():
+                  shutil.rmtree(dst)
+              if src.exists():
+                  shutil.copytree(src, dst)
+              else:
+                  dst.mkdir(parents=True, exist_ok=True)
+                  (dst / 'missing-diagnostics.txt').write_text('No .tmp/canary-diagnostics directory was produced.\n', encoding='utf-8')
+
+          def build_public_bundle(rank, issue):
+              diagnostics_dir = Path('.tmp/canary-diagnostics')
+              bundle_dir = Path(f'.tmp/weekly-selected-prompt-public-bundles/rank-{rank}')
+              if bundle_dir.exists():
+                  shutil.rmtree(bundle_dir)
+              sh([
+                  'python', 'scripts/build_public_agent_run_bundle.py',
+                  '--diagnostics-dir', str(diagnostics_dir),
+                  '--out-dir', str(bundle_dir),
+                  '--run-id', f'weekly-selected-prompt-{week}-rank-{rank}-{run_number}',
+                  '--issue-number', str(issue),
+                  '--pr-number', '',
+              ])
+              sh([
+                  'python', 'scripts/enrich_public_agent_run_bundle.py',
+                  '--diagnostics-dir', str(diagnostics_dir),
+                  '--bundle-dir', str(bundle_dir),
+              ])
+              verification_report = diagnostics_dir / 'public-agent-run-bundle-verification.json'
+              sh([
+                  'python', 'scripts/verify_public_agent_run_bundle.py',
+                  '--bundle-dir', str(bundle_dir),
+                  '--report', str(verification_report),
+              ])
+              sh([
+                  'bash', 'scripts/run_gitleaks_public_bundle_scan.sh',
+                  '--bundle-dir', str(bundle_dir),
+                  '--report', str(diagnostics_dir / 'public-agent-run-bundle-gitleaks.json'),
+                  '--findings', str(diagnostics_dir / 'public-agent-run-bundle-gitleaks-findings.json'),
+              ])
 
           base_sha = subprocess.check_output(['git', 'rev-parse', 'origin/main'], text=True).strip()
 
@@ -199,21 +259,46 @@ jobs:
               rank = str(item['rank'])
               branch = f"codex-lab-{week}-rank-{rank}-{run_number}"
               issue = str(item['issue_number'])
+              title = str(item.get('title') or 'unrecorded')
+              url = str(item.get('url') or '')
               votes = str(item['vote_count'])
               prompt = item['body']
               reason = item.get('run_reason', 'normal-weekly-run')
+              runner = 'codex-cli-selected-prompt-packet-container' if use_canonical else 'legacy-openai-lab-run'
 
               sh(['git', 'checkout', 'main'])
               sh(['git', 'checkout', '-B', branch])
-              sh([
-                  'python', 'scripts/openai_lab_run.py',
-                  '--week', week,
-                  '--candidate-rank', rank,
-                  '--issue-number', issue,
-                  '--voted-prompt', prompt,
-                  '--vote-count', votes,
-                  '--run-reason', reason,
-              ])
+              if use_canonical:
+                  prompt_file = Path(f'.tmp/weekly-selected-prompt-rank-{rank}.md')
+                  prompt_file.parent.mkdir(parents=True, exist_ok=True)
+                  prompt_file.write_text(str(prompt), encoding='utf-8')
+                  if Path('.tmp/canary-diagnostics').exists():
+                      shutil.rmtree('.tmp/canary-diagnostics')
+                  sh([
+                      'bash', 'scripts/run_codex_selected_prompt.sh',
+                      '--canary-id', 'weekly-selected-prompt',
+                      '--run-week', week,
+                      '--issue-number', issue,
+                      '--issue-title', title,
+                      '--issue-url', url,
+                      '--candidate-rank', rank,
+                      '--vote-count', votes,
+                      '--selection-policy', reason,
+                      '--prompt-file', str(prompt_file),
+                      '--work-label', f'weekly-selected-prompt-rank-{rank}',
+                  ], display=f'bash scripts/run_codex_selected_prompt.sh --prompt-file {prompt_file} --candidate-rank {rank}')
+                  build_public_bundle(rank, issue)
+                  copy_rank_diagnostics(rank)
+              else:
+                  sh([
+                      'python', 'scripts/openai_lab_run.py',
+                      '--week', week,
+                      '--candidate-rank', rank,
+                      '--issue-number', issue,
+                      '--voted-prompt', prompt,
+                      '--vote-count', votes,
+                      '--run-reason', reason,
+                  ], display=f'python scripts/openai_lab_run.py --week {week} --candidate-rank {rank} --issue-number {issue} --voted-prompt <redacted>')
               sh(['bash', 'scripts/safety-check.sh', 'origin/main', 'HEAD'])
               sh(['bash', 'scripts/static-site-check.sh'])
               diff = subprocess.run(['git', 'diff', '--quiet', '--', 'lab/'])
@@ -228,7 +313,7 @@ jobs:
               body_path = Path(f'.tmp/pr-body-rank-{rank}.md')
               summary_path = Path('.tmp/implementation-summary.md')
               body = [
-                  'Implements the selected ranked prompt candidate with the fixed implementation agent.',
+                  'Implements the selected ranked prompt candidate with the implementation agent.',
                   '',
                   '## Candidate',
                   '',
@@ -238,6 +323,8 @@ jobs:
                   f'- Votes: {votes}',
                   f'- Run reason: {reason}',
                   f'- Inherited lab base: `{base_sha}`',
+                  f'- Runner: `{runner}`',
+                  f'- Canonical selected-prompt runner: `{str(use_canonical).lower()}`',
                   '- Implementation model: `gpt-5.4-nano`',
                   '- Model policy: `rules/model-policy-v1.1.md`',
                   '- Agent-run policy: `rules/agent-run-policy-v1.0.md`',
@@ -252,6 +339,10 @@ jobs:
                   '',
                   summary_path.read_text() if summary_path.exists() else 'Implementation summary was not written.',
                   '',
+                  '## Evidence',
+                  '',
+                  'When the canonical selected-prompt runner is enabled, weekly diagnostics and public bundles are uploaded as workflow artifacts.',
+                  '',
                   '## Merge policy',
                   '',
                   'Rank 1 is the default mainline candidate. Rank 2 and rank 3 are comparison candidates. Merge remains manual. Only merged PRs become the inherited lab state for later weeks.',
@@ -265,3 +356,19 @@ jobs:
                   '--head', branch,
               ])
           PY
+
+      - name: Upload weekly selected-prompt diagnostics
+        if: ${{ steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: weekly-selected-prompt-diagnostics-${{ github.run_number }}
+          path: .tmp/weekly-selected-prompt-diagnostics
+          if-no-files-found: error
+
+      - name: Upload weekly selected-prompt public bundles
+        if: ${{ steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: weekly-selected-prompt-public-bundles-${{ github.run_number }}
+          path: .tmp/weekly-selected-prompt-public-bundles
+          if-no-files-found: error

--- a/.github/workflows/weekly-auto-run.yml
+++ b/.github/workflows/weekly-auto-run.yml
@@ -372,3 +372,43 @@ jobs:
           name: weekly-selected-prompt-public-bundles-${{ github.run_number }}
           path: .tmp/weekly-selected-prompt-public-bundles
           if-no-files-found: error
+
+      - name: Download uploaded weekly selected-prompt public bundles
+        if: ${{ steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: weekly-selected-prompt-public-bundles-${{ github.run_number }}
+          path: .tmp/weekly-selected-prompt-public-bundles-uploaded
+
+      - name: Verify uploaded weekly selected-prompt public bundles
+        if: ${{ steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical == 'true' }}
+        run: |
+          set -euo pipefail
+          mkdir -p .tmp/weekly-selected-prompt-public-bundles-uploaded-verification
+          found=0
+          for bundle in .tmp/weekly-selected-prompt-public-bundles-uploaded/rank-*; do
+            [ -d "$bundle" ] || continue
+            found=1
+            rank="${bundle##*/}"
+            out=".tmp/weekly-selected-prompt-public-bundles-uploaded-verification/$rank"
+            mkdir -p "$out"
+            python scripts/verify_public_agent_run_bundle.py \
+              --bundle-dir "$bundle" \
+              --report "$out/public-agent-run-bundle-uploaded-verification.json"
+            bash scripts/run_gitleaks_public_bundle_scan.sh \
+              --bundle-dir "$bundle" \
+              --report "$out/public-agent-run-bundle-uploaded-gitleaks.json" \
+              --findings "$out/public-agent-run-bundle-uploaded-gitleaks-findings.json"
+          done
+          if [ "$found" -ne 1 ]; then
+            echo "No uploaded weekly selected-prompt public bundles found."
+            exit 1
+          fi
+
+      - name: Upload weekly selected-prompt uploaded bundle verification
+        if: ${{ steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: weekly-selected-prompt-uploaded-bundle-verification-${{ github.run_number }}
+          path: .tmp/weekly-selected-prompt-public-bundles-uploaded-verification
+          if-no-files-found: error

--- a/scripts/test_pre_api_freeze_audit.py
+++ b/scripts/test_pre_api_freeze_audit.py
@@ -61,11 +61,16 @@ def mutate_retry_relaxation(repo: Path) -> None:
 def mutate_missing_guard(repo: Path) -> None:
     path = repo / ".github/workflows/weekly-auto-run.yml"
     text = path.read_text(encoding="utf-8")
-    target = "      - name: Install Python dependency\n        if: ${{ steps.eligibility.outputs.has_eligible == 'true' }}\n"
-    replacement = "      - name: Install Python dependency\n"
-    if target not in text:
-        raise SystemExit("test fixture could not find guarded install step")
-    path.write_text(text.replace(target, replacement, 1), encoding="utf-8")
+    step = "      - name: Install Python dependency\n"
+    start = text.find(step)
+    if start < 0:
+        raise SystemExit("test fixture could not find install step")
+    next_step = text.find("\n      - name:", start + len(step))
+    end = next_step if next_step >= 0 else len(text)
+    block = text[start:end]
+    lines = block.splitlines(keepends=True)
+    filtered = [line for line in lines if not line.lstrip().startswith("if: ")]
+    path.write_text(text[:start] + "".join(filtered) + text[end:], encoding="utf-8")
 
 
 def mutate_review_boundary(repo: Path) -> None:

--- a/scripts/test_script_check_workflow_contract.py
+++ b/scripts/test_script_check_workflow_contract.py
@@ -37,6 +37,8 @@ REQUIRED_TEXT = [
     "python scripts/test_selected_prompt_runner_contract.py",
     "Run selected prompt workflow contract test",
     "python scripts/test_selected_prompt_workflow_contract.py",
+    "Run weekly auto-run workflow contract test",
+    "python scripts/test_weekly_auto_run_workflow_contract.py",
     "Run fixed Issue instruction packet generator test",
     "python scripts/test_create_codex_issue_instruction_packet.py",
     "Run lab PR scope guard self-test",
@@ -92,8 +94,11 @@ def main() -> int:
     if text.index("Run selected prompt runner contract test") > text.index("Run selected prompt workflow contract test"):
         raise SystemExit("Selected prompt workflow contract test should run after selected prompt runner contract test")
 
-    if text.index("Run selected prompt workflow contract test") > text.index("Run fixed Issue instruction packet generator test"):
-        raise SystemExit("Fixed Issue generator test should run after selected prompt workflow contract test")
+    if text.index("Run selected prompt workflow contract test") > text.index("Run weekly auto-run workflow contract test"):
+        raise SystemExit("Weekly auto-run workflow contract test should run after selected prompt workflow contract test")
+
+    if text.index("Run weekly auto-run workflow contract test") > text.index("Run fixed Issue instruction packet generator test"):
+        raise SystemExit("Fixed Issue generator test should run after weekly auto-run workflow contract test")
 
     if text.index("Run comparison dashboard builder test") > text.index("Run comparison dashboard decision test"):
         raise SystemExit("Comparison dashboard decision test should run after the builder test")

--- a/scripts/test_weekly_auto_run_workflow_contract.py
+++ b/scripts/test_weekly_auto_run_workflow_contract.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "weekly-auto-run.yml"
+
+REQUIRED_TEXT = [
+    "name: Weekly Auto Run",
+    "workflow_dispatch:",
+    "schedule:",
+    "contents: write",
+    "pull-requests: write",
+    "issues: read",
+    "DEFAULT_USE_CANONICAL_SELECTED_PROMPT_RUNNER: \"false\"",
+    "PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER",
+    "USE_CANONICAL_SELECTED_PROMPT_RUNNER=$use_canonical",
+    "use_canonical=$use_canonical",
+    "Canonical selected-prompt runner",
+    "steps.weekly-vars.outputs.use_canonical != 'true'",
+    "scripts/openai_lab_run.py",
+    "steps.weekly-vars.outputs.use_canonical == 'true'",
+    "scripts/run_codex_selected_prompt.sh",
+    "--prompt-file",
+    "weekly-selected-prompt-diagnostics",
+    "weekly-selected-prompt-public-bundles",
+    "scripts/build_public_agent_run_bundle.py",
+    "scripts/enrich_public_agent_run_bundle.py",
+    "scripts/verify_public_agent_run_bundle.py",
+    "scripts/run_gitleaks_public_bundle_scan.sh",
+    "Canonical selected-prompt runner: `",
+    "gh', 'pr', 'create'",
+]
+
+FORBIDDEN_TEXT = [
+    "gh pr merge",
+    "auto-merge",
+    "--prompt-body",  # weekly canonical path should avoid command-argument prompt bodies
+]
+
+
+def require_all(text: str, required: list[str]) -> None:
+    missing = [item for item in required if item not in text]
+    if missing:
+        raise SystemExit(f"Missing weekly auto-run workflow text: {missing}")
+
+
+def reject_all(text: str, forbidden: list[str]) -> None:
+    found = [item for item in forbidden if item in text]
+    if found:
+        raise SystemExit(f"Forbidden weekly auto-run workflow text found: {found}")
+
+
+def main() -> int:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    require_all(text, REQUIRED_TEXT)
+    reject_all(text, FORBIDDEN_TEXT)
+
+    if text.index("DEFAULT_USE_CANONICAL_SELECTED_PROMPT_RUNNER: \"false\"") > text.index("Prepare weekly variables"):
+        raise SystemExit("canonical selected-prompt runner default should be declared before weekly variables")
+
+    if text.index("steps.weekly-vars.outputs.use_canonical != 'true'") > text.index("python -m pip install openai"):
+        raise SystemExit("legacy OpenAI dependency install should be gated before the install command")
+
+    if text.index("scripts/openai_lab_run.py") > text.index("scripts/run_codex_selected_prompt.sh"):
+        raise SystemExit("legacy path should remain before the feature-flagged canonical path in the implementation branch")
+
+    if text.index("scripts/run_codex_selected_prompt.sh") > text.index("scripts/build_public_agent_run_bundle.py"):
+        raise SystemExit("canonical runner should execute before public bundle build")
+
+    if text.index("scripts/build_public_agent_run_bundle.py") > text.index("scripts/enrich_public_agent_run_bundle.py"):
+        raise SystemExit("public bundle enrichment should run after bundle build")
+
+    if text.index("scripts/enrich_public_agent_run_bundle.py") > text.index("scripts/verify_public_agent_run_bundle.py"):
+        raise SystemExit("public bundle verification should run after enrichment")
+
+    if text.index("scripts/verify_public_agent_run_bundle.py") > text.index("scripts/run_gitleaks_public_bundle_scan.sh"):
+        raise SystemExit("Gitleaks scan should run after public bundle verification")
+
+    print("weekly auto-run workflow contract test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_weekly_auto_run_workflow_contract.py
+++ b/scripts/test_weekly_auto_run_workflow_contract.py
@@ -25,10 +25,18 @@ REQUIRED_TEXT = [
     "--prompt-file",
     "weekly-selected-prompt-diagnostics",
     "weekly-selected-prompt-public-bundles",
+    "weekly-selected-prompt-public-bundles-uploaded",
+    "weekly-selected-prompt-uploaded-bundle-verification",
+    "Download uploaded weekly selected-prompt public bundles",
+    "Verify uploaded weekly selected-prompt public bundles",
+    "Upload weekly selected-prompt uploaded bundle verification",
     "scripts/build_public_agent_run_bundle.py",
     "scripts/enrich_public_agent_run_bundle.py",
     "scripts/verify_public_agent_run_bundle.py",
     "scripts/run_gitleaks_public_bundle_scan.sh",
+    "public-agent-run-bundle-uploaded-verification.json",
+    "public-agent-run-bundle-uploaded-gitleaks.json",
+    "public-agent-run-bundle-uploaded-gitleaks-findings.json",
     "Canonical selected-prompt runner: `",
     "gh', 'pr', 'create'",
 ]
@@ -77,6 +85,15 @@ def main() -> int:
 
     if text.index("scripts/verify_public_agent_run_bundle.py") > text.index("scripts/run_gitleaks_public_bundle_scan.sh"):
         raise SystemExit("Gitleaks scan should run after public bundle verification")
+
+    if text.index("Upload weekly selected-prompt public bundles") > text.index("Download uploaded weekly selected-prompt public bundles"):
+        raise SystemExit("uploaded public bundles should be downloaded only after upload")
+
+    if text.index("Download uploaded weekly selected-prompt public bundles") > text.index("Verify uploaded weekly selected-prompt public bundles"):
+        raise SystemExit("uploaded public bundles should be verified after download")
+
+    if text.index("Verify uploaded weekly selected-prompt public bundles") > text.index("Upload weekly selected-prompt uploaded bundle verification"):
+        raise SystemExit("uploaded bundle verification artifact should upload after verification")
 
     print("weekly auto-run workflow contract test passed")
     return 0

--- a/scripts/test_weekly_auto_run_workflow_contract.py
+++ b/scripts/test_weekly_auto_run_workflow_contract.py
@@ -25,6 +25,8 @@ REQUIRED_TEXT = [
     "else:",
     "scripts/run_codex_selected_prompt.sh",
     "--prompt-file",
+    "build_public_bundle(rank, issue)",
+    "copy_rank_diagnostics(rank)",
     "weekly-selected-prompt-diagnostics",
     "weekly-selected-prompt-public-bundles",
     "weekly-selected-prompt-public-bundles-uploaded",
@@ -99,8 +101,14 @@ def main() -> int:
     require_block_order(
         text,
         "scripts/run_codex_selected_prompt.sh",
-        "scripts/build_public_agent_run_bundle.py",
-        "canonical runner should execute before public bundle build",
+        "build_public_bundle(rank, issue)",
+        "canonical runner invocation should precede the public bundle build call",
+    )
+    require_block_order(
+        text,
+        "build_public_bundle(rank, issue)",
+        "copy_rank_diagnostics(rank)",
+        "rank diagnostics copy should include public bundle verification reports",
     )
     require_block_order(
         text,

--- a/scripts/test_weekly_auto_run_workflow_contract.py
+++ b/scripts/test_weekly_auto_run_workflow_contract.py
@@ -21,6 +21,8 @@ REQUIRED_TEXT = [
     "steps.weekly-vars.outputs.use_canonical != 'true'",
     "scripts/openai_lab_run.py",
     "steps.weekly-vars.outputs.use_canonical == 'true'",
+    "if use_canonical:",
+    "else:",
     "scripts/run_codex_selected_prompt.sh",
     "--prompt-file",
     "weekly-selected-prompt-diagnostics",
@@ -60,40 +62,82 @@ def reject_all(text: str, forbidden: list[str]) -> None:
         raise SystemExit(f"Forbidden weekly auto-run workflow text found: {found}")
 
 
+def require_block_order(text: str, first: str, second: str, message: str) -> None:
+    if text.index(first) > text.index(second):
+        raise SystemExit(message)
+
+
 def main() -> int:
     text = WORKFLOW.read_text(encoding="utf-8")
     require_all(text, REQUIRED_TEXT)
     reject_all(text, FORBIDDEN_TEXT)
 
-    if text.index("DEFAULT_USE_CANONICAL_SELECTED_PROMPT_RUNNER: \"false\"") > text.index("Prepare weekly variables"):
-        raise SystemExit("canonical selected-prompt runner default should be declared before weekly variables")
-
-    if text.index("steps.weekly-vars.outputs.use_canonical != 'true'") > text.index("python -m pip install openai"):
-        raise SystemExit("legacy OpenAI dependency install should be gated before the install command")
-
-    if text.index("scripts/openai_lab_run.py") > text.index("scripts/run_codex_selected_prompt.sh"):
-        raise SystemExit("legacy path should remain before the feature-flagged canonical path in the implementation branch")
-
-    if text.index("scripts/run_codex_selected_prompt.sh") > text.index("scripts/build_public_agent_run_bundle.py"):
-        raise SystemExit("canonical runner should execute before public bundle build")
-
-    if text.index("scripts/build_public_agent_run_bundle.py") > text.index("scripts/enrich_public_agent_run_bundle.py"):
-        raise SystemExit("public bundle enrichment should run after bundle build")
-
-    if text.index("scripts/enrich_public_agent_run_bundle.py") > text.index("scripts/verify_public_agent_run_bundle.py"):
-        raise SystemExit("public bundle verification should run after enrichment")
-
-    if text.index("scripts/verify_public_agent_run_bundle.py") > text.index("scripts/run_gitleaks_public_bundle_scan.sh"):
-        raise SystemExit("Gitleaks scan should run after public bundle verification")
-
-    if text.index("Upload weekly selected-prompt public bundles") > text.index("Download uploaded weekly selected-prompt public bundles"):
-        raise SystemExit("uploaded public bundles should be downloaded only after upload")
-
-    if text.index("Download uploaded weekly selected-prompt public bundles") > text.index("Verify uploaded weekly selected-prompt public bundles"):
-        raise SystemExit("uploaded public bundles should be verified after download")
-
-    if text.index("Verify uploaded weekly selected-prompt public bundles") > text.index("Upload weekly selected-prompt uploaded bundle verification"):
-        raise SystemExit("uploaded bundle verification artifact should upload after verification")
+    require_block_order(
+        text,
+        "DEFAULT_USE_CANONICAL_SELECTED_PROMPT_RUNNER: \"false\"",
+        "Prepare weekly variables",
+        "canonical selected-prompt runner default should be declared before weekly variables",
+    )
+    require_block_order(
+        text,
+        "steps.weekly-vars.outputs.use_canonical != 'true'",
+        "python -m pip install openai",
+        "legacy OpenAI dependency install should be gated before the install command",
+    )
+    require_block_order(
+        text,
+        "if use_canonical:",
+        "scripts/run_codex_selected_prompt.sh",
+        "canonical runner invocation should be inside the feature-flag branch",
+    )
+    require_block_order(
+        text,
+        "else:",
+        "scripts/openai_lab_run.py",
+        "legacy runner invocation should be inside the non-canonical branch",
+    )
+    require_block_order(
+        text,
+        "scripts/run_codex_selected_prompt.sh",
+        "scripts/build_public_agent_run_bundle.py",
+        "canonical runner should execute before public bundle build",
+    )
+    require_block_order(
+        text,
+        "scripts/build_public_agent_run_bundle.py",
+        "scripts/enrich_public_agent_run_bundle.py",
+        "public bundle enrichment should run after bundle build",
+    )
+    require_block_order(
+        text,
+        "scripts/enrich_public_agent_run_bundle.py",
+        "scripts/verify_public_agent_run_bundle.py",
+        "public bundle verification should run after enrichment",
+    )
+    require_block_order(
+        text,
+        "scripts/verify_public_agent_run_bundle.py",
+        "scripts/run_gitleaks_public_bundle_scan.sh",
+        "Gitleaks scan should run after public bundle verification",
+    )
+    require_block_order(
+        text,
+        "Upload weekly selected-prompt public bundles",
+        "Download uploaded weekly selected-prompt public bundles",
+        "uploaded public bundles should be downloaded only after upload",
+    )
+    require_block_order(
+        text,
+        "Download uploaded weekly selected-prompt public bundles",
+        "Verify uploaded weekly selected-prompt public bundles",
+        "uploaded public bundles should be verified after download",
+    )
+    require_block_order(
+        text,
+        "Verify uploaded weekly selected-prompt public bundles",
+        "Upload weekly selected-prompt uploaded bundle verification",
+        "uploaded bundle verification artifact should upload after verification",
+    )
 
     print("weekly auto-run workflow contract test passed")
     return 0

--- a/scripts/test_weekly_auto_run_workflow_contract.py
+++ b/scripts/test_weekly_auto_run_workflow_contract.py
@@ -6,6 +6,10 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "weekly-auto-run.yml"
 
+CANONICAL_RUNNER_CALL = "display=f'bash scripts/run_codex_selected_prompt.sh --prompt-file {prompt_file} --candidate-rank {rank}'"
+PUBLIC_BUNDLE_BUILD_CALL = "                  build_public_bundle(rank, issue)"
+DIAGNOSTICS_COPY_CALL = "                  copy_rank_diagnostics(rank)"
+
 REQUIRED_TEXT = [
     "name: Weekly Auto Run",
     "workflow_dispatch:",
@@ -25,8 +29,9 @@ REQUIRED_TEXT = [
     "else:",
     "scripts/run_codex_selected_prompt.sh",
     "--prompt-file",
-    "build_public_bundle(rank, issue)",
-    "copy_rank_diagnostics(rank)",
+    CANONICAL_RUNNER_CALL,
+    PUBLIC_BUNDLE_BUILD_CALL,
+    DIAGNOSTICS_COPY_CALL,
     "weekly-selected-prompt-diagnostics",
     "weekly-selected-prompt-public-bundles",
     "weekly-selected-prompt-public-bundles-uploaded",
@@ -100,14 +105,14 @@ def main() -> int:
     )
     require_block_order(
         text,
-        "scripts/run_codex_selected_prompt.sh",
-        "build_public_bundle(rank, issue)",
+        CANONICAL_RUNNER_CALL,
+        PUBLIC_BUNDLE_BUILD_CALL,
         "canonical runner invocation should precede the public bundle build call",
     )
     require_block_order(
         text,
-        "build_public_bundle(rank, issue)",
-        "copy_rank_diagnostics(rank)",
+        PUBLIC_BUNDLE_BUILD_CALL,
+        DIAGNOSTICS_COPY_CALL,
         "rank diagnostics copy should include public bundle verification reports",
     )
     require_block_order(


### PR DESCRIPTION
## Summary
- Add `PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER` as a guarded feature flag for `weekly-auto-run`.
- Keep the default as `false`, preserving the existing legacy `scripts/openai_lab_run.py` path.
- When explicitly enabled, route eligible weekly prompt candidates through `scripts/run_codex_selected_prompt.sh` using `--prompt-file` rather than prompt text as a command argument.
- Upload weekly selected-prompt diagnostics and public bundle artifacts.
- Download the uploaded public bundles and reverify them with `verify_public_agent_run_bundle.py` and Gitleaks.
- Add and register a weekly auto-run workflow contract test.

## Risk focus before implementation
- Do not change the default weekly behavior.
- Do not expose selected prompt bodies as shell-expanded workflow inputs.
- Do not bypass bounded lab mutation checks.
- Do not add auto-merge.
- Keep canonical execution behind an explicit repository variable.

## Feature flag behavior
- `false` or unset: legacy weekly implementation path remains active.
- `true`: weekly eligible candidates use the canonical selected-prompt Docker/Codex runner.
- Any other value: workflow fails during weekly variable preparation.

## Verification expected
- Script Check
- actionlint
- Python syntax
- shell syntax
- selected-prompt runner contract
- selected-prompt workflow contract
- weekly auto-run workflow contract
- Lab PR Scope Check

## Still out of scope
- Making canonical weekly path the default.
- Removing `scripts/openai_lab_run.py`.
- Auto-merge.
- Treating this as release-ready before manual selected-prompt run evidence exists.