### PR TITLE
Add canonical status drift check

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -35,6 +35,7 @@ on:
       - "docs/canary-log-policy.md"
       - "docs/current-codex-implementation-path.md"
       - "docs/canonical-runner-evidence-guide.md"
+      - "docs/canonical-status-drift-check.md"
       - "docs/repository-5s-and-language-policy.md"
       - "docs/repository-cleanup-inventory.md"
       - "docs/workflow-family-map.md"
@@ -148,6 +149,9 @@ jobs:
 
       - name: Run canonical runner evidence guide test
         run: python scripts/test_canonical_runner_evidence_guide.py
+
+      - name: Run canonical status drift test
+        run: python scripts/test_canonical_status_drift.py
 
       - name: Run repository language policy test
         run: python scripts/test_repository_language_policy.py

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,29 +12,30 @@ Prompt Vote Lab is a prompt game and experiment. Players compete by writing prom
 2. [Experiment model](./experiment-model.md) — game model and boundaries.
 3. [How to participate](./how-to-participate.md) — submit, vote, and review.
 4. [Canonical runner evidence guide](./canonical-runner-evidence-guide.md) — how to verify Docker/Codex selected-prompt evidence.
-5. [Repository 5S and language policy](./repository-5s-and-language-policy.md) — cleanup, English-only, and sustain rules.
-6. [Repository cleanup inventory](./repository-cleanup-inventory.md) — protected evidence, canonical surfaces, legacy fallbacks, generated snapshots, and cleanup candidates.
-7. [Workflow family map](./workflow-family-map.md) — canonical, weekly, generated, safety, canary, legacy, and test workflow classification.
-8. [Usable experiment operations](./usable-experiment-ops.md) — current manual canary and comparison-run operations.
-9. [Operator runbook](./operator-runbook.md) — maintainer checklist for weekly operation, failures, merge decisions, tokens, and cleanup boundaries.
-10. [Public results export](./public-results-export.md) — raw public data snapshots for participant analysis.
-11. [Public agent run bundle](./public-agent-run-bundle.md) — redacted raw agent-run evidence; summaries are not primary evidence.
-12. [Issue lifecycle](./issue-lifecycle.md) — weekly close policy; Issues are closed, not deleted.
-13. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
-14. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
-15. [Weekly automation](./weekly-automation.md) — weekly schedule, support unlock prerequisite, and E2E status.
-16. [Automation map](./automation-map.md) — workflow boundaries.
-17. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
-18. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
-19. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and pre-canary cleanup.
-20. [Fixed first canary prompt](./first-canary-prompt.md) — the only allowed first real canary prompt.
-21. [First canary readiness checklist](./first-canary-readiness.md) — final check before running the first real canary.
-22. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
-23. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
-24. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
-25. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
-26. [Report policy](./report-policy.md) — weekly report draft policy.
-27. [Pre-API freeze checklist](./pre-api-freeze.md) — gates before paid agent runs.
+5. [Canonical status drift check](./canonical-status-drift-check.md) — canonical, legacy, default-off, auto-merge, and release-gate status contract.
+6. [Repository 5S and language policy](./repository-5s-and-language-policy.md) — cleanup, English-only, and sustain rules.
+7. [Repository cleanup inventory](./repository-cleanup-inventory.md) — protected evidence, canonical surfaces, legacy fallbacks, generated snapshots, and cleanup candidates.
+8. [Workflow family map](./workflow-family-map.md) — canonical, weekly, generated, safety, canary, legacy, and test workflow classification.
+9. [Usable experiment operations](./usable-experiment-ops.md) — current manual canary and comparison-run operations.
+10. [Operator runbook](./operator-runbook.md) — maintainer checklist for weekly operation, failures, merge decisions, tokens, and cleanup boundaries.
+11. [Public results export](./public-results-export.md) — raw public data snapshots for participant analysis.
+12. [Public agent run bundle](./public-agent-run-bundle.md) — redacted raw agent-run evidence; summaries are not primary evidence.
+13. [Issue lifecycle](./issue-lifecycle.md) — weekly close policy; Issues are closed, not deleted.
+14. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
+15. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
+16. [Weekly automation](./weekly-automation.md) — weekly schedule, support unlock prerequisite, and E2E status.
+17. [Automation map](./automation-map.md) — workflow boundaries.
+18. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
+19. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
+20. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and pre-canary cleanup.
+21. [Fixed first canary prompt](./first-canary-prompt.md) — the only allowed first real canary prompt.
+22. [First canary readiness checklist](./first-canary-readiness.md) — final check before running the first real canary.
+23. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
+24. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
+25. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
+26. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
+27. [Report policy](./report-policy.md) — weekly report draft policy.
+28. [Pre-API freeze checklist](./pre-api-freeze.md) — gates before paid agent runs.
 
 ## Current reputation status
 
