### PR TITLE
Harden operator workflow input handling

### DIFF
--- a/.github/workflows/support-unlock-export.yml
+++ b/.github/workflows/support-unlock-export.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Resolve support window
         id: window
         shell: python
+        env:
+          INPUT_WEEK_ID: ${{ inputs.week_id }}
+          INPUT_SINCE: ${{ inputs.since }}
+          INPUT_UNTIL: ${{ inputs.until }}
         run: |
           from datetime import datetime, timedelta, timezone
           import os
@@ -46,10 +50,10 @@ jobs:
           start = target - timedelta(days=iso.weekday - 1)
           start = start.replace(hour=0, minute=0, second=0, microsecond=0)
           end = start + timedelta(days=7)
-          week_id = '''${{ inputs.week_id }}'''.strip() or f"{iso.year}-W{iso.week:02d}"
-          since = '''${{ inputs.since }}'''.strip() or start.isoformat(timespec='seconds').replace('+00:00', 'Z')
-          until = '''${{ inputs.until }}'''.strip() or end.isoformat(timespec='seconds').replace('+00:00', 'Z')
-          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as handle:
+          week_id = os.environ.get("INPUT_WEEK_ID", "").strip() or f"{iso.year}-W{iso.week:02d}"
+          since = os.environ.get("INPUT_SINCE", "").strip() or start.isoformat(timespec="seconds").replace("+00:00", "Z")
+          until = os.environ.get("INPUT_UNTIL", "").strip() or end.isoformat(timespec="seconds").replace("+00:00", "Z")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
               handle.write(f"week_id={week_id}\n")
               handle.write(f"since={since}\n")
               handle.write(f"until={until}\n")

--- a/.github/workflows/weekly-issue-finalizer.yml
+++ b/.github/workflows/weekly-issue-finalizer.yml
@@ -52,8 +52,10 @@ jobs:
 
       - name: Build finalizer plan
         env:
+          WEEK_ID: ${{ inputs.week_id }}
           DRY_RUN: ${{ inputs.dry_run }}
           REQUIRE_PUBLIC_RESULTS_MEMBERSHIP: ${{ inputs.require_public_results_membership }}
+          RUN_RECORD_HINT: ${{ inputs.run_record_hint }}
         run: |
           set -euo pipefail
           dry_flag=""
@@ -63,11 +65,11 @@ jobs:
           python scripts/weekly_issue_finalizer.py \
             --issues-json .tmp/weekly-issue-finalizer/issues.json \
             --public-results data/public-results.json \
-            --week-id "${{ inputs.week_id }}" \
+            --week-id "$WEEK_ID" \
             --out-json .tmp/weekly-issue-finalizer/plan.json \
             --out-md .tmp/weekly-issue-finalizer/plan.md \
             --comments-dir .tmp/weekly-issue-finalizer/comments \
-            --run-record-hint "${{ inputs.run_record_hint }}" \
+            --run-record-hint "$RUN_RECORD_HINT" \
             $dry_flag \
             $require_flag
 

--- a/scripts/test_support_unlock_workflow_contract.py
+++ b/scripts/test_support_unlock_workflow_contract.py
@@ -8,6 +8,12 @@ SUPPORT_WORKFLOW = ROOT / ".github" / "workflows" / "support-unlock-export.yml"
 WEEKLY_WORKFLOW = ROOT / ".github" / "workflows" / "weekly-auto-run.yml"
 SCRIPT_CHECK = ROOT / ".github" / "workflows" / "script-check.yml"
 
+FORBIDDEN_RUN_TEXT = [
+    "${{ inputs.week_id }}",
+    "${{ inputs.since }}",
+    "${{ inputs.until }}",
+]
+
 
 def require(text: str, required: list[str], label: str) -> None:
     missing = [item for item in required if item not in text]
@@ -19,6 +25,38 @@ def reject(text: str, forbidden: list[str], label: str) -> None:
     found = [item for item in forbidden if item in text]
     if found:
         raise SystemExit(f"{label}: forbidden text found: {found}")
+
+
+def run_blocks(text: str) -> list[str]:
+    blocks: list[str] = []
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.strip() == "run: |":
+            indent = len(line) - len(line.lstrip())
+            block: list[str] = []
+            i += 1
+            while i < len(lines):
+                child = lines[i]
+                if child.strip() and len(child) - len(child.lstrip()) <= indent:
+                    break
+                block.append(child)
+                i += 1
+            blocks.append("\n".join(block))
+            continue
+        i += 1
+    return blocks
+
+
+def reject_inputs_in_run_blocks(text: str) -> None:
+    found: list[str] = []
+    for block in run_blocks(text):
+        for item in FORBIDDEN_RUN_TEXT:
+            if item in block:
+                found.append(item)
+    if found:
+        raise SystemExit(f"Unsafe support workflow input interpolation inside run blocks: {sorted(set(found))}")
 
 
 def main() -> int:
@@ -37,6 +75,12 @@ def main() -> int:
             "until:",
             "previous UTC ISO week",
             "target = current - timedelta(days=7)",
