### PR TITLE
Gate legacy OpenAI runner weekly fallback

### DIFF
--- a/scripts/openai_lab_run.py
+++ b/scripts/openai_lab_run.py
@@ -22,6 +22,10 @@ Agent-run policy:
 - SDK retries disabled
 - no automatic fallback
 - no automatic merge
+
+Weekly fallback safety:
+- ordinary week-* runs are refused unless PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN=true
+- first-canary-* runs are historical canary evidence and are gated at the workflow level
 """
 
 from __future__ import annotations
@@ -46,6 +50,7 @@ MAX_PROMPT_CHARS = int(os.getenv("MAX_IMPLEMENTATION_PROMPT_CHARS", "120000"))
 MAX_OUTPUT_TOKENS_LIMIT = 5000
 LEGACY_RUNNER_CLASSIFICATION = "legacy-non-canonical-fallback"
 CANONICAL_SELECTED_PROMPT_RUNNER = "codex-cli-selected-prompt-packet-container"
+ALLOW_LEGACY_WEEKLY_FALLBACK_ENV = "PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN"
 
 
 SCHEMA = {
@@ -92,6 +97,20 @@ def enforce_prompt_budget(prompt: str) -> None:
             f"Implementation prompt is too large: {len(prompt)} chars > {MAX_PROMPT_CHARS}. "
             "Refusing to start the implementation-agent attempt."
         )
+
+
+def enforce_legacy_weekly_fallback_gate(args: argparse.Namespace) -> None:
+    if not str(args.week).startswith("week-"):
+        return
+    if os.getenv(ALLOW_LEGACY_WEEKLY_FALLBACK_ENV) == "true":
+        return
+    print(
+        "Legacy API/SDK runner refused for ordinary weekly run. "
+        "Use the canonical selected-prompt Docker/Codex runner, or set "
+        f"{ALLOW_LEGACY_WEEKLY_FALLBACK_ENV}=true for an explicit emergency diagnosis.",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
 
 
 def build_prompt(args: argparse.Namespace) -> str:
@@ -165,6 +184,7 @@ def main() -> int:
     parser.add_argument("--summary-out", default=".tmp/implementation-summary.md")
     args = parser.parse_args()
 
+    enforce_legacy_weekly_fallback_gate(args)
     api_key = resolve_openai_api_key()
 
     if args.max_output_tokens > MAX_OUTPUT_TOKENS_LIMIT:

--- a/scripts/test_openai_lab_run_legacy_contract.py
+++ b/scripts/test_openai_lab_run_legacy_contract.py
@@ -14,6 +14,14 @@ REQUIRED_SCRIPT_TEXT = [
     "scripts/run_codex_selected_prompt.sh",
     "Runner: codex-cli-selected-prompt-packet-container",
     "Canonical selected-prompt runner: true",
+    "ordinary week-* runs are refused unless PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN=true",
+    "ALLOW_LEGACY_WEEKLY_FALLBACK_ENV = \"PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN\"",
+    "def enforce_legacy_weekly_fallback_gate(args: argparse.Namespace) -> None:",
+    "if not str(args.week).startswith(\"week-\"):",
+    "if os.getenv(ALLOW_LEGACY_WEEKLY_FALLBACK_ENV) == \"true\":",
+    "Legacy API/SDK runner refused for ordinary weekly run.",
+    "Use the canonical selected-prompt Docker/Codex runner",
+    "enforce_legacy_weekly_fallback_gate(args)",
     "LEGACY_RUNNER_CLASSIFICATION = \"legacy-non-canonical-fallback\"",
     "CANONICAL_SELECTED_PROMPT_RUNNER = \"codex-cli-selected-prompt-packet-container\"",
     "This is the legacy non-canonical fallback runner, not the canonical selected-prompt Docker/Codex path.",
@@ -69,6 +77,9 @@ def main() -> int:
 
     if script.index("LEGACY_RUNNER_CLASSIFICATION") > script.index("SCHEMA ="):
         raise SystemExit("runner classification constants should appear before schema definition")
+
+    if script.index("enforce_legacy_weekly_fallback_gate(args)") > script.index("build_prompt(args)"):
+        raise SystemExit("legacy weekly fallback gate should run before prompt construction")
 
     if script.index("runner_classification: {LEGACY_RUNNER_CLASSIFICATION}") > script.index("## Selected prompt"):
         raise SystemExit("runner classification should appear in prompt metadata before the selected prompt")


### PR DESCRIPTION
## Summary
- Add a downstream safety gate to `scripts/openai_lab_run.py` for ordinary `week-*` runs.
- Refuse the legacy API/SDK runner for weekly fallback unless `PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN=true` is explicitly set.
- Update the legacy runner contract test so the gate remains required.

## Why
`weekly-auto-run.yml` still contains a non-canonical fallback branch for `scripts/openai_lab_run.py`. The canonical Docker/Codex selected-prompt runner is default-on, but this downstream gate prevents accidental use of the legacy API/SDK path for ordinary weekly runs if the feature flag is changed or misconfigured.

## Scope
- `scripts/openai_lab_run.py`
- `scripts/test_openai_lab_run_legacy_contract.py`

## Non-goals
- No canonical weekly workflow change.
- No model change.
- No retry change.
- No fallback change.
- No lab implementation change.
- No generated evidence change.
- No auto-merge.
- No legacy runner removal.