@@ -57,6 +58,8 @@ The [Repository 5S and language policy](./repository-5s-and-language-policy.md) 
 The [Repository cleanup inventory](./repository-cleanup-inventory.md) classifies protected evidence, canonical active surfaces, legacy fallbacks, generated snapshots, cleanup candidates, and not-yet-removable items before any deletion work.
 
 The [Workflow family map](./workflow-family-map.md) classifies workflows before consolidation or deletion work so historical scaffolding is not mistaken for active canonical evidence.
+
+The [Canonical status drift check](./canonical-status-drift-check.md) keeps canonical runner, legacy fallback, default-off, auto-merge, and release-gate wording aligned across maintainer-authored docs.
 
 Generated public result snapshots and raw external evidence are treated separately because they may contain user-provided text.
 

--- a/docs/canonical-status-drift-check.md
+++ b/docs/canonical-status-drift-check.md
@@ -1,0 +1,147 @@
+# Canonical status drift check
+
+## Purpose
+
+This document defines the repository-wide status language for the selected-prompt runner migration.
+
+It prevents documentation drift between participant docs, operator docs, workflow docs, and implementation path docs.
+
+## Stable status contract
+
+All maintainer-authored docs should preserve these facts until a later release PR deliberately changes them:
+
+```text
+canonical selected-prompt runner: Docker/Codex selected-prompt task-packet runner
+canonical runner script: scripts/run_codex_selected_prompt.sh
+canonical runner name: codex-cli-selected-prompt-packet-container
+canonical evidence marker: Canonical selected-prompt runner: true
+legacy fallback script: scripts/openai_lab_run.py
+legacy fallback status: non-canonical migration fallback
+weekly default status: default-off during migration
+weekly feature flag: PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER
+current default constant: DEFAULT_USE_CANONICAL_SELECTED_PROMPT_RUNNER=false
+auto-merge status: disabled
+manual review status: required
+final write scope: lab/index.html, lab/style.css, lab/app.js
+```
+
+## Documents covered by this drift check
+
+| Document | Required role |
+|---|---|
+| `docs/README.md` | Short public status and navigation |
+| `docs/current-codex-implementation-path.md` | Full canonical and legacy path definition |
+| `docs/canonical-runner-evidence-guide.md` | Participant/reviewer evidence decision rule |
+| `docs/weekly-automation.md` | Weekly feature flag, default, and evidence artifact status |
+| `docs/operator-runbook.md` | Maintainer operating and cleanup instructions |
+| `docs/workflow-family-map.md` | Workflow-family classification and deletion boundary |
+| `docs/repository-cleanup-inventory.md` | Cleanup protection and not-yet-removable inventory |
+
+## Non-drift rules
+
+Docs may use different wording, but they must not contradict these rules:
+
+```text
+1. Do not call scripts/openai_lab_run.py canonical.
+2. Do not imply the weekly canonical selected-prompt runner is already default-on.
+3. Do not say auto-merge is enabled.
+4. Do not omit the canonical evidence marker from evidence-facing docs.
+5. Do not treat a useful lab diff as sufficient canonical evidence.
+6. Do not describe workflow or legacy runner deletion as safe without a release gate.
+```
+
+## Required canonical evidence marker
+
+Evidence-facing docs should preserve this exact marker:
+
+```text
+Runner: codex-cli-selected-prompt-packet-container
+Canonical selected-prompt runner: true
+```
+
+Reason:
+
+```text
+Participants and maintainers need one grep-able marker that distinguishes canonical Docker/Codex selected-prompt evidence from legacy or historical runs.
+```
+
+## Required legacy fallback language
+
+Docs that mention `scripts/openai_lab_run.py` should also identify it as:
+
+```text
+non-canonical
+fallback
+legacy or migration fallback
+```
+
+Reason:
+
+```text
+The script may still exist and may still produce useful lab diffs, but those facts do not make it canonical selected-prompt evidence.
+```
+
+## Required default status language
+
+Weekly-operation docs should preserve the default-off migration state:
+
+```text
+PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER
+DEFAULT_USE_CANONICAL_SELECTED_PROMPT_RUNNER=false
+Still not default-on
+```
+
+A future default-on release PR may change this status only if it also updates:
+
+```text
+docs/weekly-automation.md
+docs/operator-runbook.md
+docs/current-codex-implementation-path.md
+docs/canonical-runner-evidence-guide.md
+docs/README.md
+scripts/test_canonical_status_drift.py
+```
+
+## Required release gate language
+
+Docs should preserve the release-gate rule:
+
+```text
+manual selected-prompt smoke: PASS
+weekly feature-flag canary with eligible candidate: PASS
+weekly diagnostics artifact: present
+weekly public bundle artifact: present
+weekly uploaded bundle verification artifact: present
+bounded lab diff: PASS
+legacy fallback documented as non-canonical
+manual review remains required
+auto-merge remains disabled
+```
+
+## Current release status
+
+Current status is:
+
+```text
+manual selected-prompt workflow: verified
+weekly canonical selected-prompt canary: verified
+canonical weekly default: not default-on
+legacy fallback: present and non-canonical
+workflow deletion: not approved
+auto-merge: disabled
+manual review: required
+```
+
+## Change discipline
+
+A PR that changes any canonical/legacy/default status should state:
+
+```text
+Status changed:
+Affected docs:
+Affected tests:
+Evidence supporting change:
+Rollback path:
+```
+
+Do not update one status document without updating the drift contract.

