### PR TITLE
Add workflow family map

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -37,6 +37,7 @@ on:
       - "docs/canonical-runner-evidence-guide.md"
       - "docs/repository-5s-and-language-policy.md"
       - "docs/repository-cleanup-inventory.md"
+      - "docs/workflow-family-map.md"
       - "docs/operator-runbook.md"
       - "docs/weekly-automation.md"
       - "docs/public-results-export.md"
@@ -153,6 +154,9 @@ jobs:
 
       - name: Run repository cleanup inventory test
         run: python scripts/test_repository_cleanup_inventory.py
+
+      - name: Run workflow family map test
+        run: python scripts/test_workflow_family_map.py
 
       - name: Run weekly operator docs test
         run: python scripts/test_weekly_operator_docs.py

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,26 +14,27 @@ Prompt Vote Lab is a prompt game and experiment. Players compete by writing prom
 4. [Canonical runner evidence guide](./canonical-runner-evidence-guide.md) — how to verify Docker/Codex selected-prompt evidence.
 5. [Repository 5S and language policy](./repository-5s-and-language-policy.md) — cleanup, English-only, and sustain rules.
 6. [Repository cleanup inventory](./repository-cleanup-inventory.md) — protected evidence, canonical surfaces, legacy fallbacks, generated snapshots, and cleanup candidates.
-7. [Usable experiment operations](./usable-experiment-ops.md) — current manual canary and comparison-run operations.
-8. [Operator runbook](./operator-runbook.md) — maintainer checklist for weekly operation, failures, merge decisions, tokens, and cleanup boundaries.
-9. [Public results export](./public-results-export.md) — raw public data snapshots for participant analysis.
-10. [Public agent run bundle](./public-agent-run-bundle.md) — redacted raw agent-run evidence; summaries are not primary evidence.
-11. [Issue lifecycle](./issue-lifecycle.md) — weekly close policy; Issues are closed, not deleted.
-12. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
-13. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
-14. [Weekly automation](./weekly-automation.md) — weekly schedule, support unlock prerequisite, and E2E status.
-15. [Automation map](./automation-map.md) — workflow boundaries.
-16. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
-17. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
-18. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and pre-canary cleanup.
-19. [Fixed first canary prompt](./first-canary-prompt.md) — the only allowed first real canary prompt.
-20. [First canary readiness checklist](./first-canary-readiness.md) — final check before running the first real canary.
-21. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
-22. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
-23. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
-24. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
-25. [Report policy](./report-policy.md) — weekly report draft policy.
-26. [Pre-API freeze checklist](./pre-api-freeze.md) — gates before paid agent runs.
+7. [Workflow family map](./workflow-family-map.md) — canonical, weekly, generated, safety, canary, legacy, and test workflow classification.
+8. [Usable experiment operations](./usable-experiment-ops.md) — current manual canary and comparison-run operations.
+9. [Operator runbook](./operator-runbook.md) — maintainer checklist for weekly operation, failures, merge decisions, tokens, and cleanup boundaries.
+10. [Public results export](./public-results-export.md) — raw public data snapshots for participant analysis.
+11. [Public agent run bundle](./public-agent-run-bundle.md) — redacted raw agent-run evidence; summaries are not primary evidence.
+12. [Issue lifecycle](./issue-lifecycle.md) — weekly close policy; Issues are closed, not deleted.
+13. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
+14. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
+15. [Weekly automation](./weekly-automation.md) — weekly schedule, support unlock prerequisite, and E2E status.
+16. [Automation map](./automation-map.md) — workflow boundaries.
+17. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
+18. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
+19. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and pre-canary cleanup.
+20. [Fixed first canary prompt](./first-canary-prompt.md) — the only allowed first real canary prompt.
+21. [First canary readiness checklist](./first-canary-readiness.md) — final check before running the first real canary.
+22. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
+23. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
+24. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
+25. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
+26. [Report policy](./report-policy.md) — weekly report draft policy.
+27. [Pre-API freeze checklist](./pre-api-freeze.md) — gates before paid agent runs.
 
 ## Current reputation status
 
