### PR TITLE
Define legacy fallback removal gate

### DIFF
--- a/docs/canonical-status-drift-check.md
+++ b/docs/canonical-status-drift-check.md
@@ -17,6 +17,7 @@ canonical runner name: codex-cli-selected-prompt-packet-container
 canonical evidence marker: Canonical selected-prompt runner: true
 legacy fallback script: scripts/openai_lab_run.py
 legacy fallback status: non-canonical migration fallback
+legacy fallback removal status: not approved until the explicit legacy fallback removal gate passes
 weekly default status: canonical selected-prompt runner default-on
 weekly feature flag override: PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER
 current default constant: DEFAULT_USE_CANONICAL_SELECTED_PROMPT_RUNNER=true
@@ -63,6 +64,7 @@ Docs may use different wording, but they must not contradict these rules:
 4. Do not omit the canonical evidence marker from evidence-facing docs.
 5. Do not treat a useful lab diff as sufficient canonical evidence.
 6. Do not describe workflow or legacy runner deletion as safe without a separate removal gate.
+7. Do not describe legacy fallback removal as approved before the explicit legacy fallback removal gate passes.
 ```
 
 ## Required canonical evidence marker
@@ -144,10 +146,32 @@ manual selected-prompt workflow: verified
 weekly canonical selected-prompt canary: verified
 canonical weekly default: default-on
 legacy fallback: present and non-canonical
+legacy fallback removal: not approved until the explicit legacy fallback removal gate passes
 workflow deletion: not approved
 auto-merge: disabled
 manual review: required
 ```
+
+## Required legacy fallback removal gate
+
+The legacy fallback removal gate is a deletion-prevention gate, not a deletion approval by itself.
+
+`docs/workflow-family-map.md` owns the detailed checklist. Maintainer-facing docs may summarize it, but they must preserve these minimum conditions:
+
+```text
+ordinary default-on weekly no-eligible run observed
+vote summary PR created
+no implementation-agent attempt made for no-eligible run
+no Codex/API call made for no-eligible run
+legacy API/SDK runner not reached for no-eligible run
+eligible canonical run has selected-prompt canary evidence or a next natural eligible-run observation plan
+canonical evidence artifacts remain verified
+rollback plan exists
+public docs no longer cite legacy fallback as an active requirement
+maintainer explicitly approves removal
+```
+
+Until those conditions are recorded, `scripts/openai_lab_run.py` and related legacy API/SDK references remain present, non-canonical, and gated.
 
 ## Change discipline
 

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -374,6 +374,31 @@ output_token_cap_enforced: false
 
 Do not change or cite output-token caps as canonical runtime enforcement unless a future runner contract proves enforcement directly.
 
+## Legacy fallback removal gate
+
+Do not remove `scripts/openai_lab_run.py` during ordinary cleanup.
+
+A future legacy fallback removal PR may be opened only after the explicit legacy fallback removal gate in [Workflow family map](./workflow-family-map.md) passes.
+
+Before approving removal, confirm and record:
+
+```text
+ordinary default-on weekly no-eligible run observed
+vote summary PR created
+implementation PR: none for the no-eligible run
+no implementation-agent attempt made for the no-eligible run
+no Codex/API call made for the no-eligible run
+legacy API/SDK runner not reached for the no-eligible run
+eligible canonical run has selected-prompt canary evidence or a next natural eligible-run observation plan
+canonical evidence artifacts remain verified
+manual review remains required
+auto-merge remains disabled
+rollback plan exists
+maintainer explicitly approves removal
+```
+
+If any item is missing, keep the legacy fallback present, non-canonical, and gated.
+
 ## Reset and cleanup policy
 
 Do not delete public evidence casually.

--- a/docs/workflow-family-map.md
+++ b/docs/workflow-family-map.md
@@ -185,6 +185,48 @@ This second gate is intentional. The weekly feature flag alone must not silently
 
 It should not be removed merely because the canonical weekly runner is default-on. Removal requires a separate legacy-removal gate after ordinary default-on operation is verified.
 
