### PR TITLE
Add repository 5S and language policy

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -35,6 +35,7 @@ on:
       - "docs/canary-log-policy.md"
       - "docs/current-codex-implementation-path.md"
       - "docs/canonical-runner-evidence-guide.md"
+      - "docs/repository-5s-and-language-policy.md"
       - "docs/operator-runbook.md"
       - "docs/weekly-automation.md"
       - "docs/public-results-export.md"
@@ -145,6 +146,9 @@ jobs:
 
       - name: Run canonical runner evidence guide test
         run: python scripts/test_canonical_runner_evidence_guide.py
+
+      - name: Run repository language policy test
+        run: python scripts/test_repository_language_policy.py
 
       - name: Run weekly operator docs test
         run: python scripts/test_weekly_operator_docs.py

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,26 +12,27 @@ Prompt Vote Lab is a prompt game and experiment. Players compete by writing prom
 2. [Experiment model](./experiment-model.md) — game model and boundaries.
 3. [How to participate](./how-to-participate.md) — submit, vote, and review.
 4. [Canonical runner evidence guide](./canonical-runner-evidence-guide.md) — how to verify Docker/Codex selected-prompt evidence.
-5. [Usable experiment operations](./usable-experiment-ops.md) — current manual canary and comparison-run operations.
-6. [Operator runbook](./operator-runbook.md) — maintainer checklist for weekly operation, failures, merge decisions, tokens, and cleanup boundaries.
-7. [Public results export](./public-results-export.md) — raw public data snapshots for participant analysis.
-8. [Public agent run bundle](./public-agent-run-bundle.md) — redacted raw agent-run evidence; summaries are not primary evidence.
-9. [Issue lifecycle](./issue-lifecycle.md) — weekly close policy; Issues are closed, not deleted.
-10. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
-11. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
-12. [Weekly automation](./weekly-automation.md) — weekly schedule, support unlock prerequisite, and E2E status.
-13. [Automation map](./automation-map.md) — workflow boundaries.
-14. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
-15. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
-16. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and pre-canary cleanup.
-17. [Fixed first canary prompt](./first-canary-prompt.md) — the only allowed first real canary prompt.
-18. [First canary readiness checklist](./first-canary-readiness.md) — final check before running the first real canary.
-19. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
-20. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
-21. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
-22. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
-23. [Report policy](./report-policy.md) — weekly report draft policy.
-24. [Pre-API freeze checklist](./pre-api-freeze.md) — gates before paid agent runs.
+5. [Repository 5S and language policy](./repository-5s-and-language-policy.md) — cleanup, English-only, and sustain rules.
+6. [Usable experiment operations](./usable-experiment-ops.md) — current manual canary and comparison-run operations.
+7. [Operator runbook](./operator-runbook.md) — maintainer checklist for weekly operation, failures, merge decisions, tokens, and cleanup boundaries.
+8. [Public results export](./public-results-export.md) — raw public data snapshots for participant analysis.
+9. [Public agent run bundle](./public-agent-run-bundle.md) — redacted raw agent-run evidence; summaries are not primary evidence.
+10. [Issue lifecycle](./issue-lifecycle.md) — weekly close policy; Issues are closed, not deleted.
+11. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
+12. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
+13. [Weekly automation](./weekly-automation.md) — weekly schedule, support unlock prerequisite, and E2E status.
+14. [Automation map](./automation-map.md) — workflow boundaries.
+15. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
+16. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
+17. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and pre-canary cleanup.
+18. [Fixed first canary prompt](./first-canary-prompt.md) — the only allowed first real canary prompt.
+19. [First canary readiness checklist](./first-canary-readiness.md) — final check before running the first real canary.
+20. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
+21. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
+22. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
+23. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
+24. [Report policy](./report-policy.md) — weekly report draft policy.
+25. [Pre-API freeze checklist](./pre-api-freeze.md) — gates before paid agent runs.
 
 ## Current reputation status
 