@@ -54,6 +55,8 @@ Maintainer-authored repository content should be English.
 The [Repository 5S and language policy](./repository-5s-and-language-policy.md) defines Sort, Set in order, Shine, Standardize, and Sustain rules for cleanup PRs.
 
 The [Repository cleanup inventory](./repository-cleanup-inventory.md) classifies protected evidence, canonical active surfaces, legacy fallbacks, generated snapshots, cleanup candidates, and not-yet-removable items before any deletion work.
+
+The [Workflow family map](./workflow-family-map.md) classifies workflows before consolidation or deletion work so historical scaffolding is not mistaken for active canonical evidence.
 
 Generated public result snapshots and raw external evidence are treated separately because they may contain user-provided text.
 

--- a/docs/workflow-family-map.md
+++ b/docs/workflow-family-map.md
@@ -1,0 +1,144 @@
+# Workflow family map
+
+## Purpose
+
+This map classifies GitHub Actions workflows before cleanup or deletion work.
+
+It is not a removal plan.
+
+It answers one question first:
+
+```text
+Which workflows are evidence-bearing, and which workflows are historical scaffolding?
+```
+
+## Family states
+
+| State | Meaning | Default action |
+|---|---|---|
+| Canonical active | Current canonical implementation, verification, or evidence path | Keep and harden |
+| Weekly active | Scheduled or manually runnable weekly operation | Keep and harden |
+| Public generated snapshot | Owns generated public data or pages evidence | Keep; edit through owning generator |
+| Safety gate | Blocks unsafe or out-of-scope execution | Keep |
+| Canary evidence | Historical or controlled canary path with evidence value | Keep until replacement evidence is documented |
+| Legacy fallback | Non-canonical migration fallback | Keep with explicit legacy wording |
+| Test and guard | CI guard, scope guard, or contract verification | Keep |
+| Cleanup candidate | Candidate for later consolidation or retirement | Do not delete until a removal gate is recorded |
+
+## Canonical active workflows
+
+| Workflow | Path | Reason |
+|---|---|---|
+| Codex Selected Prompt Run | `.github/workflows/codex-selected-prompt-run.yml` | Manual canonical selected-prompt Docker/Codex runner smoke path |
+| Weekly Auto Run | `.github/workflows/weekly-auto-run.yml` | Weekly vote summary and feature-flagged canonical selected-prompt implementation path |
+
+Canonical evidence requires the selected-prompt Docker/Codex runner evidence:
+
+```text
+Runner: codex-cli-selected-prompt-packet-container
+Canonical selected-prompt runner: true
+```
+
+## Weekly active workflows
+
+| Workflow | Path | Reason |
+|---|---|---|
+| Support Unlock Export | `.github/workflows/support-unlock-export.yml` | Produces anonymized weekly support unlock data |
+| Weekly Auto Run | `.github/workflows/weekly-auto-run.yml` | Reads support unlock data and prompt votes |
+| Weekly Issue Finalizer | `.github/workflows/weekly-issue-finalizer.yml` | Closes weekly Issues after public results membership and outcome labeling |
+
+These workflows are not cleanup candidates while weekly operation depends on them.
+
+## Public generated snapshot workflows
+
+| Workflow | Path | Reason |
+|---|---|---|
+| Public Results Export | `.github/workflows/public-results-export.yml` | Owns `data/public-results.json`, `data/public-results.md`, and derived public evidence surfaces |
+
+Generated snapshot files should be changed through the owning workflow or generator, not by unrelated cleanup PRs.
+
+## Safety gate workflows
+
+| Workflow | Path | Reason |
+|---|---|---|
+| Issue Safety Scan | `.github/workflows/issue-safety-scan.yml` | Scans Issue text and labels unsafe or review-required Issues before execution |
+
+Safety gate workflows are not optional cleanup targets.
+
+## Test and guard workflows
+
+| Workflow | Path | Reason |
+|---|---|---|
+| Script Check | `.github/workflows/script-check.yml` | Runs syntax, contract, doc, runner, bundle, and cleanup guards |
+
+Script Check is the primary sustain mechanism for repository 5S.
+
+## Canary evidence workflows
+
+These workflows are evidence-bearing historical or controlled canary paths.
+
+They should not be deleted merely because the selected-prompt runner is now canonical.
+
+| Workflow | Path | Current role |
+|---|---|---|
+| Codex First Canary Run | `.github/workflows/codex-first-canary-run.yml` | Historical first canary path |
+| Codex Isolated 3file Canary Run | `.github/workflows/codex-isolated-3file-canary-run.yml` | Historical isolated three-file canary path |
+| Codex Isolated 3file Relaxed Canary Run | `.github/workflows/codex-isolated-3file-relaxed-canary-run.yml` | Historical relaxed canary path |
+| Codex Writeback Canary Run | `.github/workflows/codex-writeback-canary-run.yml` | Historical writeback canary path |
+| Codex Offline JSON Canary Run | `.github/workflows/codex-offline-json-canary-run.yml` | Historical non-canonical JSON writeback path |
+| Codex Agent Observed Canary Run | `.github/workflows/codex-agent-observed-canary-run.yml` | Historical agent-observed canary path |
+| Canary 007 Policy Feasibility | `.github/workflows/canary-007-policy-feasibility.yml` | Feasibility check for policy-enforced container execution |
+| Codex Policy Agent Canary Run | `.github/workflows/codex-policy-agent-canary-run.yml` | Policy-agent public bundle and diagnostics evidence path |
+| Codex Task Packet Canary Run | `.github/workflows/codex-task-packet-canary-run.yml` | Task-packet boundary evidence path |
+| Codex Fixed Issue Instruction Canary Run | `.github/workflows/codex-fixed-issue-instruction-canary-run.yml` | Fixed-Issue instruction packet and safety-gate evidence path |
+
+## Legacy fallback workflows and paths
+
+The legacy fallback is primarily a script path, not a separate workflow family:
+
+```text
+scripts/openai_lab_run.py
+```
+
+It may still be reachable through weekly migration behavior when the canonical selected-prompt runner flag is unset or false.
+
+It is non-canonical.
+
+It should not be removed until the default-on release gate explicitly approves removal.
+
+## Cleanup candidates
+
+These are candidates for future consolidation. They are not deletion instructions.
+
+| Candidate | Why it may be cleaned later | Required removal gate |
+|---|---|---|
+| Older canary workflow family | Many historical canary workflows make the active path harder to see | Replacement evidence map exists and release record approves retirement |
+| Offline JSON canary workflow | Non-canonical path can be confused with canonical evidence | Legacy fallback policy is finalized and references are updated |
+| First canary workflow family | Superseded by Docker/Codex selected-prompt task-packet evidence | Historical evidence remains linked from docs and run records |
+
+## Removal gate for workflows
+
+A workflow removal PR must state:
+
+```text
+Evidence role:
+Canonical or legacy role:
+Generated snapshot ownership:
+Replacement path:
+Affected docs:
+Affected contract tests:
+Rollback path:
+```
+
+A workflow should not be removed if any public doc still lists it as required active evidence.
+
+## Current safe next actions
+
+The next safe cleanup work is:
+
+```text
+1. Add explicit legacy fallback comments to scripts/openai_lab_run.py.
+2. Add doc-drift checks for canonical runner status across README, operator runbook, weekly automation, and evidence guide.
+3. Consolidate duplicate status wording only after the drift checks are present.
+4. Defer workflow deletion until a release readiness record approves it.
+```

