### PR TITLE
Clarify root README weekly automation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ Rejected, failed, unsafe, and unmerged comparison PRs do not become the next wee
 
 ## Weekly automation status
 
-Weekly automation is implemented. The no-eligible live path has been verified, and the eligible implementation-agent PR path still needs live E2E verification.
+Weekly automation is implemented. The no-eligible live path has been verified, the canonical selected-prompt canary has passed, and canonical weekly execution is default-on for eligible candidates.
+
+The first ordinary post-default-on weekly run still needs operational observation. If the no-change baseline wins, the run should create a vote summary PR and stop before any implementation-agent attempt.
 
 Scheduled workflows:
 


### PR DESCRIPTION
## Summary
- Clarify the root README weekly automation status after canonical weekly default-on release.
- Distinguish the verified canonical canary/default-on state from the still-pending ordinary post-default-on operational observation.

## Scope
- `README.md`

## Non-goals
- No workflow change.
- No docs source-of-truth change.
- No lab implementation change.
- No generated snapshot edit.
- No model call.
- No auto-merge.

## Reason
The root README still described the eligible implementation-agent PR path as needing live E2E verification without mentioning that the canonical selected-prompt canary has passed and weekly canonical execution is now default-on. The new wording points readers at the correct operational status while keeping the remaining ordinary-run observation explicit.