### PR TITLE
Clarify model policy verification status

### DIFF
--- a/rules/model-policy-v1.1.md
+++ b/rules/model-policy-v1.1.md
@@ -35,7 +35,7 @@ weekly-auto-run eligible implementation path
 
 Historical canary evidence may still mention earlier isolated paths, including `first-canary-009`, but current active paid implementation settings are defined by this file and the current workflows.
 
-The eligible implementation path has not yet been live-verified end-to-end. The no-eligible weekly path has been live-verified.
+The canonical selected-prompt canary has passed, and the weekly canonical selected-prompt runner is default-on for eligible candidates. The first ordinary post-default-on weekly run still needs operational observation.
 
 ## Fixed comparison rule
 


### PR DESCRIPTION
## Summary
- Update `rules/model-policy-v1.1.md` to match the current canonical weekly default-on status.
- Replace the outdated eligible-path verification sentence with the current state: canonical selected-prompt canary passed, weekly canonical runner default-on, first ordinary post-default-on run still pending observation.

## Scope
- `rules/model-policy-v1.1.md`

## Non-goals
- No model setting change.
- No workflow change.
- No lab implementation change.
- No generated snapshot edit.
- No auto-merge.
- No legacy runner removal.