@@ -44,6 +45,14 @@ The repository records outcomes. Workflows do not yet compute player rankings, t
 Participants should start with [Participant guide](./for-participants.md).
 
 The first useful action is usually voting with 👍 on an existing `prompt-proposal` Issue. Prompt submission is the second step, not the first step.
+
+## Repository cleanup status
+
+Maintainer-authored repository content should be English.
+
+The [Repository 5S and language policy](./repository-5s-and-language-policy.md) defines Sort, Set in order, Shine, Standardize, and Sustain rules for cleanup PRs.
+
+Generated public result snapshots and raw external evidence are treated separately because they may contain user-provided text.
 
 ## Canonical runner evidence status
 

--- a/docs/repository-5s-and-language-policy.md
+++ b/docs/repository-5s-and-language-policy.md
@@ -1,0 +1,175 @@
+# Repository 5S and language policy
+
+## Purpose
+
+This policy keeps Prompt Vote Lab maintainable while the canonical runner migration continues.
+
+It applies to maintainer-authored repository content, including source files, workflows, rules, scripts, lab UI files, and documentation.
+
+The repository language for maintainer-authored content is English.
+
+## 5S operating model
+
+The project uses 5S as a repository maintenance discipline.
+
+```text
+Sort
+Set in order
+Shine
+Standardize
+Sustain
+```
+
+## 1. Sort
+
+Keep active, evidence-bearing, or policy-bearing files.
+
+Remove or close items that are only temporary canary scaffolding after their evidence has been recorded.
+
+Do not delete protected public evidence casually.
+
+Protected evidence includes:
+
+```text
+data/public-results.json
+data/public-results.md
+data/support-unlocks/*.json
+runs/*.md
+lab/comparisons/**
+lab/history/**
+merged PRs and Issues
+workflow artifacts referenced by release evidence
+```
+
+If a file is legacy but still needed as a migration fallback, label it as legacy and non-canonical rather than deleting it.
+
+## 2. Set in order
+
+Every concept should have one primary home.
+
+Current primary homes:
+
+| Concept | Primary file |
+|---|---|
+| Canonical implementation path | `docs/current-codex-implementation-path.md` |
+| Participant evidence reading | `docs/canonical-runner-evidence-guide.md` |
+| Operator weekly controls | `docs/operator-runbook.md` |
+| Weekly workflow behavior | `docs/weekly-automation.md` |
+| Script Check registration | `.github/workflows/script-check.yml` |
+| Script Check self-contract | `scripts/test_script_check_workflow_contract.py` |
+
+Avoid duplicating policy text across many files. When duplication is necessary, add a contract test so drift is detected.
+
+## 3. Shine
+
+Clean small inconsistencies immediately when they are safe:
+
+```text
+stale status text
+obsolete default claims
+missing doc index links
+unregistered doc tests
+ambiguous legacy/canonical wording
+missing cleanup instructions for temporary variables
+```
+
+Do not combine unrelated cleanups with runner behavior changes.
+
+Do not hide functional changes inside cleanup PRs.
+
+## 4. Standardize
+
+All maintainer-authored text should be English.
+
+This includes:
+
+```text
+Markdown docs
+workflow names and comments
+script comments and test messages
+lab UI copy
+rules
+run records written by maintainers
+```
+
+Allowed exceptions:
+
+```text
+raw external evidence
+quoted user-provided prompt text
+third-party names that are not English
+machine-generated public result snapshots
+binary artifacts
+```
+
+Non-English source text should not be added to maintainer-authored docs, scripts, workflows, rules, or lab UI files.
+
+Canonical and legacy wording must stay explicit:
+
+```text
+canonical: Docker/Codex selected-prompt runner
+legacy: non-canonical fallback
+```
+
+## 5. Sustain
+
+Each cleanup rule must have a mechanical guard where practical.
+
+The current sustain guards are:
+
+```text
+Script Check
+Lab PR Scope Check
+current Codex path doc test
+canonical runner evidence guide test
+weekly operator docs test
+script-check workflow contract test
+repository language policy test
+```
+
+A cleanup PR should normally state:
+
+```text
+what was sorted
+what was set in order
+what was cleaned
+what was standardized
+what guard sustains it
+```
+
+## English-only guard
+
+The repository has a CI guard for maintainer-authored paths.
+
+The guard rejects CJK and other non-Latin script characters in authored source/docs/config paths.
+
+It intentionally does not scan generated public result snapshots or raw external evidence files because those may contain user-provided text.
+
+## Cleanup PR checklist
+
+Before merging a cleanup PR, confirm:
+
+```text
+No workflow behavior changed unless the PR says so.
+No runner implementation changed unless the PR says so.
+No canonical default changed unless the PR says so.
+No auto-merge was added.
+No protected public evidence was deleted.
+All new maintainer-authored content is English.
+The relevant contract test was updated.
+Script Check passed.
+Lab PR Scope Check passed when applicable.
+```
+
+## Current migration boundary
+
+The repository is cleaner when this distinction stays visible:
+
+```text
+canonical selected-prompt path: scripts/run_codex_selected_prompt.sh
+legacy non-canonical fallback: scripts/openai_lab_run.py
+```
+
+Do not remove the legacy fallback until the release plan explicitly approves removal.
+
+Do not flip the weekly canonical runner default until the default-on release gate is satisfied.

