### PR TITLE
Add release readiness review

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,29 +15,30 @@ Prompt Vote Lab is a prompt game and experiment. Players compete by writing prom
 3. [How to participate](./how-to-participate.md) — submit, vote, and review.
 4. [Canonical runner evidence guide](./canonical-runner-evidence-guide.md) — how to verify Docker/Codex selected-prompt evidence.
 5. [Canonical status drift check](./canonical-status-drift-check.md) — canonical, legacy, default-on, auto-merge, and release-gate status contract.
-6. [Repository 5S and language policy](./repository-5s-and-language-policy.md) — cleanup, English-only, and sustain rules.
-7. [Repository cleanup inventory](./repository-cleanup-inventory.md) — protected evidence, canonical surfaces, legacy fallbacks, generated snapshots, and cleanup candidates.
-8. [Workflow family map](./workflow-family-map.md) — canonical, weekly, generated, safety, canary, legacy, and test workflow classification.
-9. [Usable experiment operations](./usable-experiment-ops.md) — current manual canary and comparison-run operations.
-10. [Operator runbook](./operator-runbook.md) — maintainer checklist for weekly operation, failures, merge decisions, tokens, and cleanup boundaries.
-11. [Public results export](./public-results-export.md) — raw public data snapshots for participant analysis.
-12. [Public agent run bundle](./public-agent-run-bundle.md) — redacted raw agent-run evidence; summaries are not primary evidence.
-13. [Issue lifecycle](./issue-lifecycle.md) — weekly close policy; Issues are closed, not deleted.
-14. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
-15. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
-16. [Weekly automation](./weekly-automation.md) — weekly schedule, support unlock prerequisite, and E2E status.
-17. [Automation map](./automation-map.md) — workflow boundaries.
-18. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
-19. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
-20. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and pre-canary cleanup.
-21. [Fixed first canary prompt](./first-canary-prompt.md) — the only allowed first real canary prompt.
-22. [First canary readiness checklist](./first-canary-readiness.md) — final check before running the first real canary.
-23. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
-24. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
-25. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
-26. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
-27. [Report policy](./report-policy.md) — weekly report draft policy.
-28. [Pre-API freeze checklist](./pre-api-freeze.md) — gates before paid agent runs.
+6. [Release readiness review](./release-readiness-review.md) — security posture, participant journey, live preview, and release decision review.
+7. [Repository 5S and language policy](./repository-5s-and-language-policy.md) — cleanup, English-only, and sustain rules.
+8. [Repository cleanup inventory](./repository-cleanup-inventory.md) — protected evidence, canonical surfaces, legacy fallbacks, generated snapshots, and cleanup candidates.
+9. [Workflow family map](./workflow-family-map.md) — canonical, weekly, generated, safety, canary, legacy, and test workflow classification.
+10. [Usable experiment operations](./usable-experiment-ops.md) — current manual canary and comparison-run operations.
+11. [Operator runbook](./operator-runbook.md) — maintainer checklist for weekly operation, failures, merge decisions, tokens, and cleanup boundaries.
+12. [Public results export](./public-results-export.md) — raw public data snapshots for participant analysis.
+13. [Public agent run bundle](./public-agent-run-bundle.md) — redacted raw agent-run evidence; summaries are not primary evidence.
+14. [Issue lifecycle](./issue-lifecycle.md) — weekly close policy; Issues are closed, not deleted.
+15. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
+16. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
+17. [Weekly automation](./weekly-automation.md) — weekly schedule, support unlock prerequisite, and E2E status.
+18. [Automation map](./automation-map.md) — workflow boundaries.
+19. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
+20. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
+21. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and pre-canary cleanup.
+22. [Fixed first canary prompt](./first-canary-prompt.md) — the only allowed first real canary prompt.
+23. [First canary readiness checklist](./first-canary-readiness.md) — final check before running the first real canary.
+24. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
+25. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
+26. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
+27. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
+28. [Report policy](./report-policy.md) — weekly report draft policy.
+29. [Pre-API freeze checklist](./pre-api-freeze.md) — gates before paid agent runs.
 
 ## Current reputation status
 
