### PR TITLE
Harden weekly canonical operator docs

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -35,6 +35,8 @@ on:
       - "docs/canary-log-policy.md"
       - "docs/current-codex-implementation-path.md"
       - "docs/canonical-runner-evidence-guide.md"
+      - "docs/operator-runbook.md"
+      - "docs/weekly-automation.md"
       - "docs/public-results-export.md"
       - "docs/public-agent-run-bundle.md"
       - "docs/issue-lifecycle.md"
@@ -143,6 +145,9 @@ jobs:
 
       - name: Run canonical runner evidence guide test
         run: python scripts/test_canonical_runner_evidence_guide.py
+
+      - name: Run weekly operator docs test
+        run: python scripts/test_weekly_operator_docs.py
 
       - name: Run usable experiment ops doc test
         run: python scripts/test_usable_experiment_ops_doc.py

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -12,12 +12,30 @@ Verified live paths:
 Support Unlock Export -> data/support-unlocks/2026-W19.json
 Weekly Auto Run -> runs/week-2026-W19-vote-summary.md
 no-change baseline won -> no implementation PR created
+manual selected-prompt workflow smoke -> PASS
+weekly canonical selected-prompt canary -> run 25858202166 -> PASS
 ```
 
-Not yet verified:
+Canonical selected-prompt implementation is verified behind a default-off feature flag:
 
 ```text
-eligible prompt -> implementation-agent preflight -> implementation-agent run -> lab-only implementation PR
+PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER=true
+runner: codex-cli-selected-prompt-packet-container
+selected Issue: #282
+summary PR: #283
+implementation PR: #284
+artifacts:
+  - weekly-selected-prompt-diagnostics-7
+  - weekly-selected-prompt-public-bundles-7
+  - weekly-selected-prompt-uploaded-bundle-verification-7
+```
+
+Still not default-on:
+
+```text
+scheduled weekly canonical execution for ordinary weeks
+legacy runner removal
+auto-merge
 ```
 
 ## Weekly operating loop
@@ -29,8 +47,10 @@ Run or confirm these in order:
 2. Weekly Auto Run
 3. vote summary PR review
 4. implementation PR review, only if created
-5. Public Results Export refresh
-6. GitHub Pages sanity check
+5. public evidence artifact review, if canonical implementation ran
+6. Public Results Export refresh
+7. GitHub Pages sanity check
+8. cleanup temporary canary variables and canary Issues/PRs
 ```
 
 ## Normal schedule
@@ -41,6 +61,86 @@ Run or confirm these in order:
 | `Weekly Auto Run` | Monday 00:23 UTC | Monday 09:23 JST | `runs/week-<week-id>-vote-summary.md` PR |
 
 The scheduled path should process the previous completed UTC ISO week.
+
+## Canonical weekly feature flag policy
+
+The weekly canonical selected-prompt path is controlled by a repository variable:
+
+```text
+PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER
+```
+
+Allowed values:
+
+```text
+true
+false
+unset
+```
+
+Interpretation:
+
+| Value | Effect | Release status |
+|---|---|---|
+| unset | legacy weekly fallback path | allowed during migration |
+| `false` | legacy weekly fallback path | allowed during migration |
+| `true` | canonical Docker/Codex selected-prompt runner for eligible candidates | canary / controlled use only |
+
+The legacy `scripts/openai_lab_run.py` path is non-canonical. It is preserved as a migration fallback only.
+
+Do not treat a legacy weekly run as canonical evidence.
+
+A weekly implementation PR is canonical only when the evidence says:
+
+```text
+Runner: codex-cli-selected-prompt-packet-container
+Canonical selected-prompt runner: true
+```
+
+## Temporary canary variable policy
+
+Temporary canary variables must be removed or reset after verification.
+
+Variables used during the controlled weekly canonical canary:
+
+```text
+PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER=true
+PROMPT_VOTE_LAB_NO_CHANGE_BASELINE=0
+```
+
+Required cleanup after a canary:
+
+```text
+PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER=false or unset
+PROMPT_VOTE_LAB_NO_CHANGE_BASELINE=20 or unset
+close canary prompt Issue
+close evidence-only canary PRs without merge unless product adoption is intended
+record run URL and artifact names in durable docs or PR comments
+```
+
+Never leave `PROMPT_VOTE_LAB_NO_CHANGE_BASELINE=0` after a canary. That changes weekly selection behavior.
+
+Never leave the canonical weekly runner enabled unintentionally before default-on release approval.
+
+## Default-on release gate
+
+Do not make the canonical weekly runner default-on until all of these are true:
+
+```text
+manual selected-prompt smoke: PASS
+weekly feature-flag canary with eligible candidate: PASS
+weekly diagnostics artifact: present
+weekly public bundle artifact: present
+weekly uploaded bundle verification artifact: present
+bounded lab diff: PASS
+legacy fallback documented as non-canonical
+participant evidence guide published
+operator runbook feature-flag cleanup documented
+manual review remains required
+auto-merge remains disabled
+```
+
+Default-on means changing the repository/workflow default, not just temporarily setting a repository variable for a controlled run.
 
 ## Manual support export verification
 
