### PR TITLE
Harden weekly canonical evidence artifacts on failure paths

### DIFF
--- a/.github/workflows/weekly-auto-run.yml
+++ b/.github/workflows/weekly-auto-run.yml
@@ -358,7 +358,7 @@ jobs:
           PY
 
       - name: Upload weekly selected-prompt diagnostics
-        if: ${{ steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical == 'true' }}
+        if: ${{ always() && steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: weekly-selected-prompt-diagnostics-${{ github.run_number }}
@@ -366,7 +366,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload weekly selected-prompt public bundles
-        if: ${{ steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical == 'true' }}
+        if: ${{ always() && steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: weekly-selected-prompt-public-bundles-${{ github.run_number }}
@@ -374,14 +374,14 @@ jobs:
           if-no-files-found: error
 
       - name: Download uploaded weekly selected-prompt public bundles
-        if: ${{ steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical == 'true' }}
+        if: ${{ always() && steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical == 'true' }}
         uses: actions/download-artifact@v4
         with:
           name: weekly-selected-prompt-public-bundles-${{ github.run_number }}
           path: .tmp/weekly-selected-prompt-public-bundles-uploaded
 
       - name: Verify uploaded weekly selected-prompt public bundles
-        if: ${{ steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical == 'true' }}
+        if: ${{ always() && steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical == 'true' }}
         run: |
           set -euo pipefail
           mkdir -p .tmp/weekly-selected-prompt-public-bundles-uploaded-verification
@@ -406,7 +406,7 @@ jobs:
           fi
 
       - name: Upload weekly selected-prompt uploaded bundle verification
-        if: ${{ steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical == 'true' }}
+        if: ${{ always() && steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: weekly-selected-prompt-uploaded-bundle-verification-${{ github.run_number }}

--- a/scripts/test_weekly_auto_run_workflow_contract.py
+++ b/scripts/test_weekly_auto_run_workflow_contract.py
@@ -9,6 +9,7 @@ WORKFLOW = ROOT / ".github" / "workflows" / "weekly-auto-run.yml"
 CANONICAL_RUNNER_CALL = "display=f'bash scripts/run_codex_selected_prompt.sh --prompt-file {prompt_file} --candidate-rank {rank}'"
 PUBLIC_BUNDLE_BUILD_CALL = "                  build_public_bundle(rank, issue)"
 DIAGNOSTICS_COPY_CALL = "                  copy_rank_diagnostics(rank)"
+ALWAYS_CANONICAL_ARTIFACT_CONDITION = "always() && steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical == 'true'"
 
 REQUIRED_TEXT = [
     "name: Weekly Auto Run",
@@ -25,6 +26,7 @@ REQUIRED_TEXT = [
     "steps.weekly-vars.outputs.use_canonical != 'true'",
     "scripts/openai_lab_run.py",
     "steps.weekly-vars.outputs.use_canonical == 'true'",
+    ALWAYS_CANONICAL_ARTIFACT_CONDITION,
     "if use_canonical:",
     "else:",
     "scripts/run_codex_selected_prompt.sh",
@@ -74,10 +76,22 @@ def require_block_order(text: str, first: str, second: str, message: str) -> Non
         raise SystemExit(message)
 
 
+def require_count_at_least(text: str, marker: str, minimum: int, message: str) -> None:
+    count = text.count(marker)
+    if count < minimum:
+        raise SystemExit(f"{message}: found {count}, expected at least {minimum}")
+
+
 def main() -> int:
     text = WORKFLOW.read_text(encoding="utf-8")
     require_all(text, REQUIRED_TEXT)
     reject_all(text, FORBIDDEN_TEXT)
+    require_count_at_least(
+        text,
+        ALWAYS_CANONICAL_ARTIFACT_CONDITION,
+        5,
+        "weekly canonical artifact/evidence steps should run under always()",
+    )
 
     require_block_order(
         text,


### PR DESCRIPTION
## Summary
- Run weekly canonical selected-prompt evidence/artifact steps under `always()` while preserving the existing eligibility and feature-flag checks.
- Extend the weekly auto-run workflow contract test so the `always()` evidence guard is required for at least the five canonical artifact/evidence steps.

## Scope
- `.github/workflows/weekly-auto-run.yml`
- `scripts/test_weekly_auto_run_workflow_contract.py`

## Constraints preserved
- The canonical weekly runner remains default-off.
- Legacy weekly behavior remains unchanged when `PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER` is unset or `false`.
- No auto-merge is added.
- No legacy runner removal.

## Related
- Closes #279

## Verification expected
- Script Check
- actionlint
- weekly auto-run workflow contract test
- Lab PR Scope Check