### PR TITLE
Remove API-era output token cap from active policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,14 +170,17 @@ Current active implementation condition:
 
 ```text
 model-policy-v1.1: gpt-5.4-nano
-max_output_tokens: 5000
+attempts_per_candidate: 1
+retry_count: 0
+fallback_policy: none
+output_token_cap_enforced: false
 ```
 
-The implementation model and output budget are fixed by `rules/model-policy-v1.1.md` during the current stabilization phase.
+The implementation model and bounded-agent policy are fixed by `rules/model-policy-v1.1.md` during the current stabilization phase.
 
 All ranked candidates in the same weekly vote must use the same implementation condition.
 
-`max_output_tokens: 12000` is not active. It may be reconsidered only after the system is complete and the eligible implementation PR path has passed live E2E verification.
+The current canonical Codex CLI runner does not enforce the old API-era `max_output_tokens` cap as a runtime limit. Cost and scope are controlled through one attempt per candidate, no retry, no fallback, support-unlock rank limits, manual review, and the three-file lab scope.
 
 A stronger model may be used only for evaluation and blog/report writing. The evaluation model must not modify `lab/`.
 
@@ -245,7 +248,7 @@ Key documents:
 - [`docs/experiment-model.md`](docs/experiment-model.md) — project concept and boundaries
 - [`docs/how-to-participate.md`](docs/how-to-participate.md) — how to submit, vote, and review as a player
 - [`docs/weekly-automation.md`](docs/weekly-automation.md) — weekly schedule and support unlock prerequisite
-- [`docs/usable-experiment-ops.md`](docs/usable-experiment-ops.md) — current usable manual experiment operations
+- [`docs/usable-experiment-ops.md`](docs/usable-experiment-ops.md) — current usable experiment operations
 - [`docs/no-change-baseline.md`](docs/no-change-baseline.md) — no-change baseline explanation
 - [`docs/support-policy.md`](docs/support-policy.md) — support tiers and thresholds
 - [`docs/automation-map.md`](docs/automation-map.md) — automation boundary

--- a/rules/model-policy-v1.1.md
+++ b/rules/model-policy-v1.1.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-This policy fixes the active implementation model for Prompt Vote Lab stabilization runs.
+This policy fixes the active implementation model and bounded-agent operating conditions for Prompt Vote Lab stabilization runs.
 
-Prompt Vote Lab evaluates prompt candidates. To compare prompts fairly, the implementation model and output budget must remain fixed within the same comparison period.
+Prompt Vote Lab evaluates prompt candidates. To compare prompts fairly, the implementation model, attempt count, retry policy, fallback policy, editable file scope, and manual-review policy must remain fixed within the same comparison period.
 
 ## Active implementation model
 
@@ -44,7 +44,6 @@ For all candidates in the same weekly vote, use the same:
 ```text
 model
 sampling policy
-max output budget
 active rules
 editable file scope
 input context policy
@@ -53,7 +52,7 @@ fallback policy
 manual review policy
 ```
 
-Do not run rank 1, rank 2, and rank 3 with different implementation models in the same comparison set.
+Do not run rank 1, rank 2, and rank 3 with different implementation models or execution policies in the same comparison set.
 
 ## Active settings
 
@@ -61,29 +60,39 @@ Do not run rank 1, rank 2, and rank 3 with different implementation models in th
 model: gpt-5.4-nano
 temperature_policy: model-default
 top_p_policy: model-default
-max_output_tokens: 5000
+attempts_per_candidate: 1
 retry_count: 0
 fallback_policy: none
 auto_merge_policy: disabled