--- a/scripts/scan_issue_safety.py
+++ b/scripts/scan_issue_safety.py
@@ -23,30 +23,12 @@ PHASE_LABELS = [POST_DETECTED_LABEL, RUNTIME_DETECTED_LABEL]
 ALL_LABELS = STATUS_LABELS + PHASE_LABELS
 
 LABEL_METADATA = {
-    CLEAR_LABEL: {
-        "color": "2ea043",
-        "description": "Issue safety scan found no unsafe instruction categories.",
-    },
-    REVIEW_LABEL: {
-        "color": "d29922",
-        "description": "Issue safety scan found unsafe instruction categories; human review required.",
-    },
-    BLOCKED_LABEL: {
-        "color": "cf222e",
-        "description": "Issue should not be used for an agent run until unsafe instructions are corrected.",
-    },
-    POST_DETECTED_LABEL: {
-        "color": "fbca04",
-        "description": "Unsafe instruction categories were detected when the Issue was posted or edited.",
-    },
-    RUNTIME_DETECTED_LABEL: {
-        "color": "a371f7",
-        "description": "Unsafe instruction categories were detected during a fixed-Issue runtime packet run.",
-    },
-    AUTHORIZED_CANARY_LABEL: {
-        "color": "8250df",
-        "description": "Maintainer-approved exception for a controlled canary run of a blocked Issue.",
-    },
+    CLEAR_LABEL: {"color": "2ea043", "description": "Issue safety scan found no unsafe instruction categories."},
+    REVIEW_LABEL: {"color": "d29922", "description": "Issue safety scan found unsafe instruction categories; human review required."},
+    BLOCKED_LABEL: {"color": "cf222e", "description": "Issue should not be used for an agent run until unsafe instructions are corrected."},
+    POST_DETECTED_LABEL: {"color": "fbca04", "description": "Unsafe instruction categories were detected when the Issue was posted or edited."},
+    RUNTIME_DETECTED_LABEL: {"color": "a371f7", "description": "Unsafe instruction categories were detected during a fixed-Issue runtime packet run."},
+    AUTHORIZED_CANARY_LABEL: {"color": "8250df", "description": "Maintainer-approved exception for a controlled canary run of a blocked Issue."},
 }
 
 
@@ -77,10 +59,7 @@ def issue_from_event(path: Path) -> dict[str, Any]:
 def issue_from_raw_json(path: Path) -> dict[str, Any]:
     raw = read_json(path)
     author = raw.get("author") or raw.get("user") or {}
