### PR TITLE
Clarify lab support baseline rule

### DIFF
--- a/lab/index.html
+++ b/lab/index.html
@@ -55,6 +55,20 @@
       </div>
     </section>
 
+    <section class="summary-card" aria-labelledby="baseline-rule-title">
+      <p class="eyebrow">Selection rule</p>
+      <h2 id="baseline-rule-title">Support unlocks comparison runs only after the baseline loses.</h2>
+      <p>
+        Every week includes a virtual no-change baseline with 20 votes. If that baseline ranks first, no implementation candidate runs, even when support exists.
+      </p>
+      <ol class="review-order">
+        <li>If a real prompt ranks first, Rank 1 is eligible for the normal weekly attempt.</li>
+        <li>After that baseline pass, 5 USD weekly support can unlock Rank 2 as a comparison run.</li>
+        <li>After that baseline pass, 10 USD weekly support can unlock Rank 2 and Rank 3 as comparison runs.</li>
+        <li>Rank 2 and Rank 3 do not independently need 20+ votes after Rank 1 beats the baseline.</li>
+      </ol>
+    </section>
+
     <section class="summary-card preview-card" id="live-previews" aria-labelledby="live-preview-title">
       <p class="eyebrow">Live previews</p>
       <h2 id="live-preview-title">Open rendered pages, not source files.</h2>

--- a/scripts/lab-smoke-test.mjs
+++ b/scripts/lab-smoke-test.mjs
@@ -36,6 +36,26 @@ const checks = [
     pass: /accepted/i.test(visibleText) && /experiment runs/i.test(visibleText)
   },
   {
+    label: 'lab explains the no-change baseline has 20 votes',
+    pass: /no-change baseline/i.test(visibleText) && /20 votes/i.test(visibleText)
+  },
+  {
+    label: 'lab explains support does not override a baseline win',
+    pass: /baseline ranks first/i.test(visibleText) && /no implementation candidate/i.test(visibleText) && /even when support exists/i.test(visibleText)
+  },
+  {
+    label: 'lab explains rank 1 eligibility after baseline pass',
+    pass: /real prompt ranks first/i.test(visibleText) || /Rank 1 is eligible/i.test(visibleText)
+  },
+  {
+    label: 'lab explains support can unlock rank 2 and rank 3 comparison runs',
+    pass: /5 USD weekly support/i.test(visibleText) && /Rank 2/i.test(visibleText) && /10 USD weekly support/i.test(visibleText) && /Rank 3/i.test(visibleText)
+  },
+  {
+    label: 'lab explains rank 2 and rank 3 do not need independent 20+ votes after rank 1 beats baseline',
+    pass: /Rank 2 and Rank 3 do not independently need 20\+ votes after Rank 1 beats the baseline/i.test(visibleText)
+  },
+  {
     label: 'lab keeps a no-network expectation visible',
     pass: /without network access/i.test(visibleText) || /no network/i.test(visibleText)
   },

--- a/scripts/lab-smoke-test.mjs
+++ b/scripts/lab-smoke-test.mjs
@@ -36,26 +36,6 @@ const checks = [
     pass: /accepted/i.test(visibleText) && /experiment runs/i.test(visibleText)
   },
   {
-    label: 'lab explains the no-change baseline has 20 votes',
-    pass: /no-change baseline/i.test(visibleText) && /20 votes/i.test(visibleText)
-  },
-  {
-    label: 'lab explains support does not override a baseline win',
-    pass: /baseline ranks first/i.test(visibleText) && /no implementation candidate/i.test(visibleText) && /even when support exists/i.test(visibleText)
-  },
-  {
-    label: 'lab explains rank 1 eligibility after baseline pass',
-    pass: /real prompt ranks first/i.test(visibleText) || /Rank 1 is eligible/i.test(visibleText)
-  },
-  {
-    label: 'lab explains support can unlock rank 2 and rank 3 comparison runs',
-    pass: /5 USD weekly support/i.test(visibleText) && /Rank 2/i.test(visibleText) && /10 USD weekly support/i.test(visibleText) && /Rank 3/i.test(visibleText)
-  },
-  {
-    label: 'lab explains rank 2 and rank 3 do not need independent 20+ votes after rank 1 beats baseline',
-    pass: /Rank 2 and Rank 3 do not independently need 20\+ votes after Rank 1 beats the baseline/i.test(visibleText)
-  },
-  {
     label: 'lab keeps a no-network expectation visible',
     pass: /without network access/i.test(visibleText) || /no network/i.test(visibleText)
   },


### PR DESCRIPTION
## Summary
- Add a visible lab-page explanation for the no-change baseline and support-unlocked Rank 2/3 comparison runs.
- Clarify that support unlocks comparison runs only after the baseline loses.
- Clarify that Rank 2/3 do not independently need 20+ votes after Rank 1 beats the baseline.

## Scope
- `lab/index.html`

## Confirmed rule shown in UI
- No-change baseline has 20 votes.
- If baseline ranks first, no implementation candidate runs, even when support exists.
- If a real prompt ranks first, Rank 1 is eligible.
- After baseline pass, 5 USD weekly support can unlock Rank 2.
- After baseline pass, 10 USD weekly support can unlock Rank 2 and Rank 3.
- Rank 2/3 do not independently need 20+ votes after Rank 1 beats the baseline.

## Non-goals
- No selection behavior change.
- No support threshold change.
- No workflow behavior change.
- No test or script change in this PR.
- No runner behavior change.
- No generated snapshot edit.
- No auto-merge.
- No API call.