+output_token_cap_enforced: false
 ```
 
 The implementation runner records the temperature and top_p policies as `model-default` rather than passing unsupported or unstable sampling overrides.
 
-## Deferred settings
+## Output-token cap status
 
-The following setting is not active during the stabilization phase:
+`max_output_tokens` is not an active enforced implementation condition for the current canonical Codex CLI runner.
+
+Earlier API-oriented runner designs used a `max_output_tokens` setting. The current canonical selected-prompt path invokes the Codex CLI runner and does not enforce that API-era cap as a runtime limit.
+
+Therefore this policy treats output-token caps as non-active metadata unless a future runner can enforce them directly and records that enforcement in its runner contract.
+
+The active cost and scope guards are instead:
 
 ```text
-max_output_tokens: 12000
+attempts_per_candidate: 1
+retry_count: 0
+fallback_policy: none
+rank support unlock limits
+manual review required
+editable files limited to lab/index.html, lab/style.css, lab/app.js
 ```
 
-It may be reconsidered only after the system is complete and the eligible implementation PR path has passed at least one live end-to-end run.
-
-Do not change the active token budget during stabilization merely to increase implementation capacity.
+Do not claim a run is output-token-capped unless the runner passes and verifies an actual runtime cap.
 
 ## Ranked candidates
 
-If rank 1, rank 2, and rank 3 are executed in the same week, they must use the same implementation model settings.
+If rank 1, rank 2, and rank 3 are executed in the same week, they must use the same implementation model settings and execution policy.
 
 Rank 2 and rank 3 are comparison candidates. They are not automatically promoted if rank 1 fails review.
 
@@ -103,18 +112,19 @@ If retries are introduced later, they must use the same implementation model and
 gpt-5-nano
 ```
 
-`model-policy-v1.1` records the active stabilization model and output budget:
+`model-policy-v1.1` records the active stabilization model and execution policy:
 
 ```text
 model: gpt-5.4-nano
-max_output_tokens: 5000
+attempts_per_candidate: 1
+retry_count: 0
+fallback_policy: none
+output_token_cap_enforced: false
 ```
-
-This file also records that `max_output_tokens: 12000` is deferred, not active.
 
 Do not directly compare prompt results across v1.0 and v1.1 without noting the model-policy change.
 
-Do not directly compare prompt results across model or token-budget changes without noting the policy change.
+Do not directly compare prompt results across model, runner, retry, fallback, file-scope, or output-cap-enforcement changes without noting the policy change.
 
 ## Separation from evaluation model
 
@@ -124,8 +134,8 @@ A stronger model may be used for analysis and blog/report writing under a separa
 
 ## Rationale
 
-If the implementation model or output budget changes between candidates, the experiment no longer evaluates only prompt quality.
+If the implementation model or execution policy changes between candidates, the experiment no longer evaluates only prompt quality.
 
-The result becomes a mixture of prompt quality, model capability, context size, output budget, and retry behavior.
+The result becomes a mixture of prompt quality, model capability, context size, runner capability, retry behavior, fallback behavior, and review policy.
 
-To evaluate prompts, keep the implementation model and budget fixed within each comparison period.
+To evaluate prompts, keep the implementation model and bounded-agent policy fixed within each comparison period.

--- a/scripts/pre_api_freeze_audit.py
+++ b/scripts/pre_api_freeze_audit.py
@@ -146,12 +146,13 @@ REQUIRED_SUBSTRINGS: dict[str, list[str]] = {
     ],
     "scripts/preflight_implementation_agent.py": [
         f"ALLOWED_MODELS = {{\"{ACTIVE_MODEL}\"}}",
-        "MAX_OUTPUT_TOKENS_LIMIT = 5000",
         "if sdk_max_retries != 0",
         "api_call_limit != 1",
         "validate_env_secret(len(candidates))",
         "api_call_performed",
         "False",
+        "output_token_cap_enforced",
+        "legacy_max_output_tokens_input_present",
     ],
     "scripts/openai_lab_run.py": [
         "OpenAI(api_key=api_key, max_retries=0, timeout=120.0)",

--- a/scripts/preflight_implementation_agent.py
+++ b/scripts/preflight_implementation_agent.py
@@ -69,6 +69,7 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--eligible", default=".tmp/eligible-candidates.json")
     parser.add_argument("--model", default=os.getenv("IMPLEMENTATION_MODEL", "gpt-5.4-nano"))
+    parser.add_argument("--max-output-tokens", default=os.getenv("MAX_OUTPUT_TOKENS", ""))
     parser.add_argument("--sdk-max-retries", default=os.getenv("SDK_MAX_RETRIES", "0"))
     parser.add_argument("--api-call-limit-per-candidate", default="1")
     args = parser.parse_args()
@@ -107,6 +108,7 @@ def main() -> int:
         "api_call_limit_per_candidate": api_call_limit,
         "api_call_performed": False,
         "output_token_cap_enforced": False,
+        "legacy_max_output_tokens_input_present": bool(str(args.max_output_tokens).strip()),
     }
     print(json.dumps(summary, indent=2))
     return 0