+## Legacy fallback removal gate
+
+This gate defines when it is permissible to open a later PR that removes the legacy API/SDK fallback path.
+
+It does not remove `scripts/openai_lab_run.py`.
+
+It does not approve deletion by itself.
+
+A future legacy fallback removal PR must record all of these conditions:
+
+```text
+ordinary default-on weekly no-eligible run observed
+vote summary PR created
+implementation PR: none for the no-eligible run
+no implementation-agent attempt made for the no-eligible run
+no Codex/API call made for the no-eligible run
+legacy API/SDK runner not reached for the no-eligible run
+eligible canonical run has selected-prompt canary evidence or a next natural eligible-run observation plan
+canonical diagnostics artifact remains verified
+canonical public bundle artifact remains verified
+canonical uploaded bundle verification artifact remains verified
+manual review remains required
+auto-merge remains disabled
+rollback plan exists
+public docs no longer cite legacy fallback as an active requirement
+maintainer explicitly approves removal
+```
+
+The removal PR must also state:
+
+```text
+Legacy files removed:
+Legacy workflows or branches affected:
+Observed no-eligible run:
+Observed eligible canonical evidence or planned natural eligible observation:
+Generated snapshots intentionally untouched: true
+Rollback path:
+Contract tests updated:
+```
+
+Failing any condition means the legacy fallback remains present, non-canonical, and gated.
+
 ## Cleanup candidates
 
 These are candidates for future consolidation. They are not deletion instructions.
@@ -220,6 +262,6 @@ The next safe cleanup work is:
 2. Keep scripts/openai_lab_run.py labeled as legacy and non-canonical.
 3. Keep weak historical canary workflows gated unless a maintainer intentionally enables ALLOW_HISTORICAL_WEAK_CANARY_WORKFLOWS=true.
 4. Keep the legacy weekly fallback gated by PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN=true unless a separate removal PR retires it.