--- a/scripts/test_canonical_status_drift.py
+++ b/scripts/test_canonical_status_drift.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+DOCS = {
+    "readme": ROOT / "docs" / "README.md",
+    "current_path": ROOT / "docs" / "current-codex-implementation-path.md",
+    "evidence_guide": ROOT / "docs" / "canonical-runner-evidence-guide.md",
+    "weekly_automation": ROOT / "docs" / "weekly-automation.md",
+    "operator_runbook": ROOT / "docs" / "operator-runbook.md",
+    "workflow_family_map": ROOT / "docs" / "workflow-family-map.md",
+    "cleanup_inventory": ROOT / "docs" / "repository-cleanup-inventory.md",
+    "drift_check": ROOT / "docs" / "canonical-status-drift-check.md",
+}
+
+CANONICAL_MARKER = [
+    "Runner: codex-cli-selected-prompt-packet-container",
+    "Canonical selected-prompt runner: true",
+]
+
+GLOBAL_REQUIRED = [
+    "codex-cli-selected-prompt-packet-container",
+    "scripts/run_codex_selected_prompt.sh",
+]
+
+LEGACY_REQUIRED = [
+    "scripts/openai_lab_run.py",
+    "non-canonical",
+]
+
+DEFAULT_REQUIRED = [
+    "PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER",
+]
+
+FORBIDDEN_PHRASES = [
+    "scripts/openai_lab_run.py path is canonical",
+    "scripts/openai_lab_run.py is canonical",
+    "openai_lab_run.py is canonical",
+    "canonical_selected_prompt_runner: true for scripts/openai_lab_run.py",
+    "auto-merge enabled",
+    "automatic merge enabled",
+    "weekly canonical selected-prompt runner is already default-on",
+    "safe to delete legacy fallback now",
+    "remove scripts/openai_lab_run.py now",
+]
+
+
+def read_docs() -> dict[str, str]:
+    return {name: path.read_text(encoding="utf-8") for name, path in DOCS.items()}
+
+
+def require_all(text: str, required: list[str], label: str) -> None:
+    missing = [item for item in required if item not in text]
+    if missing:
+        raise SystemExit(f"Missing {label} text: {missing}")
+
+
+def reject_all(text: str, forbidden: list[str], label: str) -> None:
+    lowered = text.lower()
+    found = [item for item in forbidden if item.lower() in lowered]
+    if found:
+        raise SystemExit(f"Forbidden {label} text found: {found}")
+
+
+def require_marker_pair(text: str, label: str) -> None:
+    require_all(text, CANONICAL_MARKER, label)
+    if text.index(CANONICAL_MARKER[0]) > text.index(CANONICAL_MARKER[1]):
+        raise SystemExit(f"Canonical marker order is wrong in {label}")
+
+
+def main() -> int:
+    docs = read_docs()
+    all_text = "\n".join(docs.values())
+
+    require_all(docs["drift_check"], [
+        "# Canonical status drift check",
+        "Stable status contract",
+        "legacy fallback status: non-canonical migration fallback",
+        "weekly default status: default-off during migration",
+        "DEFAULT_USE_CANONICAL_SELECTED_PROMPT_RUNNER=false",
+        "auto-merge status: disabled",
+        "manual review status: required",
+        "Do not call scripts/openai_lab_run.py canonical.",
+        "Do not imply the weekly canonical selected-prompt runner is already default-on.",
+        "Do not say auto-merge is enabled.",
+        "Do not treat a useful lab diff as sufficient canonical evidence.",
+        "A PR that changes any canonical/legacy/default status should state:",
+    ], "canonical status drift doc")
+
+    for name in ["readme", "current_path", "evidence_guide", "weekly_automation", "operator_runbook"]:
+        require_marker_pair(docs[name], name)
+
+    for name in ["readme", "current_path", "evidence_guide", "weekly_automation", "operator_runbook", "workflow_family_map"]:
+        require_all(docs[name], LEGACY_REQUIRED, name)
+
+    for name in ["current_path", "weekly_automation", "operator_runbook", "drift_check"]:
+        require_all(docs[name], DEFAULT_REQUIRED, name)
+
+    require_all(docs["weekly_automation"], [
+        "DEFAULT_USE_CANONICAL_SELECTED_PROMPT_RUNNER=false",
+        "Still not default-on",
+        "legacy fallback documented as non-canonical",
+        "auto-merge remains disabled",
+    ], "weekly automation default status")
+
+    require_all(docs["operator_runbook"], [
+        "Still not default-on",
+        "legacy runner removal",
+        "auto-merge",
+        "Default-on means changing the repository/workflow default",
+        "Never leave the canonical weekly runner enabled unintentionally before default-on release approval.",
+    ], "operator runbook default status")
+
+    require_all(docs["current_path"], [
+        "The weekly eligible implementation workflow has a canonical selected-prompt path behind a default-off feature flag.",
+        "legacy `openai_lab_run.py` path remains available only as a non-canonical fallback",
+        "A non-canonical API/JSON run may be recorded, but it must be labeled non-canonical",
+    ], "current path migration status")
+
+    require_all(docs["evidence_guide"], [
+        "A run is not canonical merely because it produced a small valid lab diff.",
+        "If those lines are missing, treat the run as non-canonical until proven otherwise.",
+        "It does not satisfy the selected-prompt canonical runner requirement",
+        "Do not flip the weekly canonical selected-prompt runner to default-on",
+    ], "evidence guide decision status")
+
+    require_all(docs["workflow_family_map"], [
+        "It is non-canonical.",
+        "It should not be removed until the default-on release gate explicitly approves removal.",
+        "They are not deletion instructions.",
+    ], "workflow family map legacy status")
+
+    require_all(docs["cleanup_inventory"], [
+        "Not-yet-removable",
+        "scripts/openai_lab_run.py",
+        "Broad canonical selected-prompt weekly execution is default-on and verified across normal operation",
+    ], "cleanup inventory removal gate")
+
+    reject_all(all_text, FORBIDDEN_PHRASES, "canonical status docs")
+
+    print("canonical status drift test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_canonical_status_drift.py
+++ b/scripts/test_canonical_status_drift.py
@@ -21,11 +21,6 @@ CANONICAL_MARKER = [
     "Canonical selected-prompt runner: true",
 ]
 
-GLOBAL_REQUIRED = [
-    "codex-cli-selected-prompt-packet-container",
-    "scripts/run_codex_selected_prompt.sh",
-]
-
 LEGACY_REQUIRED = [
     "scripts/openai_lab_run.py",
     "non-canonical",
@@ -40,9 +35,10 @@ FORBIDDEN_PHRASES = [
     "scripts/openai_lab_run.py is canonical",
     "openai_lab_run.py is canonical",
     "canonical_selected_prompt_runner: true for scripts/openai_lab_run.py",
-    "auto-merge enabled",
-    "automatic merge enabled",
-    "weekly canonical selected-prompt runner is already default-on",
+    "auto-merge enabled for weekly runs",
+    "automatic merge enabled for implementation PRs",
+    "weekly canonical selected-prompt runner is default-on",
+    "canonical weekly default: default-on",
     "safe to delete legacy fallback now",
     "remove scripts/openai_lab_run.py now",
 ]

--- a/scripts/test_script_check_workflow_contract.py
+++ b/scripts/test_script_check_workflow_contract.py
@@ -13,6 +13,7 @@ REQUIRED_TEXT = [
     "lab/comparisons/**",
     "runs/**",
     "docs/canonical-runner-evidence-guide.md",
+    "docs/canonical-status-drift-check.md",
     "docs/repository-5s-and-language-policy.md",
     "docs/repository-cleanup-inventory.md",
     "docs/workflow-family-map.md",
@@ -27,6 +28,8 @@ REQUIRED_TEXT = [
     "python scripts/test_current_codex_path_doc.py",
     "Run canonical runner evidence guide test",
     "python scripts/test_canonical_runner_evidence_guide.py",
+    "Run canonical status drift test",
+    "python scripts/test_canonical_status_drift.py",
     "Run repository language policy test",
     "python scripts/test_repository_language_policy.py",
     "Run repository cleanup inventory test",
@@ -105,8 +108,11 @@ def main() -> int:
     if text.index("docs/current-codex-implementation-path.md") > text.index("docs/canonical-runner-evidence-guide.md"):
         raise SystemExit("canonical runner evidence guide should be tracked near current Codex path docs")
 
-    if text.index("docs/canonical-runner-evidence-guide.md") > text.index("docs/repository-5s-and-language-policy.md"):
-        raise SystemExit("repository 5S language policy should be tracked after the canonical runner evidence guide")
+    if text.index("docs/canonical-runner-evidence-guide.md") > text.index("docs/canonical-status-drift-check.md"):
+        raise SystemExit("canonical status drift check should be tracked after the canonical runner evidence guide")
+
+    if text.index("docs/canonical-status-drift-check.md") > text.index("docs/repository-5s-and-language-policy.md"):
+        raise SystemExit("repository 5S language policy should be tracked after the canonical status drift check")
 
     if text.index("docs/repository-5s-and-language-policy.md") > text.index("docs/repository-cleanup-inventory.md"):
         raise SystemExit("repository cleanup inventory should be tracked after the repository 5S language policy")
@@ -123,8 +129,11 @@ def main() -> int:
     if text.index("Run current Codex path doc test") > text.index("Run canonical runner evidence guide test"):
         raise SystemExit("Canonical runner evidence guide test should run after the current Codex path doc test")
 
-    if text.index("Run canonical runner evidence guide test") > text.index("Run repository language policy test"):
-        raise SystemExit("Repository language policy test should run after the canonical runner evidence guide test")
+    if text.index("Run canonical runner evidence guide test") > text.index("Run canonical status drift test"):
+        raise SystemExit("Canonical status drift test should run after the canonical runner evidence guide test")
+
+    if text.index("Run canonical status drift test") > text.index("Run repository language policy test"):
+        raise SystemExit("Repository language policy test should run after the canonical status drift test")
 
     if text.index("Run repository language policy test") > text.index("Run repository cleanup inventory test"):
         raise SystemExit("Repository cleanup inventory test should run after the repository language policy test")


### PR DESCRIPTION
## Summary
- Add a canonical status drift check doc for selected-prompt runner migration language.
- Add a contract test that keeps canonical runner, legacy fallback, default-off, auto-merge, manual-review, and release-gate wording aligned across docs.
- Link the drift check from the docs index.
- Register the drift test in Script Check and the Script Check self-contract.

## Scope
- `docs/canonical-status-drift-check.md`
- `scripts/test_canonical_status_drift.py`
- `docs/README.md`
- `.github/workflows/script-check.yml`
- `scripts/test_script_check_workflow_contract.py`

## 5S mapping
- Sorted: canonical, legacy, default, auto-merge, manual review, and release-gate status are separated into a single status contract.
- Set in order: evidence-facing docs must preserve the canonical marker and legacy fallback classification.
- Shined: doc drift becomes visible as a CI failure.
- Standardized: future status-changing PRs must update affected docs and tests together.
- Sustained by: Script Check, canonical status drift test, and script-check workflow contract test.

## Non-goals
- No runner behavior change.
- No workflow default change.
- No workflow deletion.
- No legacy fallback removal.
- No auto-merge.
- No API call.
- No generated snapshot edit.

## Verification expected
- Script Check
- canonical status drift test
- script-check workflow contract test
- Lab PR Scope Check