### PR TITLE
Gate weak historical canary workflows

### DIFF
--- a/.github/workflows/codex-agent-observed-canary-run.yml
+++ b/.github/workflows/codex-agent-observed-canary-run.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   codex-agent-observed-canary-run:
+    if: vars.ALLOW_HISTORICAL_WEAK_CANARY_WORKFLOWS == 'true'
     runs-on: ubuntu-latest
     env:
       CODEX_MODEL: gpt-5.4-nano

--- a/.github/workflows/codex-first-canary-run.yml
+++ b/.github/workflows/codex-first-canary-run.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   codex-first-canary-run:
+    if: vars.ALLOW_HISTORICAL_WEAK_CANARY_WORKFLOWS == 'true'
     runs-on: ubuntu-latest
     env:
       CODEX_MODEL: gpt-5.4-nano

--- a/.github/workflows/codex-isolated-3file-canary-run.yml
+++ b/.github/workflows/codex-isolated-3file-canary-run.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   codex-isolated-3file-canary-run:
+    if: vars.ALLOW_HISTORICAL_WEAK_CANARY_WORKFLOWS == 'true'
     runs-on: ubuntu-latest
     env:
       CODEX_MODEL: gpt-5.4-nano

--- a/.github/workflows/codex-isolated-3file-relaxed-canary-run.yml
+++ b/.github/workflows/codex-isolated-3file-relaxed-canary-run.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   codex-isolated-3file-relaxed-canary-run:
+    if: vars.ALLOW_HISTORICAL_WEAK_CANARY_WORKFLOWS == 'true'
     runs-on: ubuntu-latest
     env:
       CODEX_MODEL: gpt-5.4-nano

--- a/docs/workflow-family-map.md
+++ b/docs/workflow-family-map.md
@@ -81,16 +81,44 @@ They should not be deleted merely because the selected-prompt runner is now cano
 
 | Workflow | Path | Current role |
 |---|---|---|
-| Codex First Canary Run | `.github/workflows/codex-first-canary-run.yml` | Historical first canary path |
-| Codex Isolated 3file Canary Run | `.github/workflows/codex-isolated-3file-canary-run.yml` | Historical isolated three-file canary path |
-| Codex Isolated 3file Relaxed Canary Run | `.github/workflows/codex-isolated-3file-relaxed-canary-run.yml` | Historical relaxed canary path |
+| Codex First Canary Run | `.github/workflows/codex-first-canary-run.yml` | Historical first canary path; gated by `ALLOW_HISTORICAL_WEAK_CANARY_WORKFLOWS=true` |
+| Codex Isolated 3file Canary Run | `.github/workflows/codex-isolated-3file-canary-run.yml` | Historical isolated three-file canary path; gated by `ALLOW_HISTORICAL_WEAK_CANARY_WORKFLOWS=true` |
+| Codex Isolated 3file Relaxed Canary Run | `.github/workflows/codex-isolated-3file-relaxed-canary-run.yml` | Historical relaxed canary path; gated by `ALLOW_HISTORICAL_WEAK_CANARY_WORKFLOWS=true` |
 | Codex Writeback Canary Run | `.github/workflows/codex-writeback-canary-run.yml` | Historical writeback canary path |
 | Codex Offline JSON Canary Run | `.github/workflows/codex-offline-json-canary-run.yml` | Historical non-canonical JSON writeback path |
-| Codex Agent Observed Canary Run | `.github/workflows/codex-agent-observed-canary-run.yml` | Historical agent-observed canary path |
+| Codex Agent Observed Canary Run | `.github/workflows/codex-agent-observed-canary-run.yml` | Historical agent-observed canary path; gated by `ALLOW_HISTORICAL_WEAK_CANARY_WORKFLOWS=true` |
 | Canary 007 Policy Feasibility | `.github/workflows/canary-007-policy-feasibility.yml` | Feasibility check for policy-enforced container execution |
 | Codex Policy Agent Canary Run | `.github/workflows/codex-policy-agent-canary-run.yml` | Policy-agent public bundle and diagnostics evidence path |
 | Codex Task Packet Canary Run | `.github/workflows/codex-task-packet-canary-run.yml` | Task-packet boundary evidence path |
 | Codex Fixed Issue Instruction Canary Run | `.github/workflows/codex-fixed-issue-instruction-canary-run.yml` | Fixed-Issue instruction packet and safety-gate evidence path |