-5. Defer legacy fallback removal until a separate legacy-removal gate exists.
+5. Defer legacy fallback removal until a separate legacy-removal gate exists and passes.
 6. Defer workflow deletion until a release readiness record approves it.
 ```

--- a/scripts/test_canonical_status_drift.py
+++ b/scripts/test_canonical_status_drift.py
@@ -30,6 +30,24 @@ DEFAULT_REQUIRED = [
     "PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER",
 ]
 
+LEGACY_REMOVAL_GATE_REQUIRED = [
+    "legacy fallback removal status: not approved until the explicit legacy fallback removal gate passes",
+    "legacy fallback removal: not approved until the explicit legacy fallback removal gate passes",
+    "## Required legacy fallback removal gate",
+    "The legacy fallback removal gate is a deletion-prevention gate, not a deletion approval by itself.",
+    "ordinary default-on weekly no-eligible run observed",
+    "vote summary PR created",
+    "no implementation-agent attempt made for no-eligible run",
+    "no Codex/API call made for no-eligible run",
+    "legacy API/SDK runner not reached for no-eligible run",
+    "eligible canonical run has selected-prompt canary evidence or a next natural eligible-run observation plan",
+    "canonical evidence artifacts remain verified",
+    "rollback plan exists",
+    "public docs no longer cite legacy fallback as an active requirement",
+    "maintainer explicitly approves removal",
+    "Until those conditions are recorded, `scripts/openai_lab_run.py` and related legacy API/SDK references remain present, non-canonical, and gated.",
+]
+
 FORBIDDEN_PHRASES = [
     "scripts/openai_lab_run.py path is canonical",
     "scripts/openai_lab_run.py is canonical",
@@ -42,6 +60,7 @@ FORBIDDEN_PHRASES = [
     "DEFAULT_USE_CANONICAL_SELECTED_PROMPT_RUNNER=false",
     "safe to delete legacy fallback now",
     "remove scripts/openai_lab_run.py now",
+    "legacy fallback removal is approved",
 ]
 
 README_FORBIDDEN_STATUS_DETAILS = [
@@ -113,12 +132,14 @@ def main() -> int:
         "Do not imply the weekly canonical selected-prompt runner is still default-off.",
         "Do not say auto-merge is enabled.",
         "Do not treat a useful lab diff as sufficient canonical evidence.",
+        "Do not describe legacy fallback removal as approved before the explicit legacy fallback removal gate passes.",
         "## Required release gate language",
         "legacy fallback documented as non-canonical",
         "operator runbook feature-flag cleanup documented",
         "weekly canonical default-on release: approved",
         "A PR that changes any canonical/legacy/default status should state:",
     ], "canonical status drift doc")
+    require_all(docs["drift_check"], LEGACY_REMOVAL_GATE_REQUIRED, "canonical status drift legacy removal gate")
 
     require_all(docs["weekly_automation"], [
         "Repository-wide canonical, legacy, default-on, auto-merge, manual-review, and release-gate status is governed by [Canonical status drift check](./canonical-status-drift-check.md).",
@@ -128,6 +149,9 @@ def main() -> int:
     require_all(docs["operator_runbook"], [
         "Repository-wide canonical, legacy, default-on, auto-merge, manual-review, and release-gate status is governed by [Canonical status drift check](./canonical-status-drift-check.md).",
         "This runbook is the operating procedure, not a second status source of truth.",
+        "Do not remove `scripts/openai_lab_run.py` during ordinary cleanup.",
+        "A future legacy fallback removal PR may be opened only after the explicit legacy fallback removal gate in [Workflow family map](./workflow-family-map.md) passes.",
+        "If any item is missing, keep the legacy fallback present, non-canonical, and gated.",
     ], "operator runbook status source pointer")
 
     for name in ["readme", "current_path", "evidence_guide", "weekly_automation", "operator_runbook"]:
@@ -179,6 +203,10 @@ def main() -> int:
         "It is non-canonical.",
         "It should not be removed merely because the canonical weekly runner is default-on.",
         "Removal requires a separate legacy-removal gate after ordinary default-on operation is verified.",
+        "## Legacy fallback removal gate",
+        "It does not approve deletion by itself.",
+        "Generated snapshots intentionally untouched: true",
+        "Failing any condition means the legacy fallback remains present, non-canonical, and gated.",
         "They are not deletion instructions.",
     ], "workflow family map legacy status")
 

--- a/scripts/test_weekly_operator_docs.py
+++ b/scripts/test_weekly_operator_docs.py
@@ -46,6 +46,22 @@ RUNBOOK_REQUIRED_TEXT = [
     "## Output cap status",
     "The old API-era `MAX_OUTPUT_TOKENS` value is not an active canonical Codex runner control.",
     "output_token_cap_enforced: false",
+    "## Legacy fallback removal gate",
+    "Do not remove `scripts/openai_lab_run.py` during ordinary cleanup.",
+    "A future legacy fallback removal PR may be opened only after the explicit legacy fallback removal gate in [Workflow family map](./workflow-family-map.md) passes.",
+    "ordinary default-on weekly no-eligible run observed",
+    "vote summary PR created",
+    "implementation PR: none for the no-eligible run",
+    "no implementation-agent attempt made for the no-eligible run",
+    "no Codex/API call made for the no-eligible run",
+    "legacy API/SDK runner not reached for the no-eligible run",
+    "eligible canonical run has selected-prompt canary evidence or a next natural eligible-run observation plan",
+    "canonical evidence artifacts remain verified",
+    "manual review remains required",
+    "auto-merge remains disabled",
+    "rollback plan exists",
+    "maintainer explicitly approves removal",
+    "If any item is missing, keep the legacy fallback present, non-canonical, and gated.",
     "canonical evidence artifacts are missing for a canonical run",
     "OPENAI_API_KEY present before codex exec: no",
 ]
@@ -115,6 +131,18 @@ DRIFT_REQUIRED_TEXT = [
     "manual review remains required",
     "auto-merge remains disabled",
     "weekly canonical default-on release: approved",
+    "## Required legacy fallback removal gate",
+    "The legacy fallback removal gate is a deletion-prevention gate, not a deletion approval by itself.",
+    "ordinary default-on weekly no-eligible run observed",
+    "vote summary PR created",
+    "no implementation-agent attempt made for no-eligible run",
+    "no Codex/API call made for no-eligible run",
+    "legacy API/SDK runner not reached for no-eligible run",
+    "eligible canonical run has selected-prompt canary evidence or a next natural eligible-run observation plan",
+    "canonical evidence artifacts remain verified",
+    "rollback plan exists",
+    "public docs no longer cite legacy fallback as an active requirement",
+    "maintainer explicitly approves removal",
 ]
 
 FORBIDDEN_TEXT = [
@@ -126,6 +154,8 @@ FORBIDDEN_TEXT = [
     "Still not default-on",
     "DEFAULT_USE_CANONICAL_SELECTED_PROMPT_RUNNER=false",
     "MAX_OUTPUT_TOKENS remains at the current configured limit until the system is complete.",
+    "safe to delete legacy fallback now",
+    "legacy fallback removal is approved",
 ]
 
 RUNBOOK_RELEASE_GATE_FORBIDDEN_TEXT = [
@@ -160,6 +190,7 @@ def main() -> int:
     require_all(drift, DRIFT_REQUIRED_TEXT, "canonical status drift release gate")
     reject_all(runbook, FORBIDDEN_TEXT, "operator runbook")
     reject_all(weekly, FORBIDDEN_TEXT, "weekly automation doc")
+    reject_all(drift, FORBIDDEN_TEXT, "canonical status drift doc")
     reject_all(runbook, RUNBOOK_RELEASE_GATE_FORBIDDEN_TEXT, "operator runbook release gate duplication")
     reject_all(weekly, WEEKLY_RELEASE_GATE_FORBIDDEN_TEXT, "weekly automation release gate duplication")
 
@@ -168,6 +199,12 @@ def main() -> int:
 
     if runbook.index("Temporary override policy") > runbook.index("Default-on release status"):
         raise SystemExit("runbook override policy should precede the default-on release status")
+
+    if runbook.index("Output cap status") > runbook.index("Legacy fallback removal gate"):
+        raise SystemExit("runbook legacy fallback removal gate should follow output cap status")
+
+    if runbook.index("Legacy fallback removal gate") > runbook.index("Reset and cleanup policy"):
+        raise SystemExit("runbook cleanup policy should follow legacy fallback removal gate")
 
     if weekly.index("Canonical selected-prompt default") > weekly.index("Canonical weekly evidence artifacts"):
         raise SystemExit("weekly doc should define the default before evidence artifacts")

--- a/scripts/test_workflow_family_map.py
+++ b/scripts/test_workflow_family_map.py
@@ -66,6 +66,32 @@ REQUIRED_DOC_TEXT = [
     "The weekly feature flag alone must not silently spend a legacy API/SDK attempt.",
     "It should not be removed merely because the canonical weekly runner is default-on.",
     "Removal requires a separate legacy-removal gate after ordinary default-on operation is verified.",
+    "## Legacy fallback removal gate",
+    "This gate defines when it is permissible to open a later PR that removes the legacy API/SDK fallback path.",
+    "It does not remove `scripts/openai_lab_run.py`.",
+    "It does not approve deletion by itself.",
+    "ordinary default-on weekly no-eligible run observed",
+    "vote summary PR created",
+    "implementation PR: none for the no-eligible run",
+    "no implementation-agent attempt made for the no-eligible run",
+    "no Codex/API call made for the no-eligible run",
+    "legacy API/SDK runner not reached for the no-eligible run",
+    "eligible canonical run has selected-prompt canary evidence or a next natural eligible-run observation plan",
+    "canonical diagnostics artifact remains verified",
+    "canonical public bundle artifact remains verified",
+    "canonical uploaded bundle verification artifact remains verified",
+    "manual review remains required",
+    "auto-merge remains disabled",
+    "rollback plan exists",
+    "public docs no longer cite legacy fallback as an active requirement",
+    "maintainer explicitly approves removal",
+    "Legacy files removed:",
+    "Legacy workflows or branches affected:",
+    "Observed no-eligible run:",
+    "Observed eligible canonical evidence or planned natural eligible observation:",
+    "Generated snapshots intentionally untouched: true",
+    "Contract tests updated:",
+    "Failing any condition means the legacy fallback remains present, non-canonical, and gated.",
     "These are candidates for future consolidation. They are not deletion instructions.",
     "A workflow removal PR must state:",
     "Evidence role:",
@@ -77,7 +103,7 @@ REQUIRED_DOC_TEXT = [
     "Rollback path:",
     "Keep weak historical canary workflows gated unless a maintainer intentionally enables ALLOW_HISTORICAL_WEAK_CANARY_WORKFLOWS=true.",
     "Keep the legacy weekly fallback gated by PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN=true unless a separate removal PR retires it.",
-    "Defer legacy fallback removal until a separate legacy-removal gate exists.",
+    "Defer legacy fallback removal until a separate legacy-removal gate exists and passes.",
 ]
 
 REQUIRED_INVENTORY_TEXT = [
@@ -95,6 +121,7 @@ FORBIDDEN_DOC_TEXT = [
     "bulk delete",
     "remove all canary workflows",
     "rename all canary workflows",
+    "legacy fallback removal is approved",
 ]
 
 
@@ -141,6 +168,10 @@ def main() -> int:
         raise SystemExit("historical weak canary gate should follow canary evidence workflows")
     if doc.index("## Historical weak canary gate") > doc.index("## Canary-era archive boundary"):
         raise SystemExit("canary-era archive boundary should follow weak canary gate")
+    if doc.index("## Legacy fallback workflows and paths") > doc.index("## Legacy fallback removal gate"):
+        raise SystemExit("legacy fallback removal gate should follow legacy fallback paths")
+    if doc.index("## Legacy fallback removal gate") > doc.index("## Cleanup candidates"):
+        raise SystemExit("cleanup candidates should follow legacy fallback removal gate")
     if doc.index("## Cleanup candidates") > doc.index("## Removal gate for workflows"):
         raise SystemExit("workflow removal gate should follow cleanup candidates")
 


### PR DESCRIPTION
## Summary
- Define the explicit legacy fallback removal gate before any deletion work.
- Mark legacy fallback removal as not approved until the gate passes.
- Add operator-facing removal criteria for `scripts/openai_lab_run.py`.
- Extend contract tests so the gate, no-eligible observation requirements, manual review, auto-merge disabled state, rollback plan, and maintainer approval remain documented.

## Scope
- `docs/canonical-status-drift-check.md`
- `docs/workflow-family-map.md`
- `docs/operator-runbook.md`
- `scripts/test_canonical_status_drift.py`
- `scripts/test_workflow_family_map.py`
- `scripts/test_weekly_operator_docs.py`

## Non-goals
- No legacy runner removal.
- No workflow change.
- No runner code change.
- No lab implementation change.
- No generated snapshot edit.
- No model, retry, fallback-policy, or token-cap change.
- No auto-merge.

## Removal gate fixed by this PR
A later removal PR must record, at minimum:

```text
ordinary default-on weekly no-eligible run observed
vote summary PR created
implementation PR: none for the no-eligible run
no implementation-agent attempt made for the no-eligible run
no Codex/API call made for the no-eligible run
legacy API/SDK runner not reached for the no-eligible run
eligible canonical run has selected-prompt canary evidence or a next natural eligible-run observation plan
canonical evidence artifacts remain verified
manual review remains required
auto-merge remains disabled
rollback plan exists
public docs no longer cite legacy fallback as an active requirement
maintainer explicitly approves removal
```

## Notes
This PR intentionally keeps `scripts/openai_lab_run.py` present, non-canonical, and gated. It only defines when a later removal PR may be considered.