### PR TITLE
Require lab support baseline explanation in smoke test

### DIFF
--- a/scripts/lab-smoke-test.mjs
+++ b/scripts/lab-smoke-test.mjs
@@ -39,6 +39,7 @@ const checks = [
     label: 'lab keeps a no-network expectation visible',
     pass: /without network access/i.test(visibleText) || /no network/i.test(visibleText)
   },
+  // Protect the participant-facing baseline/support selection rule shown in lab/index.html.
   {
     label: 'lab explains the no-change baseline has 20 votes',
     pass: /no-change baseline/i.test(visibleText) && /20 votes/i.test(visibleText)

--- a/scripts/lab-smoke-test.mjs
+++ b/scripts/lab-smoke-test.mjs
@@ -40,6 +40,26 @@ const checks = [
     pass: /without network access/i.test(visibleText) || /no network/i.test(visibleText)
   },
   {
+    label: 'lab explains the no-change baseline has 20 votes',
+    pass: /no-change baseline/i.test(visibleText) && /20 votes/i.test(visibleText)
+  },
+  {
+    label: 'lab explains support does not override a baseline win',
+    pass: /baseline ranks first/i.test(visibleText) && /no implementation candidate/i.test(visibleText) && /even when support exists/i.test(visibleText)
+  },
+  {
+    label: 'lab explains rank 1 eligibility after baseline pass',
+    pass: /real prompt ranks first/i.test(visibleText) && /Rank 1 is eligible/i.test(visibleText)
+  },
+  {
+    label: 'lab explains support can unlock rank 2 and rank 3 comparison runs',
+    pass: /5 USD weekly support/i.test(visibleText) && /Rank 2/i.test(visibleText) && /10 USD weekly support/i.test(visibleText) && /Rank 3/i.test(visibleText)
+  },
+  {
+    label: 'lab explains rank 2 and rank 3 do not need independent 20+ votes after rank 1 beats baseline',
+    pass: /Rank 2 and Rank 3 do not independently need 20\+ votes after Rank 1 beats the baseline/i.test(visibleText)
+  },
+  {
     label: 'lab has Content-Security-Policy with connect-src none',
     pass: /Content-Security-Policy/i.test(html) && /connect-src 'none'/i.test(html)
   },


### PR DESCRIPTION
## Summary
- Extend `scripts/lab-smoke-test.mjs` so the visible lab page must keep the no-change baseline and support-unlocked Rank 2/3 explanation.
- Require the lab smoke test to verify that support only unlocks comparison runs after the baseline loses.
- Require the lab smoke test to verify that Rank 2/3 do not independently need 20+ votes after Rank 1 beats the baseline.

## Scope
- `scripts/lab-smoke-test.mjs`

## Confirmed rule protected by smoke test
- No-change baseline has 20 votes.
- If baseline ranks first, no implementation candidate runs, even when support exists.
- If a real prompt ranks first, Rank 1 is eligible.
- After baseline pass, 5 USD weekly support can unlock Rank 2.
- After baseline pass, 10 USD weekly support can unlock Rank 2 and Rank 3.
- Rank 2 and Rank 3 do not independently need 20+ votes after Rank 1 beats the baseline.

## Non-goals
- No lab implementation change.
- No selection behavior change.
- No support threshold change.
- No workflow behavior change.
- No runner behavior change.
- No generated snapshot edit.
- No auto-merge.
- No API call.