+
+## Historical weak canary gate
+
+Some historical canary workflows are intentionally weaker than the current canonical selected-prompt boundary because they tested earlier execution designs.
+
+These weak historical canaries remain as archive evidence, but their jobs require an explicit repository variable before they run:
+
+```text
+ALLOW_HISTORICAL_WEAK_CANARY_WORKFLOWS=true
+```
+
+Gated workflows:
+
+```text
+.github/workflows/codex-first-canary-run.yml
+.github/workflows/codex-isolated-3file-canary-run.yml
+.github/workflows/codex-isolated-3file-relaxed-canary-run.yml
+.github/workflows/codex-agent-observed-canary-run.yml
+```
+
+The gate prevents accidental reruns of old workspace-write or relaxed-sandbox experiments without deleting historical evidence surfaces.
+
+The gate does not apply to the current canonical selected-prompt path:
+
+```text
+.github/workflows/codex-selected-prompt-run.yml
+.github/workflows/weekly-auto-run.yml
+```
 
 ## Canary-era archive boundary
 
@@ -182,6 +210,7 @@ The next safe cleanup work is:
 ```text
 1. Verify the first ordinary scheduled default-on weekly run.
 2. Keep scripts/openai_lab_run.py labeled as legacy and non-canonical.
-3. Defer legacy fallback removal until a separate legacy-removal gate exists.
-4. Defer workflow deletion until a release readiness record approves it.
+3. Keep weak historical canary workflows gated unless a maintainer intentionally enables ALLOW_HISTORICAL_WEAK_CANARY_WORKFLOWS=true.
+4. Defer legacy fallback removal until a separate legacy-removal gate exists.
+5. Defer workflow deletion until a release readiness record approves it.
 ```

--- a/scripts/test_workflow_family_map.py
+++ b/scripts/test_workflow_family_map.py
@@ -8,6 +8,15 @@ DOC = ROOT / "docs" / "workflow-family-map.md"
 README = ROOT / "docs" / "README.md"
 INVENTORY = ROOT / "docs" / "repository-cleanup-inventory.md"
 
