### PR TITLE
Add canonical runner evidence guide

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -34,6 +34,7 @@ on:
       - "docs/codex-runner-contract.md"
       - "docs/canary-log-policy.md"
       - "docs/current-codex-implementation-path.md"
+      - "docs/canonical-runner-evidence-guide.md"
       - "docs/public-results-export.md"
       - "docs/public-agent-run-bundle.md"
       - "docs/issue-lifecycle.md"
@@ -139,6 +140,9 @@ jobs:
 
       - name: Run current Codex path doc test
         run: python scripts/test_current_codex_path_doc.py
+
+      - name: Run canonical runner evidence guide test
+        run: python scripts/test_canonical_runner_evidence_guide.py
 
       - name: Run usable experiment ops doc test
         run: python scripts/test_usable_experiment_ops_doc.py

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,26 +11,27 @@ Prompt Vote Lab is a prompt game and experiment. Players compete by writing prom
 1. [Participant guide](./for-participants.md) — start by voting with 👍, then submit prompts when ready.
 2. [Experiment model](./experiment-model.md) — game model and boundaries.
 3. [How to participate](./how-to-participate.md) — submit, vote, and review.
-4. [Usable experiment operations](./usable-experiment-ops.md) — current manual canary and comparison-run operations.
-5. [Operator runbook](./operator-runbook.md) — maintainer checklist for weekly operation, failures, merge decisions, tokens, and cleanup boundaries.
-6. [Public results export](./public-results-export.md) — raw public data snapshots for participant analysis.
-7. [Public agent run bundle](./public-agent-run-bundle.md) — redacted raw agent-run evidence; summaries are not primary evidence.
-8. [Issue lifecycle](./issue-lifecycle.md) — weekly close policy; Issues are closed, not deleted.
-9. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
-10. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
-11. [Weekly automation](./weekly-automation.md) — weekly schedule, support unlock prerequisite, and E2E status.
-12. [Automation map](./automation-map.md) — workflow boundaries.
-13. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
-14. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
-15. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and pre-canary cleanup.
-16. [Fixed first canary prompt](./first-canary-prompt.md) — the only allowed first real canary prompt.
-17. [First canary readiness checklist](./first-canary-readiness.md) — final check before running the first real canary.
-18. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
-19. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
-20. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
-21. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
-22. [Report policy](./report-policy.md) — weekly report draft policy.
-23. [Pre-API freeze checklist](./pre-api-freeze.md) — gates before paid agent runs.
+4. [Canonical runner evidence guide](./canonical-runner-evidence-guide.md) — how to verify Docker/Codex selected-prompt evidence.
+5. [Usable experiment operations](./usable-experiment-ops.md) — current manual canary and comparison-run operations.
+6. [Operator runbook](./operator-runbook.md) — maintainer checklist for weekly operation, failures, merge decisions, tokens, and cleanup boundaries.
+7. [Public results export](./public-results-export.md) — raw public data snapshots for participant analysis.
+8. [Public agent run bundle](./public-agent-run-bundle.md) — redacted raw agent-run evidence; summaries are not primary evidence.
+9. [Issue lifecycle](./issue-lifecycle.md) — weekly close policy; Issues are closed, not deleted.
+10. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
+11. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
+12. [Weekly automation](./weekly-automation.md) — weekly schedule, support unlock prerequisite, and E2E status.
+13. [Automation map](./automation-map.md) — workflow boundaries.
+14. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
+15. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
+16. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and pre-canary cleanup.
+17. [Fixed first canary prompt](./first-canary-prompt.md) — the only allowed first real canary prompt.
+18. [First canary readiness checklist](./first-canary-readiness.md) — final check before running the first real canary.
+19. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
+20. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
+21. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
+22. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
+23. [Report policy](./report-policy.md) — weekly report draft policy.
+24. [Pre-API freeze checklist](./pre-api-freeze.md) — gates before paid agent runs.
 
 ## Current reputation status
 
@@ -43,6 +44,19 @@ The repository records outcomes. Workflows do not yet compute player rankings, t
 Participants should start with [Participant guide](./for-participants.md).
 
 The first useful action is usually voting with 👍 on an existing `prompt-proposal` Issue. Prompt submission is the second step, not the first step.
+
+## Canonical runner evidence status
+
+The selected-prompt Docker/Codex runner is the canonical evidence path when the weekly feature flag is explicitly enabled and the PR/run evidence says:
+
+```text
+Runner: codex-cli-selected-prompt-packet-container
+Canonical selected-prompt runner: true
+```
+
+Participants should use the [Canonical runner evidence guide](./canonical-runner-evidence-guide.md) to inspect diagnostics, public bundles, uploaded bundle verification, Gitleaks results, and bounded lab diffs.
+
+The legacy `scripts/openai_lab_run.py` path is non-canonical and does not satisfy the selected-prompt canonical runner requirement.
 
 ## Report status
 
