### PR TITLE
Mark OpenAI lab runner as legacy fallback

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -158,6 +158,9 @@ jobs:
       - name: Run workflow family map test
         run: python scripts/test_workflow_family_map.py
 
+      - name: Run OpenAI lab runner legacy contract test
+        run: python scripts/test_openai_lab_run_legacy_contract.py
+
       - name: Run weekly operator docs test
         run: python scripts/test_weekly_operator_docs.py
 

--- a/scripts/openai_lab_run.py
+++ b/scripts/openai_lab_run.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
-"""Run a constrained Prompt Vote Lab implementation-agent attempt.
+"""Legacy non-canonical Prompt Vote Lab implementation-agent fallback.
 
-This script currently uses the OpenAI Responses API as the backend for the
-implementation agent, but the public experiment concept is an agent run:
+This script uses the OpenAI Responses API and mediated JSON full-file
+replacement. It is kept as a migration fallback while the repository moves to
+the canonical Docker/Codex selected-prompt task-packet runner.
 
-Prompt → 20-vote gate → agent PR → inherited lab state
+This script is not the canonical selected-prompt evidence path.
+
+Canonical selected-prompt evidence must come from:
+- scripts/run_codex_selected_prompt.sh
+- Runner: codex-cli-selected-prompt-packet-container
+- Canonical selected-prompt runner: true
 
 This script intentionally writes only:
 - lab/index.html