@@ -83,6 +183,20 @@ support unlock file is referenced
 baseline_won: true
 eligible_count: 0
 implementation PR: none
+```
+
+Expected canonical eligible result when the canonical feature flag is deliberately enabled:
+
+```text
+vote summary PR is created
+implementation PR is created
+Runner: codex-cli-selected-prompt-packet-container
+Canonical selected-prompt runner: true
+weekly-selected-prompt-diagnostics-<run_number> artifact is present
+weekly-selected-prompt-public-bundles-<run_number> artifact is present
+weekly-selected-prompt-uploaded-bundle-verification-<run_number> artifact is present
+changed files are only lab/index.html, lab/style.css, and/or lab/app.js
+auto-merge does not occur
 ```
 
 ## Merge policy
@@ -135,6 +249,19 @@ diff is small enough to review manually
 no external scripts, network calls, cookies, trackers, login, payment, eval, or unsafe dynamic code are added
 ```
 
+For canonical weekly selected-prompt PRs, also require:
+
+```text
+Runner: codex-cli-selected-prompt-packet-container
+Canonical selected-prompt runner: true
+weekly diagnostics artifact exists
+weekly public bundle artifact exists
+weekly uploaded bundle verification artifact exists
+public bundle verification passed
+uploaded bundle verification passed
+Gitleaks finding count is 0
+```
+
 Do not merge if:
 
 ```text
@@ -144,6 +271,7 @@ model appears to have ignored the selected prompt
 implementation is too large to review comfortably
 reviewer cannot explain the diff
 safety/static checks failed or were skipped
+canonical evidence artifacts are missing for a canonical run
 ```
 
 ## Support unlock failure handling
@@ -168,6 +296,8 @@ safety/static checks failed or were skipped
 | preflight failure | model/token/retry/candidate policy mismatch | Fix policy mismatch; do not bypass preflight |
 | generated no lab changes | model failed to make useful change | Record failure; do not auto-rerun |
 | safety/static check failure | unsafe or invalid output | Stop and review; do not merge |
+| canonical evidence artifact missing | canonical step failed before evidence was created or upload failed | Preserve logs, do not merge, inspect diagnostics/public bundle steps |
+| uploaded bundle verification failed | artifact changed, missing, or leaked forbidden pattern | Do not merge; inspect verification report and Gitleaks findings |
 
 ## Public results and Pages checks
 
@@ -190,6 +320,12 @@ It must not need repository write permission.
 Repository writes are performed by the workflow `GITHUB_TOKEN`.
 
 Implementation-agent API secrets are separate and must not be reused as Sponsors tokens.
+
+For canonical Docker/Codex runs, the evidence should show:
+
+```text
+OPENAI_API_KEY present before codex exec: no
+```
 
 ## Reset and cleanup policy
 

--- a/docs/weekly-automation.md
+++ b/docs/weekly-automation.md
@@ -60,11 +60,78 @@ On scheduled runs, support export defaults to the previous UTC ISO week. Manual 
 9. if eligible candidates exist, require implementation secret
 10. preflight the implementation run
 11. create implementation PRs for eligible candidates