+            "INPUT_WEEK_ID: ${{ inputs.week_id }}",
+            "INPUT_SINCE: ${{ inputs.since }}",
+            "INPUT_UNTIL: ${{ inputs.until }}",
+            "os.environ.get(\"INPUT_WEEK_ID\", \"\").strip()",
+            "os.environ.get(\"INPUT_SINCE\", \"\").strip()",
+            "os.environ.get(\"INPUT_UNTIL\", \"\").strip()",
             "SPONSORS_GRAPHQL_TOKEN",
             "scripts/fetch_support_activities.py",
             "scripts/build_support_unlocks.py",
@@ -59,6 +103,7 @@ def main() -> int:
         ],
         "support workflow",
     )
+    reject_inputs_in_run_blocks(support)
 
     require(
         weekly,
@@ -90,6 +135,9 @@ def main() -> int:
         ],
         "script check",
     )
+
+    if support.index("Resolve support window") > support.index("Fetch support activity"):
+        raise SystemExit("support window must resolve before support activity fetch")
 
     if support.index("Validate public support unlock output") > support.index("Commit support unlocks"):
         raise SystemExit("public support unlock output must be validated before commit")

--- a/scripts/test_weekly_issue_finalizer_workflow_contract.py
+++ b/scripts/test_weekly_issue_finalizer_workflow_contract.py
@@ -8,6 +8,13 @@ WORKFLOW = ROOT / ".github" / "workflows" / "weekly-issue-finalizer.yml"
 DOC = ROOT / "docs" / "issue-lifecycle.md"
 SCRIPT = ROOT / "scripts" / "weekly_issue_finalizer.py"
 
+FORBIDDEN_RUN_TEXT = [
+    "${{ inputs.week_id }}",
+    "${{ inputs.run_record_hint }}",
+    "${{ inputs.dry_run }}",
+    "${{ inputs.require_public_results_membership }}",
+]
+
 REQUIRED_WORKFLOW_TEXT = [
     "name: Weekly Issue Finalizer",
     "workflow_dispatch:",
@@ -16,10 +23,16 @@ REQUIRED_WORKFLOW_TEXT = [
     "require_public_results_membership:",
     "issues: write",
     "contents: read",
+    "WEEK_ID: ${{ inputs.week_id }}",
+    "DRY_RUN: ${{ inputs.dry_run }}",
+    "REQUIRE_PUBLIC_RESULTS_MEMBERSHIP: ${{ inputs.require_public_results_membership }}",
+    "RUN_RECORD_HINT: ${{ inputs.run_record_hint }}",
     "gh issue list",
     "--label \"week:${WEEK_ID}\"",
     "python scripts/weekly_issue_finalizer.py",
     "--public-results data/public-results.json",
+    "--week-id \"$WEEK_ID\"",
+    "--run-record-hint \"$RUN_RECORD_HINT\"",
     "--require-public-results-membership",
     "Upload finalizer plan artifact",
     "Comment and close eligible Issues",
@@ -74,6 +87,38 @@ def reject_all(text: str, forbidden: list[str], label: str) -> None:
         raise SystemExit(f"Forbidden {label}: {found}")
 
 
+def run_blocks(text: str) -> list[str]:
+    blocks: list[str] = []
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.strip() == "run: |":
+            indent = len(line) - len(line.lstrip())
+            block: list[str] = []
+            i += 1
+            while i < len(lines):
+                child = lines[i]
+                if child.strip() and len(child) - len(child.lstrip()) <= indent:
+                    break
+                block.append(child)
+                i += 1
+            blocks.append("\n".join(block))
+            continue
+        i += 1
+    return blocks
+
+
+def reject_inputs_in_run_blocks(text: str) -> None:
+    found: list[str] = []
+    for block in run_blocks(text):
+        for item in FORBIDDEN_RUN_TEXT:
+            if item in block:
+                found.append(item)
+    if found:
+        raise SystemExit(f"Unsafe weekly issue finalizer input interpolation inside run blocks: {sorted(set(found))}")
+
+
 def main() -> int:
     workflow_text = WORKFLOW.read_text(encoding="utf-8")
     script_text = SCRIPT.read_text(encoding="utf-8")
@@ -81,6 +126,7 @@ def main() -> int:
 
     require_all(workflow_text, REQUIRED_WORKFLOW_TEXT, "workflow text")
     reject_all(workflow_text, FORBIDDEN_WORKFLOW_TEXT, "workflow text")
+    reject_inputs_in_run_blocks(workflow_text)
     require_all(script_text, REQUIRED_SCRIPT_TEXT, "script text")
     require_all(doc_text, REQUIRED_DOC_TEXT, "doc text")
 


### PR DESCRIPTION
## Summary
- Pass Support Unlock Export manual inputs through step environment variables before Python reads them.
- Pass Weekly Issue Finalizer manual inputs through step environment variables before shell/Python uses them.
- Strengthen contract tests so workflow form inputs are not interpolated directly inside `run:` blocks.

## Fixes
- Fixes #305
- Fixes #306

## Scope
- `.github/workflows/support-unlock-export.yml`
- `.github/workflows/weekly-issue-finalizer.yml`
- `scripts/test_support_unlock_workflow_contract.py`
- `scripts/test_weekly_issue_finalizer_workflow_contract.py`

## Non-goals
- No lab implementation change.
- No generated snapshot edit.
- No model call.
- No support threshold change.
- No auto-merge.
- No legacy runner removal.

## Risk reduction
Manual workflow form inputs now follow the safer repository pattern:

```text
workflow input -> step env -> script reads env
```

This keeps operator-provided text out of executable script bodies while preserving existing behavior.