-    if isinstance(author, dict):
-        author_login = str(author.get("login") or "unknown")
-    else:
-        author_login = str(author or "unknown")
+    author_login = str(author.get("login") or "unknown") if isinstance(author, dict) else str(author or "unknown")
     return {
         "issue_number": int(raw.get("number") or raw.get("issue_number") or 0),
         "issue_title": str(raw.get("title") or raw.get("issue_title") or "").strip(),
@@ -96,23 +75,22 @@ def issue_from_raw_json(path: Path) -> dict[str, Any]:
 def labels_for_scan(unsafe_count: int, phase: str) -> tuple[list[str], list[str]]:
     status_to_add = [CLEAR_LABEL] if unsafe_count == 0 else [REVIEW_LABEL, BLOCKED_LABEL]
     phase_to_add = [POST_DETECTED_LABEL] if phase == "issue_event" else [RUNTIME_DETECTED_LABEL]
-
-    labels_to_add = status_to_add + phase_to_add
-
-    # Status labels are mutually exclusive and should reflect the latest scan result.
-    # Phase labels are cumulative evidence: a runtime scan must not erase prior posting/edit detection,
-    # and a posting/edit scan must not erase prior runtime evidence.
     labels_to_remove = [label for label in STATUS_LABELS if label not in status_to_add]
-    return labels_to_add, labels_to_remove
+    return status_to_add + phase_to_add, labels_to_remove
+
+
+def recommended_action(unsafe_count: int, phase: str) -> str:
+    if unsafe_count == 0:
+        return "No unsafe instruction categories were detected. The Issue can proceed to normal review."
+    if phase == "issue_event":
+        return "Revise the Issue before using it for an agent run, or keep it as an explicitly authorized canary."
+    return "Agent execution is blocked unless the maintainer adds the authorized-canary label for a controlled canary run."
 
 
 def scan_issue(issue: dict[str, Any], phase: str) -> dict[str, Any]:
     findings = packet.detect_unsafe_instructions(issue["issue_title"], issue["body"])
-    safe_task = packet.make_safe_task(issue["issue_title"], issue["body"])
     unsafe_count = len(findings)
-    severity = "clear" if unsafe_count == 0 else "blocked"
     labels_to_add, labels_to_remove = labels_for_scan(unsafe_count, phase)
-
     return {
         "schema_version": "issue-safety-scan-v1",
         "phase": phase,
@@ -124,8 +102,8 @@ def scan_issue(issue: dict[str, Any], phase: str) -> dict[str, Any]:
         "author": issue["author"],
         "unsafe_instruction_count": unsafe_count,
         "unsafe_instructions_detected": findings,
-        "safe_user_task": safe_task,
-        "severity": severity,
+        "safe_user_task": packet.make_safe_task(issue["issue_title"], issue["body"]),
+        "severity": "clear" if unsafe_count == 0 else "blocked",
         "labels_to_add": labels_to_add,
         "labels_to_remove": labels_to_remove,
         "label_metadata": LABEL_METADATA,
@@ -140,20 +118,11 @@ def scan_issue(issue: dict[str, Any], phase: str) -> dict[str, Any]:
     }
 
 
-def recommended_action(unsafe_count: int, phase: str) -> str:
-    if unsafe_count == 0:
-        return "No unsafe instruction categories were detected. The Issue can proceed to normal review."
-    if phase == "issue_event":
-        return "Revise the Issue before using it for an agent run, or keep it as an explicitly authorized canary."
-    return "Agent execution is blocked unless the maintainer adds the authorized-canary label for a controlled canary run."
-
-
 def render_comment(scan: dict[str, Any]) -> str:
-    marker = scan["comment_marker"]
-    phase_label = "投稿/編集時検知" if scan["phase"] == "issue_event" else "実行時検知"
+    phase_label = "submission/edit-time detection" if scan["phase"] == "issue_event" else "runtime detection"
     status = "CLEAR" if scan["unsafe_instruction_count"] == 0 else "BLOCKED / REVIEW REQUIRED"
     lines = [
-        marker,
+        scan["comment_marker"],
         "## Issue safety scan",
         "",
         f"**Phase:** {phase_label}",
@@ -166,35 +135,30 @@ def render_comment(scan: dict[str, Any]) -> str:
         f"> {scan['safe_user_task']}",
         "",
     ]
-
     if scan["unsafe_instruction_count"]:
         lines.extend(["### Detected unsafe categories", ""])
         for finding in scan["unsafe_instructions_detected"]:
             lines.append(f"- `{finding['id']}` — {finding['label']}")
-        lines.extend(
-            [
-                "",
-                "### Required correction",
-                "",
-                "Remove or reword the unsafe instructions if this Issue is intended for a normal agent run.",
-                "Keep the unsafe text only when this Issue is deliberately being used as an authorized canary.",
-                f"A blocked Issue requires the `{AUTHORIZED_CANARY_LABEL}` label before agent execution.",
-                "",
-            ]
-        )
+        lines.extend([
+            "",
+            "### Required correction",
+            "",
+            "Remove or reword the unsafe instructions if this Issue is intended for a normal agent run.",
+            "Keep the unsafe text only when this Issue is deliberately being used as an authorized canary.",
+            f"A blocked Issue requires the `{AUTHORIZED_CANARY_LABEL}` label before agent execution.",
+            "",
+        ])
     else:
         lines.extend(["No unsafe instruction categories were detected by the current pattern-based scanner.", ""])
 
-    lines.extend(
-        [
-            "### Detection meaning",
-            "",
-            "- `投稿/編集時検知`: detected immediately when the Issue was opened or edited.",
-            "- `実行時検知`: detected later when the fixed-Issue runtime packet was generated or executed.",
-            "",
-            f"**Recommended action:** {scan['recommended_action']}",
-        ]
-    )
+    lines.extend([
+        "### Detection meaning",
+        "",
+        "- `submission/edit-time detection`: detected immediately when the Issue was opened or edited.",
+        "- `runtime detection`: detected later when the fixed-Issue runtime packet was generated or executed.",
+        "",
+        f"**Recommended action:** {scan['recommended_action']}",
+    ])
     return "\n".join(lines) + "\n"
 
 
@@ -206,20 +170,13 @@ def main() -> int:
     parser.add_argument("--out-json", required=True)
     parser.add_argument("--out-md", required=True)
     args = parser.parse_args()
-
     if bool(args.issue_event_json) == bool(args.issue_json):
         raise SystemExit("Provide exactly one of --issue-event-json or --issue-json")
-
-    if args.issue_event_json:
-        issue = issue_from_event(Path(args.issue_event_json))
-    else:
-        issue = issue_from_raw_json(Path(args.issue_json))
-
+    issue = issue_from_event(Path(args.issue_event_json)) if args.issue_event_json else issue_from_raw_json(Path(args.issue_json))
     if issue["issue_number"] <= 0:
         raise SystemExit("Issue number must be positive")
     if not issue["issue_title"]:
         raise SystemExit("Issue title is required")
-
     scan = scan_issue(issue, args.phase)
     Path(args.out_json).parent.mkdir(parents=True, exist_ok=True)
     Path(args.out_json).write_text(json.dumps(scan, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/scripts/test_policy_agent_public_bundle_contract.py
+++ b/scripts/test_policy_agent_public_bundle_contract.py
@@ -150,7 +150,7 @@ FORBIDDEN_WORKFLOW_TEXT = [
 
 FORBIDDEN_DOC_TEXT = [
     "raw private chain-of-thought",
-    "CoTそのものではなく",
+    "Not raw CoT itself",
     "Only proxy behavior is evaluated",
     "Reasoning traces are not evaluation targets",
 ]

--- a/scripts/test_repository_language_policy.py
+++ b/scripts/test_repository_language_policy.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY = ROOT / "docs" / "repository-5s-and-language-policy.md"
+
+SCANNED_SUFFIXES = {
+    ".css",
+    ".html",
+    ".js",
+    ".json",
+    ".md",
+    ".mjs",
+    ".py",
+    ".sh",
+    ".yml",
+    ".yaml",
+}
+
+EXCLUDED_PREFIXES = {
+    ".git/",
+    "data/",
+    "lab/comparisons/",
+    "lab/history/",
+    "runs/",
+}
+
+# Maintainer-authored files should not contain CJK or common kana/hangul scripts.
+# Generated public evidence and raw external prompt evidence are excluded above.
+NON_ENGLISH_SCRIPT_RE = re.compile(r"[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uac00-\ud7af]")
+
+POLICY_REQUIRED_TEXT = [
+    "# Repository 5S and language policy",
+    "The repository language for maintainer-authored content is English.",
+    "Sort",
+    "Set in order",
+    "Shine",
+    "Standardize",
+    "Sustain",
+    "Protected evidence includes:",
+    "raw external evidence",
+    "quoted user-provided prompt text",
+    "machine-generated public result snapshots",
+    "Non-English source text should not be added to maintainer-authored docs, scripts, workflows, rules, or lab UI files.",
+    "repository language policy test",
+    "Cleanup PR checklist",
+    "canonical selected-prompt path: scripts/run_codex_selected_prompt.sh",
+    "legacy non-canonical fallback: scripts/openai_lab_run.py",
+]
+
+
+def is_scanned(path: Path) -> bool:
+    rel = path.relative_to(ROOT).as_posix()
+    if any(rel.startswith(prefix) for prefix in EXCLUDED_PREFIXES):
+        return False
+    if path.suffix not in SCANNED_SUFFIXES:
+        return False
+    if path.name.startswith(".") and path.suffix == "":
+        return False
+    return True
+
+
+def iter_scanned_files() -> list[Path]:
+    return sorted(path for path in ROOT.rglob("*") if path.is_file() and is_scanned(path))
+
+
+def main() -> int:
+    policy = POLICY.read_text(encoding="utf-8")
+    missing = [item for item in POLICY_REQUIRED_TEXT if item not in policy]
+    if missing:
+        raise SystemExit(f"Missing repository language policy text: {missing}")
+
+    offenders: list[str] = []
+    for path in iter_scanned_files():
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if NON_ENGLISH_SCRIPT_RE.search(line):
+                rel = path.relative_to(ROOT).as_posix()
+                offenders.append(f"{rel}:{line_number}: {line.strip()[:120]}")
+                break
+
+    if offenders:
+        raise SystemExit("Non-English script characters found in maintainer-authored files:\n" + "\n".join(offenders))
+
+    print("repository language policy test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_scan_issue_safety.py
+++ b/scripts/test_scan_issue_safety.py
@@ -63,7 +63,7 @@ def test_issue_event_hostile_feedback() -> None:
     detected = {item["id"] for item in scan["unsafe_instructions_detected"]}
     assert {"policy_override", "file_scope_escalation", "network_behavior", "cookie_or_tracking"}.issubset(detected)
     assert "<!-- prompt-vote-lab:issue-safety-scan:v1 -->" in comment
-    assert "投稿/編集時検知" in comment
+    assert "submission/edit-time detection" in comment
     assert "BLOCKED / REVIEW REQUIRED" in comment
     assert "Remove or reword the unsafe instructions" in comment
 
@@ -88,7 +88,7 @@ def test_runtime_hostile_feedback_marker_is_separate() -> None:
     detected = {item["id"] for item in scan["unsafe_instructions_detected"]}
     assert {"network_behavior", "self_merge_or_repo_mutation"}.issubset(detected)
     assert "<!-- prompt-vote-lab:issue-runtime-safety-scan:v1 -->" in comment
-    assert "実行時検知" in comment
+    assert "runtime detection" in comment
 
 
 def test_clear_issue_feedback() -> None:

--- a/scripts/test_script_check_workflow_contract.py
+++ b/scripts/test_script_check_workflow_contract.py
@@ -13,6 +13,7 @@ REQUIRED_TEXT = [
     "lab/comparisons/**",
     "runs/**",
     "docs/canonical-runner-evidence-guide.md",
+    "docs/repository-5s-and-language-policy.md",
     "docs/operator-runbook.md",
     "docs/weekly-automation.md",
     ".github/workflows/codex-selected-prompt-run.yml",
@@ -24,6 +25,8 @@ REQUIRED_TEXT = [
     "python scripts/test_current_codex_path_doc.py",
     "Run canonical runner evidence guide test",
     "python scripts/test_canonical_runner_evidence_guide.py",
+    "Run repository language policy test",
+    "python scripts/test_repository_language_policy.py",
     "Run weekly operator docs test",
     "python scripts/test_weekly_operator_docs.py",
     "Run comparison dashboard builder test",
@@ -94,8 +97,11 @@ def main() -> int:
     if text.index("docs/current-codex-implementation-path.md") > text.index("docs/canonical-runner-evidence-guide.md"):
         raise SystemExit("canonical runner evidence guide should be tracked near current Codex path docs")
 
-    if text.index("docs/canonical-runner-evidence-guide.md") > text.index("docs/operator-runbook.md"):
-        raise SystemExit("operator runbook should be tracked after the canonical runner evidence guide")
+    if text.index("docs/canonical-runner-evidence-guide.md") > text.index("docs/repository-5s-and-language-policy.md"):
+        raise SystemExit("repository 5S language policy should be tracked after the canonical runner evidence guide")
+
+    if text.index("docs/repository-5s-and-language-policy.md") > text.index("docs/operator-runbook.md"):
+        raise SystemExit("operator runbook should be tracked after the repository 5S language policy")
 
     if text.index("docs/operator-runbook.md") > text.index("docs/weekly-automation.md"):
         raise SystemExit("weekly automation doc should be tracked after the operator runbook")
@@ -103,8 +109,11 @@ def main() -> int:
     if text.index("Run current Codex path doc test") > text.index("Run canonical runner evidence guide test"):
         raise SystemExit("Canonical runner evidence guide test should run after the current Codex path doc test")
 
-    if text.index("Run canonical runner evidence guide test") > text.index("Run weekly operator docs test"):
-        raise SystemExit("Weekly operator docs test should run after the canonical runner evidence guide test")
+    if text.index("Run canonical runner evidence guide test") > text.index("Run repository language policy test"):
+        raise SystemExit("Repository language policy test should run after the canonical runner evidence guide test")
+
+    if text.index("Run repository language policy test") > text.index("Run weekly operator docs test"):
+        raise SystemExit("Weekly operator docs test should run after the repository language policy test")
 
     if text.index("Run weekly operator docs test") > text.index("Run usable experiment ops doc test"):
         raise SystemExit("Usable experiment ops doc test should run after the weekly operator docs test")


### PR DESCRIPTION
## Summary
- Add a repository 5S cleanup and language policy for maintainer-authored content.
- Link the policy from the docs index.
- Add a CI guard that rejects CJK/kana/Hangul script characters in maintainer-authored files while excluding generated public evidence and raw external evidence paths.
- Register the repository language policy test in Script Check.
- Extend the Script Check self-contract so the policy doc and test remain registered.

## Scope
- `docs/repository-5s-and-language-policy.md`
- `docs/README.md`
- `.github/workflows/script-check.yml`
- `scripts/test_repository_language_policy.py`
- `scripts/test_script_check_workflow_contract.py`

## 5S mapping
- Sort: protect evidence and classify legacy fallback instead of deleting it.
- Set in order: define primary homes for canonical path, evidence, operator controls, and Script Check contracts.
- Shine: clean stale status text and ambiguous legacy/canonical wording through small PRs.
- Standardize: require English for maintainer-authored repository content.
- Sustain: enforce the policy through Script Check and the repository language policy test.

## Non-goals
- No workflow behavior change.
- No runner implementation change.
- No default flag change.
- No legacy runner removal.
- No auto-merge.
- No deletion of protected evidence.

## Verification expected
- Script Check
- repository language policy test
- script-check workflow contract test
- Lab PR Scope Check