+12. upload canonical weekly diagnostics and public evidence when the canonical feature flag is enabled
+13. reverify uploaded canonical public bundles
 ```
 
 The support unlock file is required before vote collection and rank selection.
 
 If the file is missing, the weekly workflow fails before selecting eligible ranks. It must not silently treat missing support data as 0 USD.
+
+## Canonical selected-prompt feature flag
+
+The weekly canonical selected-prompt path is controlled by:
+
+```text
+PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER
+```
+
+The default remains non-canonical during migration:
+
+```text
+DEFAULT_USE_CANONICAL_SELECTED_PROMPT_RUNNER=false
+```
+
+When the variable is unset or `false`, `Weekly Auto Run` keeps the legacy fallback path.
+
+When the variable is `true` and at least one prompt proposal beats the no-change baseline, `Weekly Auto Run` uses the canonical Docker/Codex selected-prompt runner:
+
+```text
+scripts/run_codex_selected_prompt.sh
+Runner: codex-cli-selected-prompt-packet-container
+Canonical selected-prompt runner: true
+```
+
+The legacy `scripts/openai_lab_run.py` path is non-canonical and does not satisfy the selected-prompt canonical runner requirement.
+
+## Canonical weekly evidence artifacts
+
+A successful canonical weekly selected-prompt run should produce:
+
+```text
+weekly-selected-prompt-diagnostics-<run_number>
+weekly-selected-prompt-public-bundles-<run_number>
+weekly-selected-prompt-uploaded-bundle-verification-<run_number>
+```
+
+The evidence chain must include:
+
+```text
+public bundle verification: ok
+uploaded bundle verification: ok
+Gitleaks finding count: 0
+changed files subset of lab/index.html, lab/style.css, lab/app.js
+repo_root_mounted: false
+OPENAI_API_KEY present before codex exec: no
+```
+
+## Temporary canary settings
+
+A controlled weekly canonical canary may temporarily set:
+
+```text
+PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER=true
+PROMPT_VOTE_LAB_NO_CHANGE_BASELINE=0
+```
+
+After the canary, reset or remove them:
+
+```text
+PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER=false or unset
+PROMPT_VOTE_LAB_NO_CHANGE_BASELINE=20 or unset
+```
+
+Leaving `PROMPT_VOTE_LAB_NO_CHANGE_BASELINE=0` changes selection behavior and is not acceptable for normal scheduled operation.
 
 ## Why support export is separate
 
@@ -84,6 +151,7 @@ Weekly auto run:
 - reads the weekly support unlock file
 - creates vote summary PRs
 - creates implementation PRs only when candidates are eligible
+- may use the canonical Docker/Codex selected-prompt runner only when explicitly enabled during migration
 - must not merge PRs automatically
 
 ## Time-window caveat
@@ -135,7 +203,7 @@ rank_3_unlocked: false
 privacy flags: all false
 ```
 
-Verified weekly automation evidence:
+Verified no-eligible weekly automation evidence:
 
 ```text
 Weekly Auto Run: PASS
@@ -146,7 +214,27 @@ eligible_count: 0
 implementation PR: none
 ```
 
-Manual verification is still useful after token rotation, workflow changes, or backfills.
+Verified canonical weekly selected-prompt canary evidence:
+
+```text
+Weekly Auto Run: PASS
+run: 25858202166
+selected Issue: #282
+summary PR: #283
+implementation PR: #284
+Runner: codex-cli-selected-prompt-packet-container
+Canonical selected-prompt runner: true
+artifacts:
+  - weekly-selected-prompt-diagnostics-7
+  - weekly-selected-prompt-public-bundles-7
+  - weekly-selected-prompt-uploaded-bundle-verification-7
+bounded lab diff: PASS
+auto-merge: disabled
+```
+
+The canary Issue and PRs were closed without merge because they were evidence-only artifacts, not product changes.
+
+Manual verification is still useful after token rotation, workflow changes, backfills, or changes to the canonical runner boundary.
 
 Example support export input:
 
@@ -170,6 +258,24 @@ Automation may create PRs, but it must not merge them.
 
 `main` merge remains manual.
 
+## Default-on release gate
+
+Do not make the canonical selected-prompt runner the weekly default until all of these remain true:
+
+```text
+manual selected-prompt smoke: PASS
+weekly feature-flag canary with eligible candidate: PASS
+weekly diagnostics artifact: present
+weekly public bundle artifact: present
+weekly uploaded bundle verification artifact: present
+bounded lab diff: PASS
+legacy fallback documented as non-canonical
+participant evidence guide published
+operator runbook feature-flag cleanup documented
+manual review remains required
+auto-merge remains disabled
+```
+
 ## Current production status
 
 Implemented and live-verified:
@@ -178,7 +284,10 @@ Implemented and live-verified:
 - `Support Unlock Export` can generate and validate an anonymized support unlock file.
 - `Weekly Auto Run` can read that unlock file and create a no-eligible vote summary PR.
 - The no-change baseline path can complete without creating an implementation PR.
+- The weekly canonical selected-prompt feature-flag path can create a bounded lab-only implementation PR with diagnostics, public bundle, and uploaded bundle reverification artifacts.
 
-Still not fully production-verified:
+Still not default-on:
 
-- eligible prompt -> implementation-agent preflight -> implementation-agent run -> lab-only implementation PR
+- ordinary scheduled weekly canonical execution without a controlled canary flag
+- removal of the legacy fallback
+- auto-merge

