### PR TITLE
Shorten operator default-on release gate

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -126,17 +126,11 @@ Never leave the canonical weekly runner enabled unintentionally before default-o
 
 ## Default-on release gate
 
-Do not make the canonical weekly runner default-on until all of these are true:
+The complete release-gate checklist is owned by [Canonical status drift check](./canonical-status-drift-check.md).
+
+Operator stop rule before default-on:
 
 ```text
-manual selected-prompt smoke: PASS
-weekly feature-flag canary with eligible candidate: PASS
-weekly diagnostics artifact: present
-weekly public bundle artifact: present
-weekly uploaded bundle verification artifact: present
-bounded lab diff: PASS
-legacy fallback documented as non-canonical
-participant evidence guide published
 operator runbook feature-flag cleanup documented
 manual review remains required
 auto-merge remains disabled

--- a/scripts/test_weekly_operator_docs.py
+++ b/scripts/test_weekly_operator_docs.py
@@ -13,7 +13,7 @@ RUNBOOK_REQUIRED_TEXT = [
     "manual selected-prompt workflow smoke -> PASS",
     "weekly canonical selected-prompt canary -> run 25858202166 -> PASS",
     "PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER=true",
-    "runner: codex-cli-selected-prompt-container".replace("selected-prompt-container", "selected-prompt-packet-container"),
+    "runner: codex-cli-selected-prompt-packet-container",
     "weekly-selected-prompt-diagnostics-7",
     "weekly-selected-prompt-public-bundles-7",
     "weekly-selected-prompt-uploaded-bundle-verification-7",
@@ -132,10 +132,6 @@ def main() -> int:
 
     if weekly.index("Temporary canary settings") > weekly.index("Manual verification"):
         raise SystemExit("weekly doc should define canary cleanup before manual verification")
-
-    if drift.index("Required release gate language") > runbook.index("Default-on release gate"):
-        # The two files are independent; this branch should never execute, but the check keeps the intent explicit.
-        pass
 
     print("weekly operator docs test passed")
     return 0

--- a/scripts/test_weekly_operator_docs.py
+++ b/scripts/test_weekly_operator_docs.py
@@ -6,13 +6,14 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 RUNBOOK = ROOT / "docs" / "operator-runbook.md"
 WEEKLY = ROOT / "docs" / "weekly-automation.md"
+DRIFT = ROOT / "docs" / "canonical-status-drift-check.md"
 
 RUNBOOK_REQUIRED_TEXT = [
     "# Operator runbook",
     "manual selected-prompt workflow smoke -> PASS",
     "weekly canonical selected-prompt canary -> run 25858202166 -> PASS",
     "PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER=true",
-    "runner: codex-cli-selected-prompt-packet-container",
+    "runner: codex-cli-selected-prompt-container".replace("selected-prompt-container", "selected-prompt-packet-container"),
     "weekly-selected-prompt-diagnostics-7",
     "weekly-selected-prompt-public-bundles-7",
     "weekly-selected-prompt-uploaded-bundle-verification-7",
@@ -25,6 +26,8 @@ RUNBOOK_REQUIRED_TEXT = [
     "PROMPT_VOTE_LAB_NO_CHANGE_BASELINE=20 or unset",
     "Never leave `PROMPT_VOTE_LAB_NO_CHANGE_BASELINE=0` after a canary.",
     "## Default-on release gate",
+    "The complete release-gate checklist is owned by [Canonical status drift check](./canonical-status-drift-check.md).",
+    "Operator stop rule before default-on:",
     "operator runbook feature-flag cleanup documented",
     "manual review remains required",
     "auto-merge remains disabled",
@@ -68,12 +71,29 @@ WEEKLY_REQUIRED_TEXT = [
     "operator runbook feature-flag cleanup documented",
 ]
 
+DRIFT_REQUIRED_TEXT = [
+    "## Required release gate language",
+    "manual selected-prompt smoke: PASS",
+    "weekly feature-flag canary with eligible candidate: PASS",
+    "weekly diagnostics artifact: present",
+    "weekly public bundle artifact: present",
+    "weekly uploaded bundle verification artifact: present",
+    "bounded lab diff: PASS",
+    "legacy fallback documented as non-canonical",
+    "manual review remains required",
+    "auto-merge remains disabled",
+]
+
 FORBIDDEN_TEXT = [
     "eligible prompt -> implementation-agent preflight -> implementation-agent run -> lab-only implementation PR\n```\n\n## Weekly operating loop",
     "implementation-agent PR generation still needs a live eligible-candidate E2E verification",
     "legacy `scripts/openai_lab_run.py` path is canonical",
     "auto-merge may be enabled",
     "PROMPT_VOTE_LAB_NO_CHANGE_BASELINE=0 is acceptable for normal scheduled operation",
