### PR TITLE
Consolidate canonical status doc sources

### DIFF
--- a/docs/canonical-status-drift-check.md
+++ b/docs/canonical-status-drift-check.md
@@ -25,6 +25,21 @@ manual review status: required
 final write scope: lab/index.html, lab/style.css, lab/app.js
 ```
 
+## Source-of-truth map
+
+Use this map before adding or editing status text.
+
+| Topic | Source of truth | Pointer docs |
+|---|---|---|
+| Repository-wide canonical, legacy, default-off, auto-merge, manual-review, and release-gate status | `docs/canonical-status-drift-check.md` | `docs/README.md`, `docs/weekly-automation.md`, `docs/operator-runbook.md` |
+| Technical implementation boundary | `docs/current-codex-implementation-path.md` | `docs/canonical-runner-evidence-guide.md`, `docs/workflow-family-map.md` |
+| Participant/reviewer evidence decision rule | `docs/canonical-runner-evidence-guide.md` | `docs/README.md`, `docs/operator-runbook.md`, `docs/weekly-automation.md` |
+| Weekly workflow operation | `docs/weekly-automation.md` | `docs/operator-runbook.md` |
+| Maintainer operating procedure and stop rules | `docs/operator-runbook.md` | `docs/README.md` |
+| Cleanup and deletion boundaries | `docs/repository-cleanup-inventory.md`, `docs/workflow-family-map.md` | `docs/README.md`, `docs/operator-runbook.md` |
+
+Pointer docs may summarize status, but they should not become a second source of truth for release-gate wording.
+
 ## Documents covered by this drift check
 
 | Document | Required role |

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -4,6 +4,8 @@ This runbook is for maintainers operating Prompt Vote Lab.
 
 It describes what to check, what to merge, what to stop, and what must never be automated.
 
+Repository-wide canonical, legacy, default-off, auto-merge, manual-review, and release-gate status is governed by [Canonical status drift check](./canonical-status-drift-check.md). This runbook is the operating procedure, not a second status source of truth.
+
 ## Current production status
 
 Verified live paths:

--- a/docs/weekly-automation.md
+++ b/docs/weekly-automation.md
@@ -2,6 +2,8 @@
 
 This document explains what runs automatically, when it runs, and what must exist before each weekly run can proceed.
 
+Repository-wide canonical, legacy, default-off, auto-merge, manual-review, and release-gate status is governed by [Canonical status drift check](./canonical-status-drift-check.md). This page is the weekly workflow operation detail, not a second status source of truth.
+
 ## Short answer
 
 Yes. `Weekly Auto Run` is scheduled to run every week.

--- a/scripts/test_canonical_status_drift.py
+++ b/scripts/test_canonical_status_drift.py
@@ -74,6 +74,14 @@ def main() -> int:
     require_all(docs["drift_check"], [
         "# Canonical status drift check",
         "Stable status contract",
+        "## Source-of-truth map",
+        "Repository-wide canonical, legacy, default-off, auto-merge, manual-review, and release-gate status",
+        "Technical implementation boundary",
+        "Participant/reviewer evidence decision rule",
+        "Weekly workflow operation",
+        "Maintainer operating procedure and stop rules",
+        "Cleanup and deletion boundaries",
+        "Pointer docs may summarize status, but they should not become a second source of truth for release-gate wording.",
         "legacy fallback status: non-canonical migration fallback",
         "weekly default status: default-off during migration",
         "DEFAULT_USE_CANONICAL_SELECTED_PROMPT_RUNNER=false",
@@ -85,6 +93,16 @@ def main() -> int:
         "Do not treat a useful lab diff as sufficient canonical evidence.",
         "A PR that changes any canonical/legacy/default status should state:",
     ], "canonical status drift doc")
+
+    require_all(docs["weekly_automation"], [
+        "Repository-wide canonical, legacy, default-off, auto-merge, manual-review, and release-gate status is governed by [Canonical status drift check](./canonical-status-drift-check.md).",
+        "This page is the weekly workflow operation detail, not a second status source of truth.",
+    ], "weekly automation status source pointer")
+
+    require_all(docs["operator_runbook"], [
+        "Repository-wide canonical, legacy, default-off, auto-merge, manual-review, and release-gate status is governed by [Canonical status drift check](./canonical-status-drift-check.md).",
+        "This runbook is the operating procedure, not a second status source of truth.",
+    ], "operator runbook status source pointer")
 
     for name in ["readme", "current_path", "evidence_guide", "weekly_automation", "operator_runbook"]:
         require_marker_pair(docs[name], name)


### PR DESCRIPTION
## Summary
- Add a source-of-truth map to the canonical status drift check.
- Mark weekly automation and operator runbook as pointer/operation docs, not second status sources of truth.
- Extend the canonical status drift contract test to require those source-of-truth pointers.

## Scope
- `docs/canonical-status-drift-check.md`
- `docs/weekly-automation.md`
- `docs/operator-runbook.md`
- `scripts/test_canonical_status_drift.py`

## 5S mapping
- Sorted: repository-wide status ownership is separated from workflow operation and maintainer procedure.
- Set in order: canonical status drift check owns status; weekly automation owns workflow operation; operator runbook owns maintainer procedure.
- Shined: duplicate status-source ambiguity becomes visible.
- Standardized: pointer docs may summarize status, but must not become a second release-gate source of truth.
- Sustained by: canonical status drift test and Script Check.

## Non-goals
- No runner behavior change.
- No workflow default change.
- No workflow deletion.
- No legacy fallback removal.
- No auto-merge.
- No API call.
- No generated snapshot edit.

## Verification expected
- Script Check
- canonical status drift test
- weekly operator docs test
- Lab PR Scope Check