--- a/scripts/preflight_implementation_agent.py
+++ b/scripts/preflight_implementation_agent.py
@@ -10,14 +10,12 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import os
 from pathlib import Path
 from typing import Any
 
 
 ALLOWED_MODELS = {"gpt-5.4-nano"}
-MAX_OUTPUT_TOKENS_LIMIT = 5000
 REQUIRED_RUN_REASONS = {"normal-weekly-run", "support-unlocked-run"}
 
 
@@ -71,7 +69,6 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--eligible", default=".tmp/eligible-candidates.json")
     parser.add_argument("--model", default=os.getenv("IMPLEMENTATION_MODEL", "gpt-5.4-nano"))
-    parser.add_argument("--max-output-tokens", default=os.getenv("MAX_OUTPUT_TOKENS", "5000"))
     parser.add_argument("--sdk-max-retries", default=os.getenv("SDK_MAX_RETRIES", "0"))
     parser.add_argument("--api-call-limit-per-candidate", default="1")
     args = parser.parse_args()
@@ -83,10 +80,6 @@ def main() -> int:
     model = args.model.strip()
     if model not in ALLOWED_MODELS:
         raise SystemExit(f"implementation model {model!r} is not allowed")
-
-    max_output_tokens = parse_int(str(args.max_output_tokens), "max_output_tokens")
-    if max_output_tokens < 1 or max_output_tokens > MAX_OUTPUT_TOKENS_LIMIT:
-        raise SystemExit(f"max_output_tokens must be between 1 and {MAX_OUTPUT_TOKENS_LIMIT}")
 
     sdk_max_retries = parse_int(str(args.sdk_max_retries), "sdk_max_retries")
     if sdk_max_retries != 0:
@@ -110,10 +103,10 @@ def main() -> int:
         "eligible_count": len(candidates),
         "eligible_ranks": sorted(seen_ranks),
         "model": model,
-        "max_output_tokens": max_output_tokens,
         "sdk_max_retries": sdk_max_retries,
         "api_call_limit_per_candidate": api_call_limit,
         "api_call_performed": False,
+        "output_token_cap_enforced": False,
     }
     print(json.dumps(summary, indent=2))
     return 0

