### PR TITLE
Fix Pages smoke baseline copy

### DIFF
--- a/scripts/pages-smoke-check.py
+++ b/scripts/pages-smoke-check.py
@@ -11,6 +11,15 @@ import sys
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+ROOT_EXPECTED_TEXT = [
+    "Prompt Vote Lab",
+    "20-vote baseline",
+]
+
+LAB_EXPECTED_TEXT = [
+    "Prompt Vote Lab",
+]
+
 
 def fetch(url: str) -> tuple[int, str, str]:
     req = Request(url, headers={"User-Agent": "prompt-vote-lab-pages-smoke-check"})
@@ -36,15 +45,19 @@ def require(url: str, expected: str) -> None:
     print(f"OK: {url}")
 
 
+def require_all(url: str, expected_texts: list[str]) -> None:
+    for expected in expected_texts:
+        require(url, expected)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--base-url", required=True, help="Example: https://unjuno.github.io/prompt-vote-lab")
     args = parser.parse_args()
 
     base = args.base_url.rstrip("/")
-    require(base + "/", "Prompt Vote Lab")
-    require(base + "/", "20 virtual votes")
-    require(base + "/lab/", "Prompt Vote Lab")
+    require_all(base + "/", ROOT_EXPECTED_TEXT)
+    require_all(base + "/lab/", LAB_EXPECTED_TEXT)
     return 0
 
 

--- a/scripts/test_pages_smoke_check_contract.py
+++ b/scripts/test_pages_smoke_check_contract.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "pages-smoke-check.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "pages-smoke-check.yml"
+INDEX = ROOT / "index.html"
+LAB_INDEX = ROOT / "lab" / "index.html"
+
+REQUIRED_SCRIPT_TEXT = [
+    "ROOT_EXPECTED_TEXT",
+    "LAB_EXPECTED_TEXT",
+    "20-vote baseline",
+    "require_all(base + \"/\", ROOT_EXPECTED_TEXT)",
+    "require_all(base + \"/lab/\", LAB_EXPECTED_TEXT)",
+]
+
+REQUIRED_WORKFLOW_TEXT = [
+    "name: GitHub Pages Smoke Check",
+    "python scripts/pages-smoke-check.py --base-url \"https://unjuno.github.io/prompt-vote-lab\"",
+]
+
+FORBIDDEN_TEXT = [
+    "20 virtual votes",
+]
+
+
+def require_all(text: str, required: list[str], label: str) -> None:
+    missing = [item for item in required if item not in text]
+    if missing:
+        raise SystemExit(f"Missing {label} text: {missing}")
+
+
+def reject_all(text: str, forbidden: list[str], label: str) -> None:
+    found = [item for item in forbidden if item in text]
+    if found:
+        raise SystemExit(f"Forbidden {label} text found: {found}")
+
+
+def main() -> int:
+    script = SCRIPT.read_text(encoding="utf-8")
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    index = INDEX.read_text(encoding="utf-8")
+    lab_index = LAB_INDEX.read_text(encoding="utf-8")
+
+    require_all(script, REQUIRED_SCRIPT_TEXT, "pages smoke script")
+    require_all(workflow, REQUIRED_WORKFLOW_TEXT, "pages smoke workflow")
+    require_all(index, ["Prompt Vote Lab", "20-vote baseline"], "root landing page")
+    require_all(lab_index, ["Prompt Vote Lab"], "lab page")
+
+    reject_all(script, FORBIDDEN_TEXT, "pages smoke script")
+    reject_all(workflow, FORBIDDEN_TEXT, "pages smoke workflow")
+    reject_all(index, FORBIDDEN_TEXT, "root landing page")
+
+    print("pages smoke check contract test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Update `scripts/pages-smoke-check.py` to check the current landing-page baseline copy: `20-vote baseline`.
- Remove the stale `20 virtual votes` expectation that caused the scheduled Pages smoke check to fail.
- Add a small contract test documenting the smoke-check expectations and forbidding the stale phrase.

## Why
The published root page still contains the intended Prompt Vote Lab and baseline messaging, but the scheduled smoke check was asserting an old LP phrase. The failure was therefore a stale smoke-test expectation, not a broken published page.

## Scope
- `scripts/pages-smoke-check.py`
- `scripts/test_pages_smoke_check_contract.py`

## Non-goals
- No lab implementation change.
- No workflow behavior change.
- No generated snapshot edit.
- No model/runner/policy change.
- No legacy fallback change.
- No auto-merge.

## Note
A direct `script-check.yml` wiring update was intentionally deferred because workflow full-file replacement was blocked by safety filtering. This PR still fixes the failing scheduled check path itself; the added contract test is available for explicit future wiring in a separate workflow PR if needed.