@@ -38,6 +44,8 @@ LAB_FILES = {
 
 MAX_PROMPT_CHARS = int(os.getenv("MAX_IMPLEMENTATION_PROMPT_CHARS", "120000"))
 MAX_OUTPUT_TOKENS_LIMIT = 5000
+LEGACY_RUNNER_CLASSIFICATION = "legacy-non-canonical-fallback"
+CANONICAL_SELECTED_PROMPT_RUNNER = "codex-cli-selected-prompt-packet-container"
 
 
 SCHEMA = {
@@ -107,6 +115,7 @@ def build_prompt(args: argparse.Namespace) -> str:
     prompt = "\n\n".join(
         [
             "You are the implementation agent for Prompt Vote Lab.",
+            "This is the legacy non-canonical fallback runner, not the canonical selected-prompt Docker/Codex path.",
             "Modify exactly these three lab files and return their full replacement contents as JSON.",
             "Do not create additional files. Do not use network calls, external scripts, forms, login, payment, cookies, eval, or trackers.",
             "Controlled new Function(...) is allowed only when the function body is fixed by repository code and not assembled from user input, URL data, localStorage, sessionStorage, IndexedDB, imported JSON, GitHub Issue text, or any external source.",
@@ -115,6 +124,9 @@ def build_prompt(args: argparse.Namespace) -> str:
             "This is one bounded implementation-agent attempt. Do not ask for a hidden retry or another pass.",
             "The current lab files are the inherited lab state from the main branch.",
             "## Run metadata",
+            f"runner_classification: {LEGACY_RUNNER_CLASSIFICATION}",
+            f"canonical_selected_prompt_runner: false",
+            f"canonical_runner_name: {CANONICAL_SELECTED_PROMPT_RUNNER}",
             f"week: {args.week}",
             f"candidate_rank: {args.candidate_rank}",
             f"issue_number: {args.issue_number}",
@@ -203,6 +215,9 @@ def main() -> int:
     summary = [
         f"# Implementation-agent summary for {args.week} rank {args.candidate_rank}",
         "",
+        f"- runner_classification: `{LEGACY_RUNNER_CLASSIFICATION}`",
+        "- canonical_selected_prompt_runner: false",
+        f"- canonical_runner_name: `{CANONICAL_SELECTED_PROMPT_RUNNER}`",
         f"- model: `{args.model}`",
         "- agent_attempts: 1",
         "- sdk_max_retries: 0",

--- a/scripts/test_openai_lab_run_legacy_contract.py
+++ b/scripts/test_openai_lab_run_legacy_contract.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "openai_lab_run.py"
+CURRENT_PATH_DOC = ROOT / "docs" / "current-codex-implementation-path.md"
+WORKFLOW_MAP = ROOT / "docs" / "workflow-family-map.md"
+
+REQUIRED_SCRIPT_TEXT = [
+    "Legacy non-canonical Prompt Vote Lab implementation-agent fallback.",
+    "This script is not the canonical selected-prompt evidence path.",
+    "scripts/run_codex_selected_prompt.sh",
+    "Runner: codex-cli-selected-prompt-packet-container",
+    "Canonical selected-prompt runner: true",
+    "LEGACY_RUNNER_CLASSIFICATION = \"legacy-non-canonical-fallback\"",
+    "CANONICAL_SELECTED_PROMPT_RUNNER = \"codex-cli-selected-prompt-packet-container\"",
+    "This is the legacy non-canonical fallback runner, not the canonical selected-prompt Docker/Codex path.",
+    "runner_classification: {LEGACY_RUNNER_CLASSIFICATION}",
+    "canonical_selected_prompt_runner: false",
+    "canonical_runner_name: {CANONICAL_SELECTED_PROMPT_RUNNER}",
+    "- runner_classification: `{LEGACY_RUNNER_CLASSIFICATION}`",
+    "- canonical_selected_prompt_runner: false",
+    "- canonical_runner_name: `{CANONICAL_SELECTED_PROMPT_RUNNER}`",
+    "no automatic merge",
+]
+
+FORBIDDEN_SCRIPT_TEXT = [
+    "This script is the canonical selected-prompt evidence path.",
+    "canonical_selected_prompt_runner: true",
+    "LEGACY_RUNNER_CLASSIFICATION = \"canonical\"",
+    "auto merge",
+    "automatic merge enabled",
+]
+
+REQUIRED_DOC_TEXT = [
+    "legacy `scripts/openai_lab_run.py` path remains only as a non-canonical default-off migration fallback",
+    "scripts/openai_lab_run.py",
+    "It is non-canonical.",
+]
+
+
+def require_all(text: str, required: list[str], label: str) -> None:
+    missing = [item for item in required if item not in text]
+    if missing:
+        raise SystemExit(f"Missing {label} text: {missing}")
+
+
+def reject_all(text: str, forbidden: list[str], label: str) -> None:
+    found = [item for item in forbidden if item in text]
+    if found:
+        raise SystemExit(f"Forbidden {label} text found: {found}")
+
+
+def main() -> int:
+    script = SCRIPT.read_text(encoding="utf-8")
+    current_path_doc = CURRENT_PATH_DOC.read_text(encoding="utf-8")
+    workflow_map = WORKFLOW_MAP.read_text(encoding="utf-8")
+
+    require_all(script, REQUIRED_SCRIPT_TEXT, "openai_lab_run legacy contract")
+    reject_all(script, FORBIDDEN_SCRIPT_TEXT, "openai_lab_run legacy contract")
+    require_all(current_path_doc + "\n" + workflow_map, REQUIRED_DOC_TEXT, "legacy fallback docs")
+
+    if script.index("Legacy non-canonical") > script.index("from __future__ import annotations"):
+        raise SystemExit("legacy classification should appear in the module docstring before imports")
+
+    if script.index("LEGACY_RUNNER_CLASSIFICATION") > script.index("SCHEMA ="):
+        raise SystemExit("runner classification constants should appear before schema definition")
+
+    if script.index("runner_classification: {LEGACY_RUNNER_CLASSIFICATION}") > script.index("## Selected prompt"):
+        raise SystemExit("runner classification should appear in prompt metadata before the selected prompt")
+
+    print("OpenAI lab runner legacy contract test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_openai_lab_run_legacy_contract.py
+++ b/scripts/test_openai_lab_run_legacy_contract.py
@@ -35,9 +35,10 @@ FORBIDDEN_SCRIPT_TEXT = [
 ]
 
 REQUIRED_DOC_TEXT = [
-    "legacy `scripts/openai_lab_run.py` path remains only as a non-canonical default-off migration fallback",
     "scripts/openai_lab_run.py",
-    "It is non-canonical.",
+    "non-canonical",
+    "fallback",
+    "codex-cli-selected-prompt-packet-container",
 ]
 
 
@@ -57,10 +58,11 @@ def main() -> int:
     script = SCRIPT.read_text(encoding="utf-8")
     current_path_doc = CURRENT_PATH_DOC.read_text(encoding="utf-8")
     workflow_map = WORKFLOW_MAP.read_text(encoding="utf-8")
+    docs_text = current_path_doc + "\n" + workflow_map
 
     require_all(script, REQUIRED_SCRIPT_TEXT, "openai_lab_run legacy contract")
     reject_all(script, FORBIDDEN_SCRIPT_TEXT, "openai_lab_run legacy contract")
-    require_all(current_path_doc + "\n" + workflow_map, REQUIRED_DOC_TEXT, "legacy fallback docs")
+    require_all(docs_text, REQUIRED_DOC_TEXT, "legacy fallback docs")
 
     if script.index("Legacy non-canonical") > script.index("from __future__ import annotations"):
         raise SystemExit("legacy classification should appear in the module docstring before imports")

--- a/scripts/test_script_check_workflow_contract.py
+++ b/scripts/test_script_check_workflow_contract.py
@@ -33,6 +33,8 @@ REQUIRED_TEXT = [
     "python scripts/test_repository_cleanup_inventory.py",
     "Run workflow family map test",
     "python scripts/test_workflow_family_map.py",
+    "Run OpenAI lab runner legacy contract test",
+    "python scripts/test_openai_lab_run_legacy_contract.py",
     "Run weekly operator docs test",
     "python scripts/test_weekly_operator_docs.py",
     "Run comparison dashboard builder test",
@@ -130,8 +132,11 @@ def main() -> int:
     if text.index("Run repository cleanup inventory test") > text.index("Run workflow family map test"):
         raise SystemExit("Workflow family map test should run after the repository cleanup inventory test")
 
-    if text.index("Run workflow family map test") > text.index("Run weekly operator docs test"):
-        raise SystemExit("Weekly operator docs test should run after the workflow family map test")
+    if text.index("Run workflow family map test") > text.index("Run OpenAI lab runner legacy contract test"):
+        raise SystemExit("OpenAI lab runner legacy contract test should run after the workflow family map test")
+
+    if text.index("Run OpenAI lab runner legacy contract test") > text.index("Run weekly operator docs test"):
+        raise SystemExit("Weekly operator docs test should run after the OpenAI lab runner legacy contract test")
 
     if text.index("Run weekly operator docs test") > text.index("Run usable experiment ops doc test"):
         raise SystemExit("Usable experiment ops doc test should run after the weekly operator docs test")


### PR DESCRIPTION
## Summary
- Mark `scripts/openai_lab_run.py` as a legacy non-canonical migration fallback in code.
- Add explicit runner classification metadata to the legacy prompt and summary output.
- Add a contract test that prevents the legacy runner from being presented as canonical selected-prompt evidence.
- Register the contract test in Script Check and the Script Check self-contract.

## Scope
- `scripts/openai_lab_run.py`
- `scripts/test_openai_lab_run_legacy_contract.py`
- `.github/workflows/script-check.yml`
- `scripts/test_script_check_workflow_contract.py`

## 5S mapping
- Sorted: legacy fallback is separated from canonical selected-prompt runner code.
- Set in order: the script itself now names the canonical runner that supersedes it.
- Shined: ambiguous implementation-agent wording is made explicit.
- Standardized: legacy/non-canonical metadata is written into prompt and summary text.
- Sustained by: OpenAI lab runner legacy contract test and Script Check.

## Non-goals
- No runner deletion.
- No workflow behavior change.
- No default flag change.
- No auto-merge.
- No API call.
- No generated snapshot edit.

## Verification expected
- Script Check
- OpenAI lab runner legacy contract test
- script-check workflow contract test
- Lab PR Scope Check