### PR TITLE
Align root README with static UI function policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The AI agent must not edit:
 - config/secrets
 - files outside `lab/`
 
-The lab must not use external scripts, CDNs, hidden network calls, cookies, iframes, `eval`, `new Function(...)`, login, payment, or trackers.
+The lab must not use external scripts, CDNs, hidden network calls, cookies, iframes, `eval`, login, payment, or trackers. Controlled `new Function(...)` is allowed only for fixed repository-authored logic under `rules/static-ui-v1.0.md` and must not use user-controlled input.
 
 ## State inheritance
 


### PR DESCRIPTION
## Summary
- Align the root README with `rules/static-ui-v1.0.md` and `scripts/static-site-check.sh`.
- Clarify that `eval` remains forbidden while controlled `new Function(...)` is allowed only for fixed repository-authored logic and must not use user-controlled input.
- Restore the final newline removed by the previous README-only update.

## Scope
- `README.md`

## Non-goals
- No workflow change.
- No docs source-of-truth change.
- No lab implementation change.
- No generated snapshot edit.
- No model call.
- No auto-merge.