@@ -50,6 +51,25 @@ The repository records outcomes. Workflows do not yet compute player rankings, t
 Participants should start with [Participant guide](./for-participants.md).
 
 The first useful action is usually voting with 👍 on an existing `prompt-proposal` Issue. Prompt submission is the second step, not the first step.
+
+## Release readiness status
+
+The [Release readiness review](./release-readiness-review.md) is the release-facing check for three user-visible questions:
+
+```text
+security posture
+participant journey
+live preview
+```
+
+It currently records:
+
+```text
+security posture: PASS with remaining operational observation
+participant journey: PASS
+live preview: PASS
+ordinary default-on weekly observation: pending
+```
 
 ## Repository cleanup status
 

--- a/docs/release-readiness-review.md
+++ b/docs/release-readiness-review.md
@@ -1,0 +1,289 @@
+# Release readiness review
+
+This document is the release-facing review page for Prompt Vote Lab.
+
+It answers three practical questions:
+
+```text
+Is the current system secure enough for a static public experiment?
+Is there a participant path from first visit to useful action?
+Is there a live preview path for the lab and recorded outcomes?
+```
+
+It is not a replacement for the canonical status contract. Canonical, legacy, default-on, auto-merge, and release-gate status remains owned by `docs/canonical-status-drift-check.md`.
+
+## Current judgment
+
+```text
+security posture: PASS with remaining operational observation
+participant journey: PASS
+live preview: PASS
+release blocker: none known from static review
+ordinary default-on weekly observation: pending
+```
+
+The project is not fully production-proven until at least one ordinary post-default-on weekly run is observed.
+
+## Security review
+
+### Static-site boundary
+
+Current public surfaces are static pages and repository-rendered documents.
+
+The lab page sets a restrictive Content Security Policy:
+
+```text
+default-src 'self'
+script-src 'self'
+style-src 'self'
+img-src 'self' data:
+connect-src 'none'
+frame-src 'none'
+object-src 'none'
+base-uri 'none'
+form-action 'none'
+```
+
+Security consequence:
+
+```text
+external network calls are blocked by policy
+iframes are blocked
+forms are blocked
+external scripts are blocked
+object/embed surfaces are blocked
+```
+
+### Runtime behavior
+
+Current `lab/app.js` only records that JavaScript is enabled:
+
+```text
+document.documentElement.dataset.js = 'enabled'
+```
+
+Current lab runtime does not fetch, post, track, authenticate, take payment, or store cookies.
+
+### Repository guardrails
+
+Implementation-agent changes are constrained by multiple layers:
+
+```text
+editable files: lab/index.html, lab/style.css, lab/app.js
+changed-file guard: required
+safety-check: required
+static-site-check: required
+manual review: required
+auto-merge: disabled
+```
+
+The static UI rule forbids:
+
+```text
+fetch
+XMLHttpRequest
+WebSocket
+EventSource
+eval
+document.cookie
+external scripts
+external APIs
+trackers
+login forms
+payment forms
+password fields
+```
+
+### Canonical runner boundary
+
+The current canonical implementation runner is the Docker/Codex selected-prompt task-packet path:
+
+```text
+/work:rw
+/task:ro
+/codex-runtime:rw
+repo root not mounted
+OPENAI_API_KEY unset before codex exec
+copyback restricted to lab/index.html, lab/style.css, lab/app.js
+```
+
+Canonical implementation evidence must include:
+
+```text
+Runner: codex-cli-selected-prompt-packet-container
+Canonical selected-prompt runner: true
+```
+
+### Legacy API/SDK isolation
+
+The legacy API/SDK path remains present but is non-canonical.
+
+It is isolated by wording and gates:
+
+```text
+first-canary workflow requires confirm_legacy_api_canary: RUN_LEGACY_API_CANARY
+ordinary week-* legacy fallback requires PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN=true
+```
+
+The weekly canonical feature flag alone must not silently spend a legacy API/SDK attempt.
+
+### Security limitations
+
+The system is not a general secure application platform.
+
+It does not provide:
+
+```text
+user accounts
+server-side authorization
+database isolation
+private submissions
+secret handling by the browser
+moderation beyond GitHub and repository workflows
+```
+
+That is acceptable because the current product is a public static experiment, not a private app.
+
+## Participant journey review
+
+The intended participant path exists.
+
+### First visit
+
+Root landing page gives the high-level game model and primary actions:
+
+```text
+Submit a prompt
+Vote on prompts
+Watch the lab
+Read rules
+```
+
+### Lowest-friction action
+
+The participant docs correctly say that the first useful action is voting, not writing a prompt:
+
+```text
+1. Open Issues labeled prompt-proposal.
+2. Read the prompt.
+3. Add 👍 only if you trust it enough to spend one bounded implementation-agent attempt.
+4. Submit your own prompt after you understand what good prompts look like.
+```
+
+### Lab page path
+
+The lab page exposes participant navigation:
+
+```text
+Vote on prompt Issues
+Live previews
+Submit prompt
+Participant guide
+Latest comparison
+History
+Public results
+Weekly runs
+```
+
+This is enough for a new participant to:
+
+```text
+understand the game
+see the current lab
+vote with 👍
+submit a prompt
+inspect prior outcomes
+watch weekly automation
+```
+
+### Remaining journey weakness
+
+The journey depends on GitHub.
+
+Users without GitHub accounts can read the project and live previews, but they cannot vote with reactions or submit Issues.
+
+This is acceptable for the current GitHub-native release.
+
+## Live preview review
+
+Live preview exists.
+
+The repository is designed for GitHub Pages with:
+
+```text
+branch: main
+folder: /
+```
+
+Useful preview paths are:
+
+```text
+/       stable landing page
+/lab/   current accepted lab UI
+/lab/comparisons/<week>/   comparison dashboard
+/lab/comparisons/<week>/rank-<n>/   rank output preview
+/lab/history/   historical state flow
+```
+
+The lab page already includes a `Live previews` section with links to:
+
+```text
+current accepted lab
+2026-W20 rank 1 output
+2026-W20 rank 2 output
+2026-W20 rank 3 output
+2026-W20 comparison dashboard
+history
+```
+
+## Release blockers
+
+No release blocker is known from this static review.
+
+Still required before stronger release claim:
+
+```text
+observe ordinary default-on weekly run
+confirm no-eligible path stops before implementation-agent attempt when baseline wins
+confirm no legacy API/SDK path is reached during ordinary weekly operation
+record the result in runs/ or release notes
+```
+
+## Release decision rule
+
+Use this decision rule:
+
+```text
+PASS if:
+  static security boundary remains intact
+  participant journey links remain visible
+  live preview links render
+  ordinary default-on weekly run is observed
+  manual review remains required
+  auto-merge remains disabled
+
+FAIL if:
+  any external runtime dependency is added
+  lab begins calling network APIs
+  cookies, login, payment, iframe, or tracking behavior appears
+  implementation runs when no eligible candidate exists
+  legacy API/SDK runner is reached without explicit diagnostic gate
+  auto-merge is enabled
+
+UNCERTAIN if:
+  ordinary weekly run has not been observed yet
+  generated evidence is stale or missing
+  GitHub Pages deployment status is unknown
+```
+
+## Current next action
+
+Do not delete the legacy fallback yet.
+
+Next safe action:
+
+```text
+define the legacy fallback removal gate
+observe the next ordinary default-on weekly run
+then decide whether to retire the legacy fallback
+```


### PR DESCRIPTION
## Summary
- Add `docs/release-readiness-review.md` as a release-facing static review of security posture, participant journey, and live preview status.
- Link the new review from `docs/README.md`.
- Record the current judgment: static security posture PASS with remaining operational observation, participant journey PASS, live preview PASS, and ordinary default-on weekly observation still pending.

## Scope
- `docs/release-readiness-review.md`
- `docs/README.md`

## Current review outcome
- Security: static boundary is strong for the current public experiment, with ordinary weekly observation still pending.
- User journey: root landing, participant guide, lab navigation, Issues, runs, history, and public results provide a coherent path.
- Live preview: `/lab/`, comparison outputs, comparison dashboard, and history are linked from the lab page.

## Non-goals
- No workflow change.
- No runner code change.
- No lab implementation change.
- No generated evidence change.
- No auto-merge.
- No legacy fallback removal.