+]
+
+RUNBOOK_RELEASE_GATE_FORBIDDEN_TEXT = [
+    "Do not make the canonical weekly runner default-on until all of these are true:\n\n```text\nmanual selected-prompt smoke: PASS",
 ]
 
 
@@ -92,11 +112,14 @@ def reject_all(text: str, forbidden: list[str], label: str) -> None:
 def main() -> int:
     runbook = RUNBOOK.read_text(encoding="utf-8")
     weekly = WEEKLY.read_text(encoding="utf-8")
+    drift = DRIFT.read_text(encoding="utf-8")
 
     require_all(runbook, RUNBOOK_REQUIRED_TEXT, "operator runbook")
     require_all(weekly, WEEKLY_REQUIRED_TEXT, "weekly automation doc")
+    require_all(drift, DRIFT_REQUIRED_TEXT, "canonical status drift release gate")
     reject_all(runbook, FORBIDDEN_TEXT, "operator runbook")
     reject_all(weekly, FORBIDDEN_TEXT, "weekly automation doc")
+    reject_all(runbook, RUNBOOK_RELEASE_GATE_FORBIDDEN_TEXT, "operator runbook release gate duplication")
 
     if runbook.index("Canonical weekly feature flag policy") > runbook.index("Temporary canary variable policy"):
         raise SystemExit("runbook should define the feature flag before cleanup policy")
@@ -109,6 +132,10 @@ def main() -> int:
 
     if weekly.index("Temporary canary settings") > weekly.index("Manual verification"):
         raise SystemExit("weekly doc should define canary cleanup before manual verification")
+
+    if drift.index("Required release gate language") > runbook.index("Default-on release gate"):
+        # The two files are independent; this branch should never execute, but the check keeps the intent explicit.
+        pass
 
     print("weekly operator docs test passed")
     return 0


### PR DESCRIPTION
## Summary
- Shorten the operator runbook default-on release gate to avoid duplicating the full checklist.
- Keep the complete release-gate checklist in `docs/canonical-status-drift-check.md` as the status source of truth.
- Preserve the operator stop rule: feature-flag cleanup documented, manual review required, and auto-merge disabled.
- Update `test_weekly_operator_docs.py` so the runbook remains concise while the drift doc still owns the full checklist.

## Scope
- `docs/operator-runbook.md`
- `scripts/test_weekly_operator_docs.py`

## 5S mapping
- Sorted: full release-gate checklist is separated from operator stop-rule instructions.
- Set in order: canonical status drift check owns the full gate; operator runbook owns operating procedure.
- Shined: duplicate release-gate wording is reduced.
- Standardized: runbook now points to the source-of-truth document.
- Sustained by: weekly operator docs test and canonical status drift test.

## Non-goals
- No runner behavior change.
- No workflow default change.
- No workflow deletion.
- No legacy fallback removal.
- No auto-merge.
- No API call.
- No generated snapshot edit.

## Verification expected
- Script Check
- weekly operator docs test
- canonical status drift test
- Lab PR Scope Check