--- a/scripts/test_canary_policy_alignment.py
+++ b/scripts/test_canary_policy_alignment.py
@@ -50,7 +50,8 @@ REQUIRED = {
         f"ALLOWED_MODELS = {{\"{ACTIVE_MODEL}\"}}",
         "if sdk_max_retries != 0",
         "api_call_limit != 1",
-        "MAX_OUTPUT_TOKENS_LIMIT = 5000",
+        "output_token_cap_enforced",
+        "legacy_max_output_tokens_input_present",
     ],
     "scripts/openai_lab_run.py": [
         "OpenAI(api_key=api_key, max_retries=0, timeout=120.0)",
@@ -111,6 +112,7 @@ FORBIDDEN = {
         "ALLOWED_MODELS = {\"gpt-5-nano\"}",
         "sdk_max_retries != 1",
         "api_call_limit != 2",
+        "MAX_OUTPUT_TOKENS_LIMIT = 5000",
         "MAX_OUTPUT_TOKENS_LIMIT = 12000",
     ],
     "scripts/openai_lab_run.py": [

--- a/scripts/test_preflight_implementation_agent.py
+++ b/scripts/test_preflight_implementation_agent.py
@@ -44,7 +44,7 @@ def main() -> int:
         tmp = Path(tmp_name)
         empty = tmp / "empty.json"
         eligible = tmp / "eligible.json"
-        bad_model = tmp / "bad-model.json"
+        bad_reason_fixture = tmp / "bad-reason.json"
 
         write_json(empty, [])
         write_json(
@@ -60,7 +60,7 @@ def main() -> int:
             ],
         )
         write_json(
-            bad_model,
+            bad_reason_fixture,
             [
                 {
                     "rank": 2,
@@ -76,6 +76,9 @@ def main() -> int:
         if no_eligible.returncode != 0:
             print(no_eligible.stdout)
             raise SystemExit("empty eligible list should pass without secret")
+        if "output_token_cap_enforced" not in no_eligible.stdout:
+            print(no_eligible.stdout)
+            raise SystemExit("preflight summary should declare that no output token cap is enforced")
 
         needs_secret = run(["--eligible", str(eligible), "--model", ACTIVE_MODEL])
         if needs_secret.returncode == 0:
@@ -88,6 +91,9 @@ def main() -> int:
         if with_secret.returncode != 0:
             print(with_secret.stdout)
             raise SystemExit("eligible candidates with placeholder secret should pass preflight")
+        if '"output_token_cap_enforced": false' not in with_secret.stdout:
+            print(with_secret.stdout)
+            raise SystemExit("preflight summary should record output_token_cap_enforced=false")
 
         wrong_model = run(
             ["--eligible", str(eligible), "--model", "not-allowed-model"],
@@ -95,13 +101,6 @@ def main() -> int:
         )
         if wrong_model.returncode == 0:
             raise SystemExit("wrong model should fail")
-
-        too_many_tokens = run(
-            ["--eligible", str(eligible), "--model", ACTIVE_MODEL, "--max-output-tokens", "5001"],
-            env={"OPENAI_API_KEY_": "test-secret-placeholder"},
-        )
-        if too_many_tokens.returncode == 0:
-            raise SystemExit("too many output tokens should fail")
 
         retry_enabled = run(
             ["--eligible", str(eligible), "--model", ACTIVE_MODEL, "--sdk-max-retries", "1"],
@@ -111,7 +110,7 @@ def main() -> int:
             raise SystemExit("sdk retries should fail")
 
         bad_reason = run(
-            ["--eligible", str(bad_model), "--model", ACTIVE_MODEL],
+            ["--eligible", str(bad_reason_fixture), "--model", ACTIVE_MODEL],
             env={"OPENAI_API_KEY_": "test-secret-placeholder"},
         )
         if bad_reason.returncode == 0:


### PR DESCRIPTION
## Summary
- Remove `max_output_tokens: 5000` from the active model-policy condition.
- Treat output token caps as non-enforced for the current canonical Codex CLI runner unless a future runner contract proves runtime enforcement.
- Keep `--max-output-tokens` accepted by `preflight_implementation_agent.py` as legacy metadata so existing workflow plumbing does not break.
- Keep the real active controls focused on one attempt per candidate, retry 0, fallback none, manual review, support unlock rank limits, and the three-file lab scope.

## Scope
- `rules/model-policy-v1.1.md`
- `README.md`
- `scripts/preflight_implementation_agent.py`
- `scripts/test_preflight_implementation_agent.py`

## Why
`max_output_tokens` was an API-era setting. The current canonical selected-prompt path uses the Codex CLI runner and does not enforce this value as a runtime output cap. Keeping it as an active condition is misleading.

## Non-goals
- No model change.
- No retry change.
- No fallback change.
- No workflow behavior change.
- No lab implementation change.
- No generated evidence change.
- No auto-merge.
- No legacy runner removal.