--- a/scripts/test_script_check_workflow_contract.py
+++ b/scripts/test_script_check_workflow_contract.py
@@ -15,6 +15,7 @@ REQUIRED_TEXT = [
     "docs/canonical-runner-evidence-guide.md",
     "docs/repository-5s-and-language-policy.md",
     "docs/repository-cleanup-inventory.md",
+    "docs/workflow-family-map.md",
     "docs/operator-runbook.md",
     "docs/weekly-automation.md",
     ".github/workflows/codex-selected-prompt-run.yml",
@@ -30,6 +31,8 @@ REQUIRED_TEXT = [
     "python scripts/test_repository_language_policy.py",
     "Run repository cleanup inventory test",
     "python scripts/test_repository_cleanup_inventory.py",
+    "Run workflow family map test",
+    "python scripts/test_workflow_family_map.py",
     "Run weekly operator docs test",
     "python scripts/test_weekly_operator_docs.py",
     "Run comparison dashboard builder test",
@@ -106,8 +109,11 @@ def main() -> int:
     if text.index("docs/repository-5s-and-language-policy.md") > text.index("docs/repository-cleanup-inventory.md"):
         raise SystemExit("repository cleanup inventory should be tracked after the repository 5S language policy")
 
-    if text.index("docs/repository-cleanup-inventory.md") > text.index("docs/operator-runbook.md"):
-        raise SystemExit("operator runbook should be tracked after the repository cleanup inventory")
+    if text.index("docs/repository-cleanup-inventory.md") > text.index("docs/workflow-family-map.md"):
+        raise SystemExit("workflow family map should be tracked after the repository cleanup inventory")
+
+    if text.index("docs/workflow-family-map.md") > text.index("docs/operator-runbook.md"):
+        raise SystemExit("operator runbook should be tracked after the workflow family map")
 
     if text.index("docs/operator-runbook.md") > text.index("docs/weekly-automation.md"):
         raise SystemExit("weekly automation doc should be tracked after the operator runbook")
@@ -121,8 +127,11 @@ def main() -> int:
     if text.index("Run repository language policy test") > text.index("Run repository cleanup inventory test"):
         raise SystemExit("Repository cleanup inventory test should run after the repository language policy test")
 
-    if text.index("Run repository cleanup inventory test") > text.index("Run weekly operator docs test"):
-        raise SystemExit("Weekly operator docs test should run after the repository cleanup inventory test")
+    if text.index("Run repository cleanup inventory test") > text.index("Run workflow family map test"):
+        raise SystemExit("Workflow family map test should run after the repository cleanup inventory test")
+
+    if text.index("Run workflow family map test") > text.index("Run weekly operator docs test"):
+        raise SystemExit("Weekly operator docs test should run after the workflow family map test")
 
     if text.index("Run weekly operator docs test") > text.index("Run usable experiment ops doc test"):
         raise SystemExit("Usable experiment ops doc test should run after the weekly operator docs test")

--- a/scripts/test_workflow_family_map.py
+++ b/scripts/test_workflow_family_map.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "workflow-family-map.md"
+README = ROOT / "docs" / "README.md"
+INVENTORY = ROOT / "docs" / "repository-cleanup-inventory.md"
+
+REQUIRED_DOC_TEXT = [
+    "# Workflow family map",
+    "It is not a removal plan.",
+    "Canonical active",
+    "Weekly active",
+    "Public generated snapshot",
+    "Safety gate",
+    "Canary evidence",
+    "Legacy fallback",
+    "Test and guard",
+    "Cleanup candidate",
+    ".github/workflows/codex-selected-prompt-run.yml",
+    ".github/workflows/weekly-auto-run.yml",
+    "Runner: codex-cli-selected-prompt-packet-container",
+    "Canonical selected-prompt runner: true",
+    ".github/workflows/support-unlock-export.yml",
+    ".github/workflows/public-results-export.yml",
+    ".github/workflows/issue-safety-scan.yml",
+    ".github/workflows/script-check.yml",
+    ".github/workflows/codex-first-canary-run.yml",
+    ".github/workflows/codex-policy-agent-canary-run.yml",
+    ".github/workflows/codex-task-packet-canary-run.yml",
+    ".github/workflows/codex-fixed-issue-instruction-canary-run.yml",
+    "scripts/openai_lab_run.py",
+    "It is non-canonical.",
+    "These are candidates for future consolidation. They are not deletion instructions.",
+    "A workflow removal PR must state:",
+    "Evidence role:",
+    "Canonical or legacy role:",
+    "Generated snapshot ownership:",
+    "Replacement path:",
+    "Affected docs:",
+    "Affected contract tests:",
+    "Rollback path:",
+    "Defer workflow deletion until a release readiness record approves it.",
+]
+
+REQUIRED_INVENTORY_TEXT = [
+    "Add a workflow-family map",
+    "Avoid deleting evidence or fallback code until a release gate is recorded.",
+]
+
+FORBIDDEN_DOC_TEXT = [
+    "delete immediately",
+    "remove immediately",
+    "safe to delete now",
+    "auto-delete",
+    "bulk delete",
+    "remove all canary workflows",
+]
+
+
+def require_all(text: str, required: list[str], label: str) -> None:
+    missing = [item for item in required if item not in text]
+    if missing:
+        raise SystemExit(f"Missing {label} text: {missing}")
+
+
+def reject_all(text: str, forbidden: list[str], label: str) -> None:
+    lowered = text.lower()
+    found = [item for item in forbidden if item.lower() in lowered]
+    if found:
+        raise SystemExit(f"Forbidden {label} text found: {found}")
+
+
+def main() -> int:
+    doc = DOC.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    inventory = INVENTORY.read_text(encoding="utf-8")
+
+    require_all(doc, REQUIRED_DOC_TEXT, "workflow family map")
+    reject_all(doc, FORBIDDEN_DOC_TEXT, "workflow family map")
+    require_all(inventory, REQUIRED_INVENTORY_TEXT, "repository cleanup inventory")
+    require_all(readme, ["Repository cleanup inventory"], "docs README")
+
+    if doc.index("## Canonical active workflows") > doc.index("## Weekly active workflows"):
+        raise SystemExit("canonical workflows should be listed before weekly active workflows")
+    if doc.index("## Weekly active workflows") > doc.index("## Public generated snapshot workflows"):
+        raise SystemExit("public generated snapshot workflows should follow weekly active workflows")
+    if doc.index("## Test and guard workflows") > doc.index("## Canary evidence workflows"):
+        raise SystemExit("canary evidence workflows should follow test and guard workflows")
+    if doc.index("## Cleanup candidates") > doc.index("## Removal gate for workflows"):
+        raise SystemExit("workflow removal gate should follow cleanup candidates")
+
+    print("workflow family map test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a workflow-family map before any workflow deletion or consolidation work.
- Classify workflows as canonical active, weekly active, public generated snapshot, safety gate, canary evidence, legacy fallback, test and guard, or cleanup candidate.
- Link the map from the docs index.
- Add a workflow-family map contract test.
- Register the test in Script Check and the Script Check self-contract.

## Scope
- `docs/workflow-family-map.md`
- `docs/README.md`
- `.github/workflows/script-check.yml`
- `scripts/test_workflow_family_map.py`
- `scripts/test_script_check_workflow_contract.py`

## 5S mapping
- Sorted: workflow families are classified before deletion work.
- Set in order: canonical and weekly active workflows are separated from canary evidence and cleanup candidates.
- Shined: historical scaffolding is made visible without deleting evidence-bearing workflows.
- Standardized: workflow removal PRs must state evidence role, replacement path, affected docs/tests, and rollback path.
- Sustained by: Script Check, workflow family map test, and script-check workflow contract test.

## Non-goals
- No workflow deletion.
- No workflow behavior change.
- No runner implementation change.
- No default flag change.
- No legacy fallback removal.
- No auto-merge.
- No generated snapshot edits.

## Verification expected
- Script Check
- workflow family map test
- script-check workflow contract test
- Lab PR Scope Check