### PR TITLE
Clarify participant support baseline docs

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -41,6 +41,9 @@ on:
       - "docs/workflow-family-map.md"
       - "docs/operator-runbook.md"
       - "docs/weekly-automation.md"
+      - "docs/for-participants.md"
+      - "docs/how-to-participate.md"
+      - "docs/no-change-baseline.md"
       - "docs/public-results-export.md"
       - "docs/public-agent-run-bundle.md"
       - "docs/issue-lifecycle.md"
@@ -167,6 +170,9 @@ jobs:
 
       - name: Run weekly operator docs test
         run: python scripts/test_weekly_operator_docs.py
+
+      - name: Run participant baseline support docs test
+        run: python scripts/test_participant_baseline_support_docs.py
 
       - name: Run usable experiment ops doc test
         run: python scripts/test_usable_experiment_ops_doc.py

--- a/docs/for-participants.md
+++ b/docs/for-participants.md
@@ -42,6 +42,22 @@ If no real prompt beats the baseline, no implementation-agent attempt is created
 
 That is not failure. It means the group preferred not to spend a bounded attempt on weak prompts.
 
+Baseline passing is decided by the weekly candidate set:
+
+```text
+baseline ranks first -> no implementation candidates
+real prompt ranks first -> baseline passed -> rank 1 is eligible
+```
+
+If the baseline is passed, support can unlock extra comparison runs:
+
+```text
+5 USD weekly support -> rank 2 can also be attempted
+10 USD weekly support -> rank 2 and rank 3 can also be attempted
+```
+
+Rank 2 and rank 3 do not independently need 20+ votes after rank 1 beats the baseline. Support does not help if the baseline ranks first.
+
 ## How to vote
 
 1. Go to the repository Issues page.
@@ -135,7 +151,7 @@ unsafe dynamic code
 
 ## What support can and cannot do
 
-Support can unlock extra comparison runs for rank 2 and rank 3 when the weekly support threshold is met.
+Support can unlock extra comparison runs for rank 2 and rank 3 when the weekly support threshold is met and the real prompt set has already beaten the no-change baseline.
 
 Support cannot buy:
 
@@ -149,7 +165,7 @@ feature control
 private request handling
 ```
 
-Support increases comparison capacity. It does not override the game.
+Support increases comparison capacity. It does not override the no-change baseline.
 
 ## Where to see results
 
@@ -192,6 +208,10 @@ Yes, to vote with reactions or create Issues.
 ### Does the most popular prompt always merge?
 
 No. Votes select candidates for bounded attempts. Merge still requires review.
+
+### Can rank 2 or rank 3 run without 20 votes?
+
+Yes, but only after a real prompt beats the no-change baseline. After that, support can unlock rank 2 or rank 3 comparison runs. If the baseline ranks first, support unlocks nothing.
 
 ### Can a failed prompt be useful?
 

--- a/docs/how-to-participate.md
+++ b/docs/how-to-participate.md
@@ -13,8 +13,8 @@ Winning attention is only the first step. A prompt still has to survive implemen
 ```text
 Submit a prompt
 → persuade other players
