### PR TITLE
Update experiment model active model policy reference

### DIFF
--- a/docs/experiment-model.md
+++ b/docs/experiment-model.md
@@ -105,10 +105,10 @@ As rounds accumulate, the three files become harder to modify cleanly. That risi
 
 Prompt candidates should be compared under the same implementation condition.
 
-The implementation model is fixed by `rules/model-policy-v1.0.md`:
+The active implementation model is fixed by `rules/model-policy-v1.1.md`:
 
 ```text
-gpt-5-nano
+gpt-5.4-nano
 ```
 
 A stronger model may be used for reports, but it must not modify `lab/`.


### PR DESCRIPTION
## Summary
- Update `docs/experiment-model.md` from the historical `model-policy-v1.0` / `gpt-5-nano` reference to the active `model-policy-v1.1` / `gpt-5.4-nano` implementation condition.

## Scope
- `docs/experiment-model.md`

## Non-goals
- No model setting change.
- No workflow change.
- No lab implementation change.
- No generated snapshot edit.
- No auto-merge.
- No legacy runner removal.