### PR TITLE
Clarify automation map current workflow status

### DIFF
--- a/docs/automation-map.md
+++ b/docs/automation-map.md
@@ -65,9 +65,9 @@ The project must not automate:
 | `static-site-check.yml` | implemented | PR/path-triggered | Check public page structure, support wording, and lab smoke expectations | 0 |
 | `lab-pr-scope-check.yml` | implemented | PR/path-triggered | Prevent lab implementation PRs from mixing lab and non-lab files | 0 |
 | `script-check.yml` | implemented | PR/path-triggered + manual | Check scripts, offline workflow smoke tests, and workflow contracts | 0 |
-| `support-unlock-export.yml` | implemented, live-token verification pending | daily 00:17 UTC / 09:17 JST + manual | Export anonymized support unlock aggregates and validate them before commit | 0 |
-| `weekly-auto-run.yml` | implemented, not fully production-verified | Monday 00:23 UTC / 09:23 JST + manual | Collect votes and create implementation PRs for eligible prompts | paid only if eligible |
-| `evidence-pipeline-dry-run.yml` | implemented | manual | Manually generate snapshot, run log, weekly summary, public briefing, and HN draft as artifact | 0 |
+| `support-unlock-export.yml` | implemented, operator input hardened, live-token verification pending | daily 00:17 UTC / 09:17 JST + manual | Export anonymized support unlock aggregates and validate them before commit | 0 |
+| `weekly-auto-run.yml` | implemented, canonical default-on, first ordinary post-default-on observation pending | Monday 00:23 UTC / 09:23 JST + manual | Collect votes and create implementation PRs for eligible prompts | paid only if eligible |
+| `evidence-pipeline-dry-run.yml` | implemented, read-only, operator input hardened | manual | Manually generate snapshot, run log, weekly summary, public briefing, and HN draft as artifact | 0 |
 | `exception-matrix-test.yml` | implemented | PR/manual | Test known pass/fail boundary cases | 0 |
 | `multi-fuzz-test.yml` | implemented | PR/manual | Run weighted random boundary mutations | 0 |
 | `weekly-mock-run.yml` | implemented | manual | Test weekly selection and PR creation without model API calls | 0 |


### PR DESCRIPTION
## Summary
- Update `docs/automation-map.md` workflow status labels to match the current release state.
- Clarify that `weekly-auto-run.yml` is canonical default-on with first ordinary post-default-on observation still pending.
- Clarify that `support-unlock-export.yml` and `evidence-pipeline-dry-run.yml` now use hardened operator input handling.

## Scope
- `docs/automation-map.md`

## Non-goals
- No workflow change.
- No source-of-truth status change.
- No lab implementation change.
- No generated snapshot edit.
- No model call.
- No auto-merge.
- No legacy runner removal.