-→ beat the 20-vote gate
-→ receive one bounded agent attempt
+→ beat the 20-vote no-change baseline as a candidate set
+→ receive one bounded agent attempt, or support-unlocked comparison attempts
 → review the public outcome
 → update trust for the next round
 ```
@@ -92,6 +92,22 @@ Every week includes this virtual competitor:
 If no real prompt beats 20, the lab does not move that week.
 
 Doing nothing is always in the game.
+
+Baseline passing is a candidate-set rule:
+
+```text
+no-change baseline ranks first -> no implementation candidates
+real prompt ranks first -> rank 1 is eligible
+```
+
+After a real prompt ranks first, support can unlock additional comparison candidates:
+
+```text
+5 USD weekly support -> rank 2 may also receive a bounded attempt
+10 USD weekly support -> rank 2 and rank 3 may also receive bounded attempts
+```
+
+Rank 2 and rank 3 do not independently need 20+ votes after rank 1 beats the baseline. Support does not override a baseline win.
 
 ## 5. Review outcomes
 

--- a/docs/no-change-baseline.md
+++ b/docs/no-change-baseline.md
@@ -17,6 +17,13 @@ If the no-change baseline ranks first, no implementation-agent attempt is create
 
 Only real `prompt-proposal` issues can create implementation-agent attempts.
 
+Baseline passing is decided by the weekly candidate set after the baseline is inserted and candidates are sorted by votes:
+
+```text
+no-change baseline ranks first -> no implementation candidates
+real prompt ranks first -> baseline passed -> rank 1 is eligible
+```
+
 ## Why this exists
 
 The baseline makes doing nothing a competitor.
@@ -63,7 +70,48 @@ Issue #1 becomes the normal weekly implementation candidate.
 
 Support does not override the no-change baseline.
 
-Support only opens additional comparison runs among real prompt candidates that remain eligible after the baseline is inserted.
+Support only opens additional comparison runs among real prompt candidates after the weekly candidate set has passed the baseline rule.
+
+Current support interaction:
+
+```text
+baseline ranks first -> support unlocks nothing
+real prompt ranks first and support is 0 USD -> rank 1 only
+real prompt ranks first and support is at least 5 USD -> rank 1 and rank 2
+real prompt ranks first and support is at least 10 USD -> rank 1, rank 2, and rank 3
+```
+
+Rank 2 and rank 3 do not independently need 20+ votes after rank 1 beats the baseline.
+
+## Support example
+
+| Candidate | Votes | Result |
+|---|---:|---|
+| Issue #1 | 25 | rank 1, normal weekly candidate |
+| No change baseline | 20 | loses |
+| Issue #2 | 12 | rank 2, support-unlocked at 5 USD |
+| Issue #3 | 8 | rank 3, support-unlocked at 10 USD |
+
+Result at 10 USD weekly support:
+
+```text
+Issue #1, Issue #2, and Issue #3 are eligible implementation candidates.
+```
+
+## Support counterexample
+
+| Candidate | Votes | Result |
+|---|---:|---|
+| No change baseline | 20 | wins |
+| Issue #1 | 18 | not attempted |
+| Issue #2 | 12 | not attempted |
+| Issue #3 | 8 | not attempted |
+
+Result even at 10 USD weekly support:
+
+```text
+No implementation PR is created.
+```
 
 ## Reputation interaction
 

--- a/scripts/test_participant_baseline_support_docs.py
+++ b/scripts/test_participant_baseline_support_docs.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PARTICIPANT = ROOT / "docs" / "for-participants.md"
+HOW_TO = ROOT / "docs" / "how-to-participate.md"
+BASELINE = ROOT / "docs" / "no-change-baseline.md"
+SUPPORT = ROOT / "docs" / "support-policy.md"
+
+SHARED_REQUIRED_TEXT = [
+    "no-change baseline",
+    "20",
+    "rank 1",
+    "rank 2",
+    "rank 3",
+]
+
+PARTICIPANT_REQUIRED_TEXT = [
+    "baseline ranks first -> no implementation candidates",
+    "real prompt ranks first -> baseline passed -> rank 1 is eligible",
+    "5 USD weekly support -> rank 2 can also be attempted",
+    "10 USD weekly support -> rank 2 and rank 3 can also be attempted",
+    "Rank 2 and rank 3 do not independently need 20+ votes after rank 1 beats the baseline.",
+    "Support does not help if the baseline ranks first.",
+    "Support increases comparison capacity. It does not override the no-change baseline.",
+    "Can rank 2 or rank 3 run without 20 votes?",
+    "If the baseline ranks first, support unlocks nothing.",
+]
+
+HOW_TO_REQUIRED_TEXT = [
+    "beat the 20-vote no-change baseline as a candidate set",
+    "receive one bounded agent attempt, or support-unlocked comparison attempts",
+    "Baseline passing is a candidate-set rule:",
+    "no-change baseline ranks first -> no implementation candidates",
+    "real prompt ranks first -> rank 1 is eligible",
+    "5 USD weekly support -> rank 2 may also receive a bounded attempt",
+    "10 USD weekly support -> rank 2 and rank 3 may also receive bounded attempts",
+    "Rank 2 and rank 3 do not independently need 20+ votes after rank 1 beats the baseline.",
+    "Support does not override a baseline win.",
+]
+
+BASELINE_REQUIRED_TEXT = [
+    "Baseline passing is decided by the weekly candidate set after the baseline is inserted and candidates are sorted by votes:",
+    "no-change baseline ranks first -> no implementation candidates",
+    "real prompt ranks first -> baseline passed -> rank 1 is eligible",
+    "Support only opens additional comparison runs among real prompt candidates after the weekly candidate set has passed the baseline rule.",
+    "baseline ranks first -> support unlocks nothing",
+    "real prompt ranks first and support is 0 USD -> rank 1 only",
+    "real prompt ranks first and support is at least 5 USD -> rank 1 and rank 2",
+    "real prompt ranks first and support is at least 10 USD -> rank 1, rank 2, and rank 3",
+    "Rank 2 and rank 3 do not independently need 20+ votes after rank 1 beats the baseline.",
+    "Issue #1 | 25 | rank 1, normal weekly candidate",
+    "Issue #2 | 12 | rank 2, support-unlocked at 5 USD",
+    "Issue #3 | 8 | rank 3, support-unlocked at 10 USD",
+    "No change baseline | 20 | wins",
+    "No implementation PR is created.",
+]
+
+SUPPORT_REQUIRED_TEXT = [
+    "Rank 2 and rank 3 do not independently need to exceed 20 votes after the candidate set has passed the baseline rule.",
+    "Support unlocks additional comparison runs only after the prompt candidate set beats the no-change baseline.",
+]
+
+FORBIDDEN_TEXT = [
+    "Rank 2 and rank 3 must independently exceed 20 votes",
+    "rank 2 must independently exceed 20 votes",
+    "rank 3 must independently exceed 20 votes",
+    "Support overrides the no-change baseline",
+    "Support buys an implementation run when the baseline wins",
+    "If no real prompt beats 20, support can still unlock rank 2",
+]
+
+
+def require_all(text: str, required: list[str], label: str) -> None:
+    missing = [item for item in required if item not in text]
+    if missing:
+        raise SystemExit(f"Missing {label} text: {missing}")
+
+
+def reject_all(text: str, forbidden: list[str], label: str) -> None:
+    lowered = text.lower()
+    found = [item for item in forbidden if item.lower() in lowered]
+    if found:
+        raise SystemExit(f"Forbidden {label} text found: {found}")
+
+
+def main() -> int:
+    participant = PARTICIPANT.read_text(encoding="utf-8")
+    how_to = HOW_TO.read_text(encoding="utf-8")
+    baseline = BASELINE.read_text(encoding="utf-8")
+    support = SUPPORT.read_text(encoding="utf-8")
+    combined = "\n".join([participant, how_to, baseline, support])
+
+    for label, text in [
+        ("participant guide", participant),
+        ("how-to-participate", how_to),
+        ("no-change baseline", baseline),
+    ]:
+        require_all(text, SHARED_REQUIRED_TEXT, label)
+
+    require_all(participant, PARTICIPANT_REQUIRED_TEXT, "participant guide")
+    require_all(how_to, HOW_TO_REQUIRED_TEXT, "how-to-participate")
+    require_all(baseline, BASELINE_REQUIRED_TEXT, "no-change baseline")
+    require_all(support, SUPPORT_REQUIRED_TEXT, "support policy")
+    reject_all(combined, FORBIDDEN_TEXT, "participant-facing baseline/support docs")
+
+    if participant.index("Why voting matters") > participant.index("What support can and cannot do"):
+        raise SystemExit("participant guide should define voting and baseline before support")
+
+    if how_to.index("Beat the no-change baseline") > how_to.index("Review outcomes"):
+        raise SystemExit("how-to should define baseline before outcome review")
+
+    if baseline.index("## Rule") > baseline.index("## Support interaction"):
+        raise SystemExit("baseline rule should appear before support interaction")
+
+    print("participant baseline support docs test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_script_check_workflow_contract.py
+++ b/scripts/test_script_check_workflow_contract.py
@@ -19,6 +19,9 @@ REQUIRED_TEXT = [
     "docs/workflow-family-map.md",
     "docs/operator-runbook.md",
     "docs/weekly-automation.md",
+    "docs/for-participants.md",
+    "docs/how-to-participate.md",
+    "docs/no-change-baseline.md",
     ".github/workflows/codex-selected-prompt-run.yml",
     "workflow_dispatch:",
     "contents: read",
@@ -40,6 +43,8 @@ REQUIRED_TEXT = [
     "python scripts/test_openai_lab_run_legacy_contract.py",
     "Run weekly operator docs test",
     "python scripts/test_weekly_operator_docs.py",
+    "Run participant baseline support docs test",
+    "python scripts/test_participant_baseline_support_docs.py",
     "Run comparison dashboard builder test",
     "python scripts/test_build_comparison_dashboard.py",
     "Run comparison dashboard decision test",
@@ -126,6 +131,15 @@ def main() -> int:
     if text.index("docs/operator-runbook.md") > text.index("docs/weekly-automation.md"):
         raise SystemExit("weekly automation doc should be tracked after the operator runbook")
 
+    if text.index("docs/weekly-automation.md") > text.index("docs/for-participants.md"):
+        raise SystemExit("participant-facing docs should be tracked after weekly automation")
+
+    if text.index("docs/for-participants.md") > text.index("docs/how-to-participate.md"):
+        raise SystemExit("how-to-participate should be tracked after participant guide")
+
+    if text.index("docs/how-to-participate.md") > text.index("docs/no-change-baseline.md"):
+        raise SystemExit("no-change baseline should be tracked after how-to-participate")
+
     if text.index("Run current Codex path doc test") > text.index("Run canonical runner evidence guide test"):
         raise SystemExit("Canonical runner evidence guide test should run after the current Codex path doc test")
 
@@ -147,8 +161,11 @@ def main() -> int:
     if text.index("Run OpenAI lab runner legacy contract test") > text.index("Run weekly operator docs test"):
         raise SystemExit("Weekly operator docs test should run after the OpenAI lab runner legacy contract test")
 
-    if text.index("Run weekly operator docs test") > text.index("Run usable experiment ops doc test"):
-        raise SystemExit("Usable experiment ops doc test should run after the weekly operator docs test")
+    if text.index("Run weekly operator docs test") > text.index("Run participant baseline support docs test"):
+        raise SystemExit("Participant baseline support docs test should run after the weekly operator docs test")
+
+    if text.index("Run participant baseline support docs test") > text.index("Run usable experiment ops doc test"):
+        raise SystemExit("Usable experiment ops doc test should run after the participant baseline support docs test")
 
     if text.index("Run public agent run bundle enrichment test") > text.index("Run public agent run bundle verifier test"):
         raise SystemExit("Public bundle verifier test should run after enrichment test")


### PR DESCRIPTION
## Summary
- Clarify participant-facing docs for the no-change baseline and support-unlocked Rank 2/3 comparison runs.
- Explain that baseline passing is a candidate-set rule: if the baseline ranks first, no implementation candidates are eligible.
- Explain that after a real prompt ranks first, support can unlock Rank 2 and Rank 3 even if those ranks do not independently have 20+ votes.
- Add a participant-facing docs contract test and register it in Script Check.

## Scope
- `docs/for-participants.md`
- `docs/how-to-participate.md`
- `docs/no-change-baseline.md`
- `scripts/test_participant_baseline_support_docs.py`
- `.github/workflows/script-check.yml`
- `scripts/test_script_check_workflow_contract.py`

## Confirmed rule
- Baseline ranks first -> no implementation candidates, regardless of support.
- Real prompt ranks first -> Rank 1 is eligible.
- Support >= 5 USD after baseline pass -> Rank 2 may also run.
- Support >= 10 USD after baseline pass -> Rank 2 and Rank 3 may also run.
- Rank 2/3 do not independently need 20+ votes after Rank 1 beats the baseline.

## Non-goals
- No selection behavior change.
- No support threshold change.
- No workflow behavior change beyond Script Check coverage.
- No runner behavior change.
- No generated snapshot edit.
- No auto-merge.
- No API call.