--- a/scripts/test_script_check_workflow_contract.py
+++ b/scripts/test_script_check_workflow_contract.py
@@ -13,6 +13,8 @@ REQUIRED_TEXT = [
     "lab/comparisons/**",
     "runs/**",
     "docs/canonical-runner-evidence-guide.md",
+    "docs/operator-runbook.md",
+    "docs/weekly-automation.md",
     ".github/workflows/codex-selected-prompt-run.yml",
     "workflow_dispatch:",
     "contents: read",
@@ -22,6 +24,8 @@ REQUIRED_TEXT = [
     "python scripts/test_current_codex_path_doc.py",
     "Run canonical runner evidence guide test",
     "python scripts/test_canonical_runner_evidence_guide.py",
+    "Run weekly operator docs test",
+    "python scripts/test_weekly_operator_docs.py",
     "Run comparison dashboard builder test",
     "python scripts/test_build_comparison_dashboard.py",
     "Run comparison dashboard decision test",
@@ -90,11 +94,20 @@ def main() -> int:
     if text.index("docs/current-codex-implementation-path.md") > text.index("docs/canonical-runner-evidence-guide.md"):
         raise SystemExit("canonical runner evidence guide should be tracked near current Codex path docs")
 
+    if text.index("docs/canonical-runner-evidence-guide.md") > text.index("docs/operator-runbook.md"):
+        raise SystemExit("operator runbook should be tracked after the canonical runner evidence guide")
+
+    if text.index("docs/operator-runbook.md") > text.index("docs/weekly-automation.md"):
+        raise SystemExit("weekly automation doc should be tracked after the operator runbook")
+
     if text.index("Run current Codex path doc test") > text.index("Run canonical runner evidence guide test"):
         raise SystemExit("Canonical runner evidence guide test should run after the current Codex path doc test")
 
-    if text.index("Run canonical runner evidence guide test") > text.index("Run usable experiment ops doc test"):
-        raise SystemExit("Usable experiment ops doc test should run after the canonical runner evidence guide test")
+    if text.index("Run canonical runner evidence guide test") > text.index("Run weekly operator docs test"):
+        raise SystemExit("Weekly operator docs test should run after the canonical runner evidence guide test")
+
+    if text.index("Run weekly operator docs test") > text.index("Run usable experiment ops doc test"):
+        raise SystemExit("Usable experiment ops doc test should run after the weekly operator docs test")
 
     if text.index("Run public agent run bundle enrichment test") > text.index("Run public agent run bundle verifier test"):
         raise SystemExit("Public bundle verifier test should run after enrichment test")

--- a/scripts/test_weekly_operator_docs.py
+++ b/scripts/test_weekly_operator_docs.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNBOOK = ROOT / "docs" / "operator-runbook.md"
+WEEKLY = ROOT / "docs" / "weekly-automation.md"
+
+RUNBOOK_REQUIRED_TEXT = [
+    "# Operator runbook",
+    "manual selected-prompt workflow smoke -> PASS",
+    "weekly canonical selected-prompt canary -> run 25858202166 -> PASS",
+    "PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER=true",
+    "runner: codex-cli-selected-prompt-packet-container",
+    "weekly-selected-prompt-diagnostics-7",
+    "weekly-selected-prompt-public-bundles-7",
+    "weekly-selected-prompt-uploaded-bundle-verification-7",
+    "## Canonical weekly feature flag policy",
+    "The legacy `scripts/openai_lab_run.py` path is non-canonical.",
+    "Runner: codex-cli-selected-prompt-packet-container",
+    "Canonical selected-prompt runner: true",
+    "## Temporary canary variable policy",
+    "PROMPT_VOTE_LAB_NO_CHANGE_BASELINE=0",
+    "PROMPT_VOTE_LAB_NO_CHANGE_BASELINE=20 or unset",
+    "Never leave `PROMPT_VOTE_LAB_NO_CHANGE_BASELINE=0` after a canary.",
+    "## Default-on release gate",
+    "operator runbook feature-flag cleanup documented",
+    "manual review remains required",
+    "auto-merge remains disabled",
+    "Expected canonical eligible result when the canonical feature flag is deliberately enabled:",
+    "canonical evidence artifacts are missing for a canonical run",
+    "OPENAI_API_KEY present before codex exec: no",
+]
+
+WEEKLY_REQUIRED_TEXT = [
+    "# Weekly automation",
+    "upload canonical weekly diagnostics and public evidence when the canonical feature flag is enabled",
+    "reverify uploaded canonical public bundles",
+    "## Canonical selected-prompt feature flag",
+    "PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER",
+    "DEFAULT_USE_CANONICAL_SELECTED_PROMPT_RUNNER=false",
+    "scripts/run_codex_selected_prompt.sh",
+    "Runner: codex-cli-selected-prompt-packet-container",
+    "Canonical selected-prompt runner: true",
+    "The legacy `scripts/openai_lab_run.py` path is non-canonical",
+    "## Canonical weekly evidence artifacts",
+    "weekly-selected-prompt-diagnostics-<run_number>",
+    "weekly-selected-prompt-public-bundles-<run_number>",
+    "weekly-selected-prompt-uploaded-bundle-verification-<run_number>",
+    "public bundle verification: ok",
+    "uploaded bundle verification: ok",
+    "Gitleaks finding count: 0",
+    "repo_root_mounted: false",
+    "OPENAI_API_KEY present before codex exec: no",
+    "## Temporary canary settings",
+    "PROMPT_VOTE_LAB_NO_CHANGE_BASELINE=0",
+    "PROMPT_VOTE_LAB_NO_CHANGE_BASELINE=20 or unset",
+    "Leaving `PROMPT_VOTE_LAB_NO_CHANGE_BASELINE=0` changes selection behavior",
+    "Verified canonical weekly selected-prompt canary evidence:",
+    "run: 25858202166",
+    "selected Issue: #282",
+    "summary PR: #283",
+    "implementation PR: #284",
+    "bounded lab diff: PASS",
+    "auto-merge: disabled",
+    "## Default-on release gate",
+    "operator runbook feature-flag cleanup documented",
+]
+
+FORBIDDEN_TEXT = [
+    "eligible prompt -> implementation-agent preflight -> implementation-agent run -> lab-only implementation PR\n```\n\n## Weekly operating loop",
+    "implementation-agent PR generation still needs a live eligible-candidate E2E verification",
+    "legacy `scripts/openai_lab_run.py` path is canonical",
+    "auto-merge may be enabled",
+    "PROMPT_VOTE_LAB_NO_CHANGE_BASELINE=0 is acceptable for normal scheduled operation",
+]
+
+
+def require_all(text: str, required: list[str], label: str) -> None:
+    missing = [item for item in required if item not in text]
+    if missing:
+        raise SystemExit(f"Missing {label} text: {missing}")
+
+
+def reject_all(text: str, forbidden: list[str], label: str) -> None:
+    found = [item for item in forbidden if item in text]
+    if found:
+        raise SystemExit(f"Forbidden {label} text found: {found}")
+
+
+def main() -> int:
+    runbook = RUNBOOK.read_text(encoding="utf-8")
+    weekly = WEEKLY.read_text(encoding="utf-8")
+
+    require_all(runbook, RUNBOOK_REQUIRED_TEXT, "operator runbook")
+    require_all(weekly, WEEKLY_REQUIRED_TEXT, "weekly automation doc")
+    reject_all(runbook, FORBIDDEN_TEXT, "operator runbook")
+    reject_all(weekly, FORBIDDEN_TEXT, "weekly automation doc")
+
+    if runbook.index("Canonical weekly feature flag policy") > runbook.index("Temporary canary variable policy"):
+        raise SystemExit("runbook should define the feature flag before cleanup policy")
+
+    if runbook.index("Temporary canary variable policy") > runbook.index("Default-on release gate"):
+        raise SystemExit("runbook cleanup policy should precede the default-on gate")
+
+    if weekly.index("Canonical selected-prompt feature flag") > weekly.index("Canonical weekly evidence artifacts"):
+        raise SystemExit("weekly doc should define the feature flag before evidence artifacts")
+
+    if weekly.index("Temporary canary settings") > weekly.index("Manual verification"):
+        raise SystemExit("weekly doc should define canary cleanup before manual verification")
+
+    print("weekly operator docs test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Update the operator runbook to reflect the verified weekly canonical selected-prompt canary.
- Document the canonical weekly feature flag policy, temporary canary variable cleanup, and default-on release gate.
- Update weekly automation docs with canonical selected-prompt evidence artifacts, canary cleanup, and verified run `25858202166`.
- Add a weekly operator docs contract test and register it in Script Check.

## Scope
- `docs/operator-runbook.md`
- `docs/weekly-automation.md`
- `.github/workflows/script-check.yml`
- `scripts/test_weekly_operator_docs.py`
- `scripts/test_script_check_workflow_contract.py`

## Non-goals
- No workflow behavior change.
- No runner implementation change.
- No default flag change.
- No legacy runner removal.
- No auto-merge.

## Verification expected
- Script Check
- actionlint
- weekly operator docs test
- script-check workflow contract test
- Lab PR Scope Check