@@ -88,7 +102,7 @@ Closed Issues remain visible. They are not deleted.
 
 ## Current usable experiment status
 
-The repository has scheduled weekly automation and support-unlock gates implemented, but implementation-agent PR generation still needs a live eligible-candidate E2E verification.
+The repository has scheduled weekly automation and support-unlock gates implemented, but broad default-on canonical weekly execution still requires release hardening.
 
 The live no-eligible path is verified:
 
@@ -98,6 +112,18 @@ Weekly Auto Run -> runs/week-2026-W19-vote-summary.md
 baseline_won: true
 eligible_count: 0
 implementation PR: none
+```
+
+The weekly selected-prompt canonical feature-flag path is verified by a controlled canary:
+
+```text
+Weekly Auto Run -> run 25858202166
+selected Issue #282
+summary PR #283
+implementation PR #284
+canonical runner: true
+artifacts present: diagnostics, public bundle, uploaded bundle verification
+result: PASS
 ```
 
 manual canary experiments and comparison operations remain available:

--- a/docs/canonical-runner-evidence-guide.md
+++ b/docs/canonical-runner-evidence-guide.md
@@ -1,0 +1,168 @@
+# Canonical runner evidence guide
+
+## Purpose
+
+This guide is for participants and reviewers who want to decide whether a Prompt Vote Lab implementation run used the canonical Docker/Codex selected-prompt runner.
+
+A run is not canonical merely because it produced a small valid lab diff.
+
+A run is canonical only when the public PR/run evidence shows the Docker/Codex selected-prompt task-packet path and the bounded evidence chain.
+
+## Quick decision rule
+
+Treat a weekly implementation PR as canonical only when the PR or run evidence says:
+
+```text
+Runner: codex-cli-selected-prompt-packet-container
+Canonical selected-prompt runner: true
+```
+
+If those lines are missing, treat the run as non-canonical until proven otherwise.
+
+## What to inspect first
+
+For a weekly canonical selected-prompt run, inspect these in order:
+
+```text
+1. The implementation PR body
+2. The Weekly Auto Run workflow run
+3. The diagnostics artifact
+4. The public bundle artifact
+5. The uploaded bundle verification artifact
+6. The changed file list
+```
+
+Do not start by trusting the visible UI change. The UI diff is only the output. The evidence chain tells you whether the boundary held.
+
+## Expected artifacts
+
+A successful weekly canonical selected-prompt run should expose artifacts named like:
+
+```text
+weekly-selected-prompt-diagnostics-<run_number>
+weekly-selected-prompt-public-bundles-<run_number>
+weekly-selected-prompt-uploaded-bundle-verification-<run_number>
+```
+
+For the verified weekly canary, the artifact names were:
+
+```text
+weekly-selected-prompt-diagnostics-7
+weekly-selected-prompt-public-bundles-7
+weekly-selected-prompt-uploaded-bundle-verification-7
+```
+
+## What each artifact proves
+
+| Evidence | What it is used for | What it does not prove alone |
+|---|---|---|
+| diagnostics artifact | Internal boundary and run diagnostics | Public safety by itself |
+| public bundle artifact | Redacted participant-facing evidence | That upload/download preserved it |
+| uploaded bundle verification artifact | Reverification after artifact upload/download | That the implementation diff is desirable |
+| implementation PR diff | Final changed files and review target | That the runner was canonical |
+
+## Boundary checks to look for
+
+A canonical selected-prompt Docker/Codex run should show:
+
+```text
+/work:rw
+/task:ro
+/codex-runtime:rw
+repo_root_mounted: false
+OPENAI_API_KEY present before codex exec: no
+changed files subset of lab/index.html, lab/style.css, lab/app.js
+forbidden changed files: none
+```
+
+The `/task:ro` write-test may have a failing write exit code. That is expected when the read-only mount rejects writes.
+
+## Changed file rule
+
+Only these final files may change:
+
+```text
+lab/index.html
+lab/style.css
+lab/app.js
+```
+
+If a canonical implementation PR changes workflows, scripts, rules, docs, data, run records, or repository policy, treat it as a boundary failure unless a separate human-authored PR explains the non-agent change.
+
+## Secret and redaction checks
+
+Public evidence should pass both bundle verification and Gitleaks-style scanning.
+
+Expected result:
+
+```text
+public bundle verification: ok
+uploaded bundle verification: ok
+Gitleaks finding count: 0
+```
+
+Redaction is a publication guard, not a mathematical proof that secrets are impossible. If a token-like secret appears in any public artifact, rotate the token and treat it as an incident.
+
+## Non-canonical fallback
+
+The legacy `scripts/openai_lab_run.py` path may still exist as a migration fallback.
+
+It is non-canonical.
+
+It does not satisfy the selected-prompt canonical runner requirement, even if it produces a useful lab diff.
+
+## Verified weekly canary
+
+The first verified weekly canonical selected-prompt canary used:
+
+```text
+workflow run: 25858202166
+selected Issue: #282
+summary PR: #283
+implementation PR: #284
+runner: codex-cli-selected-prompt-packet-container
+canonical selected-prompt runner: true
+artifacts:
+  - weekly-selected-prompt-diagnostics-7
+  - weekly-selected-prompt-public-bundles-7
+  - weekly-selected-prompt-uploaded-bundle-verification-7
+result: PASS
+```
+
+The canary PRs were closed without merge because they were evidence-only canary artifacts, not product changes.
+
+## Release readiness rule
+
+Do not flip the weekly canonical selected-prompt runner to default-on until all of these are true:
+
+```text
+manual selected-prompt smoke: PASS
+weekly feature-flag canary with eligible candidate: PASS
+weekly diagnostics artifact: present
+weekly public bundle artifact: present
+weekly uploaded bundle verification artifact: present
+bounded lab diff: PASS
+legacy fallback documented as non-canonical
+participant evidence guide published
+manual review remains required
+auto-merge remains disabled
+```
+
+## What participants should conclude
+
+A canonical evidence chain supports this conclusion:
+
+```text
+The implementation was produced through the bounded Docker/Codex selected-prompt runner, with public evidence sufficient for participant review.
+```
+
+It does not automatically prove:
+
+```text
+The change is desirable.
+The prompt was the best prompt.
+The model reasoned correctly.
+The run should be merged.
+```
+
+Merge decisions remain manual.

--- a/scripts/test_canonical_runner_evidence_guide.py
+++ b/scripts/test_canonical_runner_evidence_guide.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDE = ROOT / "docs" / "canonical-runner-evidence-guide.md"
+DOCS_INDEX = ROOT / "docs" / "README.md"
+
+GUIDE_REQUIRED_TEXT = [
+    "# Canonical runner evidence guide",
+    "Runner: codex-cli-selected-prompt-packet-container",
+    "Canonical selected-prompt runner: true",
+    "weekly-selected-prompt-diagnostics-<run_number>",
+    "weekly-selected-prompt-public-bundles-<run_number>",
+    "weekly-selected-prompt-uploaded-bundle-verification-<run_number>",
+    "weekly-selected-prompt-diagnostics-7",
+    "weekly-selected-prompt-public-bundles-7",
+    "weekly-selected-prompt-uploaded-bundle-verification-7",
+    "/work:rw",
+    "/task:ro",
+    "/codex-runtime:rw",
+    "repo_root_mounted: false",
+    "OPENAI_API_KEY present before codex exec: no",
+    "changed files subset of lab/index.html, lab/style.css, lab/app.js",
+    "forbidden changed files: none",
+    "lab/index.html",
+    "lab/style.css",
+    "lab/app.js",
+    "public bundle verification: ok",
+    "uploaded bundle verification: ok",
+    "Gitleaks finding count: 0",
+    "The legacy `scripts/openai_lab_run.py` path may still exist as a migration fallback.",
+    "It is non-canonical.",
+    "workflow run: 25858202166",
+    "selected Issue: #282",
+    "summary PR: #283",
+    "implementation PR: #284",
+    "manual selected-prompt smoke: PASS",
+    "weekly feature-flag canary with eligible candidate: PASS",
+    "participant evidence guide published",
+    "manual review remains required",
+    "auto-merge remains disabled",
+    "It does not automatically prove:",
+    "The run should be merged.",
+]
+
+GUIDE_FORBIDDEN_TEXT = [
+    "A run is canonical merely because it produced a small valid lab diff.",
+    "The legacy `scripts/openai_lab_run.py` path satisfies the selected-prompt canonical runner requirement.",
+    "auto-merge may be enabled",
+    "public bundle verification is optional",
+    "uploaded bundle verification is optional",
+]
+
+INDEX_REQUIRED_TEXT = [
+    "[Canonical runner evidence guide](./canonical-runner-evidence-guide.md)",
+    "Runner: codex-cli-selected-prompt-packet-container",
+    "Canonical selected-prompt runner: true",
+    "The legacy `scripts/openai_lab_run.py` path is non-canonical",
+    "Weekly Auto Run -> run 25858202166",
+    "artifacts present: diagnostics, public bundle, uploaded bundle verification",
+]
+
+
+def require_all(text: str, required: list[str], label: str) -> None:
+    missing = [item for item in required if item not in text]
+    if missing:
+        raise SystemExit(f"Missing {label} text: {missing}")
+
+
+def reject_all(text: str, forbidden: list[str], label: str) -> None:
+    found = [item for item in forbidden if item in text]
+    if found:
+        raise SystemExit(f"Forbidden {label} text found: {found}")
+
+
+def main() -> int:
+    guide = GUIDE.read_text(encoding="utf-8")
+    index = DOCS_INDEX.read_text(encoding="utf-8")
+    require_all(guide, GUIDE_REQUIRED_TEXT, "canonical runner evidence guide")
+    reject_all(guide, GUIDE_FORBIDDEN_TEXT, "canonical runner evidence guide")
+    require_all(index, INDEX_REQUIRED_TEXT, "docs index")
+
+    if guide.index("What to inspect first") > guide.index("Expected artifacts"):
+        raise SystemExit("inspection order should be described before artifact names")
+
+    if guide.index("Expected artifacts") > guide.index("What each artifact proves"):
+        raise SystemExit("artifact names should appear before artifact interpretation")
+
+    if guide.index("Non-canonical fallback") > guide.index("Verified weekly canary"):
+        raise SystemExit("legacy fallback warning should appear before the canary example")
+
+    if guide.index("Verified weekly canary") > guide.index("Release readiness rule"):
+        raise SystemExit("release readiness should follow the verified canary example")
+
+    print("canonical runner evidence guide test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_script_check_workflow_contract.py
+++ b/scripts/test_script_check_workflow_contract.py
@@ -12,11 +12,16 @@ REQUIRED_TEXT = [
     "paths:",
     "lab/comparisons/**",
     "runs/**",
+    "docs/canonical-runner-evidence-guide.md",
     ".github/workflows/codex-selected-prompt-run.yml",
     "workflow_dispatch:",
     "contents: read",
     "Run actionlint",
     "raven-actions/actionlint@v2",
+    "Run current Codex path doc test",
+    "python scripts/test_current_codex_path_doc.py",
+    "Run canonical runner evidence guide test",
+    "python scripts/test_canonical_runner_evidence_guide.py",
     "Run comparison dashboard builder test",
     "python scripts/test_build_comparison_dashboard.py",
     "Run comparison dashboard decision test",
@@ -81,6 +86,15 @@ def main() -> int:
 
     if text.index("lab/comparisons/**") > text.index("runs/**"):
         raise SystemExit("runs/** should be tracked near generated/evidence paths")
+
+    if text.index("docs/current-codex-implementation-path.md") > text.index("docs/canonical-runner-evidence-guide.md"):
+        raise SystemExit("canonical runner evidence guide should be tracked near current Codex path docs")
+
+    if text.index("Run current Codex path doc test") > text.index("Run canonical runner evidence guide test"):
+        raise SystemExit("Canonical runner evidence guide test should run after the current Codex path doc test")
+
+    if text.index("Run canonical runner evidence guide test") > text.index("Run usable experiment ops doc test"):
+        raise SystemExit("Usable experiment ops doc test should run after the canonical runner evidence guide test")
 
     if text.index("Run public agent run bundle enrichment test") > text.index("Run public agent run bundle verifier test"):
         raise SystemExit("Public bundle verifier test should run after enrichment test")


### PR DESCRIPTION
## Summary
- Add a participant-facing canonical runner evidence guide.
- Link the guide from the docs index.
- Explain how to verify canonical weekly selected-prompt runs from PR text, workflow artifacts, diagnostics, public bundles, uploaded bundle verification, Gitleaks, and bounded lab diffs.
- Clarify that legacy `scripts/openai_lab_run.py` remains non-canonical.
- Add a contract test for the guide and register it in Script Check.

## Scope
- `docs/canonical-runner-evidence-guide.md`
- `docs/README.md`
- `.github/workflows/script-check.yml`
- `scripts/test_canonical_runner_evidence_guide.py`
- `scripts/test_script_check_workflow_contract.py`

## Non-goals
- No workflow behavior change.
- No runner implementation change.
- No default flag change.
- No auto-merge.

## Verification expected
- Script Check
- actionlint
- canonical runner evidence guide test
- script-check workflow contract test
- Lab PR Scope Check