+WEAK_CANARY_WORKFLOWS = [
+    ROOT / ".github" / "workflows" / "codex-first-canary-run.yml",
+    ROOT / ".github" / "workflows" / "codex-isolated-3file-canary-run.yml",
+    ROOT / ".github" / "workflows" / "codex-isolated-3file-relaxed-canary-run.yml",
+    ROOT / ".github" / "workflows" / "codex-agent-observed-canary-run.yml",
+]
+
+GATE = "if: vars.ALLOW_HISTORICAL_WEAK_CANARY_WORKFLOWS == 'true'"
+
 REQUIRED_DOC_TEXT = [
     "# Workflow family map",
     "It is not a removal plan.",
@@ -32,6 +41,10 @@ REQUIRED_DOC_TEXT = [
     ".github/workflows/codex-policy-agent-canary-run.yml",
     ".github/workflows/codex-task-packet-canary-run.yml",
     ".github/workflows/codex-fixed-issue-instruction-canary-run.yml",
+    "## Historical weak canary gate",
+    "ALLOW_HISTORICAL_WEAK_CANARY_WORKFLOWS=true",
+    "The gate prevents accidental reruns of old workspace-write or relaxed-sandbox experiments without deleting historical evidence surfaces.",
+    "The gate does not apply to the current canonical selected-prompt path:",
     "## Canary-era archive boundary",
     "Canary-era names are historical evidence labels, not active canonical status claims.",
     "first-canary",
@@ -59,6 +72,7 @@ REQUIRED_DOC_TEXT = [
     "Affected docs:",
     "Affected contract tests:",
     "Rollback path:",
+    "Keep weak historical canary workflows gated unless a maintainer intentionally enables ALLOW_HISTORICAL_WEAK_CANARY_WORKFLOWS=true.",
     "Defer legacy fallback removal until a separate legacy-removal gate exists.",
 ]
 
@@ -93,6 +107,15 @@ def reject_all(text: str, forbidden: list[str], label: str) -> None:
         raise SystemExit(f"Forbidden {label} text found: {found}")
 
 
+def require_weak_canary_gates() -> None:
+    for path in WEAK_CANARY_WORKFLOWS:
+        text = path.read_text(encoding="utf-8")
+        if GATE not in text:
+            raise SystemExit(f"Weak historical canary workflow is not gated: {path.relative_to(ROOT)}")
+        if text.index(GATE) > text.index("runs-on: ubuntu-latest"):
+            raise SystemExit(f"Weak canary gate must appear before runs-on: {path.relative_to(ROOT)}")
+
+
 def main() -> int:
     doc = DOC.read_text(encoding="utf-8")
     readme = README.read_text(encoding="utf-8")
@@ -102,6 +125,7 @@ def main() -> int:
     reject_all(doc, FORBIDDEN_DOC_TEXT, "workflow family map")
     require_all(inventory, REQUIRED_INVENTORY_TEXT, "repository cleanup inventory")
     require_all(readme, ["Repository cleanup inventory"], "docs README")
+    require_weak_canary_gates()
 
     if doc.index("## Canonical active workflows") > doc.index("## Weekly active workflows"):
         raise SystemExit("canonical workflows should be listed before weekly active workflows")
@@ -109,8 +133,10 @@ def main() -> int:
         raise SystemExit("public generated snapshot workflows should follow weekly active workflows")
     if doc.index("## Test and guard workflows") > doc.index("## Canary evidence workflows"):
         raise SystemExit("canary evidence workflows should follow test and guard workflows")
-    if doc.index("## Canary evidence workflows") > doc.index("## Canary-era archive boundary"):
-        raise SystemExit("canary-era archive boundary should follow canary evidence workflows")
+    if doc.index("## Canary evidence workflows") > doc.index("## Historical weak canary gate"):
+        raise SystemExit("historical weak canary gate should follow canary evidence workflows")
+    if doc.index("## Historical weak canary gate") > doc.index("## Canary-era archive boundary"):
+        raise SystemExit("canary-era archive boundary should follow weak canary gate")
     if doc.index("## Cleanup candidates") > doc.index("## Removal gate for workflows"):
         raise SystemExit("workflow removal gate should follow cleanup candidates")
 


### PR DESCRIPTION
## Summary
- Add an explicit repository-variable gate to weak historical Codex canary workflows.
- Document that those workflows remain as historical evidence, but should not run accidentally before release.
- Strengthen the workflow-family contract test so those weak historical canaries must stay gated.

## Gate

```text
ALLOW_HISTORICAL_WEAK_CANARY_WORKFLOWS=true
```

## Gated workflows
- `.github/workflows/codex-first-canary-run.yml`
- `.github/workflows/codex-isolated-3file-canary-run.yml`
- `.github/workflows/codex-isolated-3file-relaxed-canary-run.yml`
- `.github/workflows/codex-agent-observed-canary-run.yml`

## Why
These workflows are historical evidence surfaces and should not be deleted, but they include older workspace-write or relaxed-sandbox experiments that are weaker than the current canonical selected-prompt boundary.

## Fixes
- Addresses #312 with Option C.

## Non-goals
- No workflow deletion.
- No run record or generated evidence deletion.
- No canonical weekly default-on change.
- No lab implementation change.
- No model call.
- No auto-merge.
- No legacy runner removal.