### PR TITLE
Shorten weekly default-on release gate

### DIFF
--- a/docs/canonical-status-drift-check.md
+++ b/docs/canonical-status-drift-check.md
@@ -129,6 +129,7 @@ weekly public bundle artifact: present
 weekly uploaded bundle verification artifact: present
 bounded lab diff: PASS
 legacy fallback documented as non-canonical
+operator runbook feature-flag cleanup documented
 manual review remains required
 auto-merge remains disabled
 ```

--- a/docs/weekly-automation.md
+++ b/docs/weekly-automation.md
@@ -262,18 +262,16 @@ Automation may create PRs, but it must not merge them.
 
 ## Default-on release gate
 
-Do not make the canonical selected-prompt runner the weekly default until all of these remain true:
+The complete release-gate checklist is owned by [Canonical status drift check](./canonical-status-drift-check.md).
+
+Weekly workflow stop rule before default-on:
 
 ```text
-manual selected-prompt smoke: PASS
 weekly feature-flag canary with eligible candidate: PASS
 weekly diagnostics artifact: present
 weekly public bundle artifact: present
 weekly uploaded bundle verification artifact: present
 bounded lab diff: PASS
-legacy fallback documented as non-canonical
-participant evidence guide published
-operator runbook feature-flag cleanup documented
 manual review remains required
 auto-merge remains disabled
 ```

--- a/scripts/test_canonical_status_drift.py
+++ b/scripts/test_canonical_status_drift.py
@@ -91,6 +91,9 @@ def main() -> int:
         "Do not imply the weekly canonical selected-prompt runner is already default-on.",
         "Do not say auto-merge is enabled.",
         "Do not treat a useful lab diff as sufficient canonical evidence.",
+        "## Required release gate language",
+        "legacy fallback documented as non-canonical",
+        "operator runbook feature-flag cleanup documented",
         "A PR that changes any canonical/legacy/default status should state:",
     ], "canonical status drift doc")
 
@@ -116,7 +119,13 @@ def main() -> int:
     require_all(docs["weekly_automation"], [
         "DEFAULT_USE_CANONICAL_SELECTED_PROMPT_RUNNER=false",
         "Still not default-on",
-        "legacy fallback documented as non-canonical",
+        "The complete release-gate checklist is owned by [Canonical status drift check](./canonical-status-drift-check.md).",
+        "Weekly workflow stop rule before default-on:",
+        "weekly feature-flag canary with eligible candidate: PASS",
+        "weekly diagnostics artifact: present",
+        "weekly public bundle artifact: present",
+        "weekly uploaded bundle verification artifact: present",
+        "bounded lab diff: PASS",
         "auto-merge remains disabled",
     ], "weekly automation default status")
 

--- a/scripts/test_weekly_operator_docs.py
+++ b/scripts/test_weekly_operator_docs.py
@@ -68,7 +68,15 @@ WEEKLY_REQUIRED_TEXT = [
     "bounded lab diff: PASS",
     "auto-merge: disabled",
     "## Default-on release gate",
-    "operator runbook feature-flag cleanup documented",
+    "The complete release-gate checklist is owned by [Canonical status drift check](./canonical-status-drift-check.md).",
+    "Weekly workflow stop rule before default-on:",
+    "weekly feature-flag canary with eligible candidate: PASS",
+    "weekly diagnostics artifact: present",
+    "weekly public bundle artifact: present",
+    "weekly uploaded bundle verification artifact: present",
+    "bounded lab diff: PASS",
+    "manual review remains required",
+    "auto-merge remains disabled",
 ]
 
 DRIFT_REQUIRED_TEXT = [
@@ -96,6 +104,11 @@ RUNBOOK_RELEASE_GATE_FORBIDDEN_TEXT = [
     "Do not make the canonical weekly runner default-on until all of these are true:\n\n```text\nmanual selected-prompt smoke: PASS",
 ]
 
+WEEKLY_RELEASE_GATE_FORBIDDEN_TEXT = [
+    "Do not make the canonical selected-prompt runner the weekly default until all of these remain true:\n\n```text\nmanual selected-prompt smoke: PASS",
+    "participant evidence guide published\noperator runbook feature-flag cleanup documented",
+]
+
 
 def require_all(text: str, required: list[str], label: str) -> None:
     missing = [item for item in required if item not in text]
@@ -120,6 +133,7 @@ def main() -> int:
     reject_all(runbook, FORBIDDEN_TEXT, "operator runbook")
     reject_all(weekly, FORBIDDEN_TEXT, "weekly automation doc")
     reject_all(runbook, RUNBOOK_RELEASE_GATE_FORBIDDEN_TEXT, "operator runbook release gate duplication")
+    reject_all(weekly, WEEKLY_RELEASE_GATE_FORBIDDEN_TEXT, "weekly automation release gate duplication")
 
     if runbook.index("Canonical weekly feature flag policy") > runbook.index("Temporary canary variable policy"):
         raise SystemExit("runbook should define the feature flag before cleanup policy")
@@ -132,6 +146,9 @@ def main() -> int:
 
     if weekly.index("Temporary canary settings") > weekly.index("Manual verification"):
         raise SystemExit("weekly doc should define canary cleanup before manual verification")
+
+    if weekly.index("Merge policy") > weekly.index("Default-on release gate"):
+        raise SystemExit("weekly merge policy should precede the default-on gate")
 
     print("weekly operator docs test passed")
     return 0


### PR DESCRIPTION
## Summary
- Shorten the weekly automation default-on release gate to avoid duplicating the full checklist.
- Keep the complete release-gate checklist in `docs/canonical-status-drift-check.md` as the status source of truth.
- Preserve the weekly workflow stop rule: canary pass, diagnostics/public bundle/uploaded verification present, bounded lab diff pass, manual review required, and auto-merge disabled.
- Update `test_weekly_operator_docs.py` so weekly automation remains concise while the drift doc owns the full checklist.

## Scope
- `docs/weekly-automation.md`
- `scripts/test_weekly_operator_docs.py`

## 5S mapping
- Sorted: full release-gate checklist is separated from weekly workflow stop-rule instructions.
- Set in order: canonical status drift check owns the full gate; weekly automation owns workflow operation details.
- Shined: duplicate release-gate wording is reduced.
- Standardized: weekly automation now points to the source-of-truth document.
- Sustained by: weekly operator docs test and canonical status drift test.

## Non-goals
- No runner behavior change.
- No workflow default change.
- No workflow deletion.
- No legacy fallback removal.
- No auto-merge.
- No API call.
- No generated snapshot edit.

## Verification expected
- Script Check
- weekly operator docs test
- canonical status drift test
- Lab PR Scope Check