### PR TITLE
Add root folder audit

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,29 +16,30 @@ Prompt Vote Lab is a prompt game and experiment. Players compete by writing prom
 4. [Canonical runner evidence guide](./canonical-runner-evidence-guide.md) — how to verify Docker/Codex selected-prompt evidence.
 5. [Canonical status drift check](./canonical-status-drift-check.md) — canonical, legacy, default-on, auto-merge, and release-gate status contract.
 6. [Release readiness review](./release-readiness-review.md) — security posture, participant journey, live preview, and release decision review.
-7. [Repository 5S and language policy](./repository-5s-and-language-policy.md) — cleanup, English-only, and sustain rules.
-8. [Repository cleanup inventory](./repository-cleanup-inventory.md) — protected evidence, canonical surfaces, legacy fallbacks, generated snapshots, and cleanup candidates.
-9. [Workflow family map](./workflow-family-map.md) — canonical, weekly, generated, safety, canary, legacy, and test workflow classification.
-10. [Usable experiment operations](./usable-experiment-ops.md) — current manual canary and comparison-run operations.
-11. [Operator runbook](./operator-runbook.md) — maintainer checklist for weekly operation, failures, merge decisions, tokens, and cleanup boundaries.
-12. [Public results export](./public-results-export.md) — raw public data snapshots for participant analysis.
-13. [Public agent run bundle](./public-agent-run-bundle.md) — redacted raw agent-run evidence; summaries are not primary evidence.
-14. [Issue lifecycle](./issue-lifecycle.md) — weekly close policy; Issues are closed, not deleted.
-15. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
-16. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
-17. [Weekly automation](./weekly-automation.md) — weekly schedule, support unlock prerequisite, and E2E status.
-18. [Automation map](./automation-map.md) — workflow boundaries.
-19. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
-20. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
-21. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and pre-canary cleanup.
-22. [Fixed first canary prompt](./first-canary-prompt.md) — the only allowed first real canary prompt.
-23. [First canary readiness checklist](./first-canary-readiness.md) — final check before running the first real canary.
-24. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
-25. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
-26. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
-27. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
-28. [Report policy](./report-policy.md) — weekly report draft policy.
-29. [Pre-API freeze checklist](./pre-api-freeze.md) — gates before paid agent runs.
+7. [Root folder audit](./root-folder-audit.md) — top-level folder roles, cleanup posture, and maintainer questions before cleanup.
+8. [Repository 5S and language policy](./repository-5s-and-language-policy.md) — cleanup, English-only, and sustain rules.
+9. [Repository cleanup inventory](./repository-cleanup-inventory.md) — protected evidence, canonical surfaces, legacy fallbacks, generated snapshots, and cleanup candidates.
+10. [Workflow family map](./workflow-family-map.md) — canonical, weekly, generated, safety, canary, legacy, and test workflow classification.
+11. [Usable experiment operations](./usable-experiment-ops.md) — current manual canary and comparison-run operations.
+12. [Operator runbook](./operator-runbook.md) — maintainer checklist for weekly operation, failures, merge decisions, tokens, and cleanup boundaries.
+13. [Public results export](./public-results-export.md) — raw public data snapshots for participant analysis.
+14. [Public agent run bundle](./public-agent-run-bundle.md) — redacted raw agent-run evidence; summaries are not primary evidence.
+15. [Issue lifecycle](./issue-lifecycle.md) — weekly close policy; Issues are closed, not deleted.
+16. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
+17. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
+18. [Weekly automation](./weekly-automation.md) — weekly schedule, support unlock prerequisite, and E2E status.
+19. [Automation map](./automation-map.md) — workflow boundaries.
+20. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
+21. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
+22. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and pre-canary cleanup.
+23. [Fixed first canary prompt](./first-canary-prompt.md) — the only allowed first real canary prompt.
+24. [First canary readiness checklist](./first-canary-readiness.md) — final check before running the first real canary.
+25. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
+26. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
+27. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
+28. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
+29. [Report policy](./report-policy.md) — weekly report draft policy.
+30. [Pre-API freeze checklist](./pre-api-freeze.md) — gates before paid agent runs.
 
 ## Current reputation status
 
@@ -76,6 +77,8 @@ ordinary default-on weekly observation: pending
 Maintainer-authored repository content should be English.
 
 The [Repository 5S and language policy](./repository-5s-and-language-policy.md) defines Sort, Set in order, Shine, Standardize, and Sustain rules for cleanup PRs.
+
+The [Root folder audit](./root-folder-audit.md) records top-level folder roles, cleanup posture, and maintainer questions before broad cleanup.
 
 The [Repository cleanup inventory](./repository-cleanup-inventory.md) classifies protected evidence, canonical active surfaces, legacy fallbacks, generated snapshots, cleanup candidates, and not-yet-removable items before any deletion work.
 

--- a/docs/root-folder-audit.md
+++ b/docs/root-folder-audit.md
@@ -1,0 +1,67 @@
+# Root folder audit
+
+This document records a top-level repository audit before cleanup.
+
+## Current judgment
+
+```text
+static security posture: acceptable
+participant journey: present
+live preview: present
+bulk cleanup: not recommended yet
+ordinary default-on weekly observation: pending
+```
+
+## Top-level surfaces
+
+| Surface | Role | Status | Action |
+|---|---|---|---|
+| `.github/` | workflows and templates | active plus historical | keep and classify |
+| `data/` | public generated data | protected evidence | keep under owning workflows |
+| `docs/` | explanation and operations | active documentation | keep and consolidate |
+| `formal/` | Lean policy evidence | contract or historical evidence | keep for now |
+| `lab/` | public static lab and previews | active product surface | keep |
+| `rules/` | agent and experiment constraints | active plus historical policy | keep and label |
+| `runs/` | weekly summaries and records | protected evidence | keep |
+| `scripts/` | automation, generators, guards, tests | active machinery plus legacy path | keep and map dependencies |
+| `tests/` | fixtures and test support | support surface | keep when referenced |
+| `index.html` | landing page | active entry | keep |
+| `README.md` | repository entry | active entry | keep |
+| `LICENSE` | license | required | keep |
+
+## Findings
+
+1. No top-level surface is obviously misplaced for the current static GitHub Pages experiment.
+2. The repository is evidence-heavy, not automatically messy.
+3. Historical and legacy surfaces must stay clearly labeled.
+4. The largest remaining release condition is ordinary default-on weekly observation.
+5. Cleanup should be staged by gates, not performed as a broad sweep.
+
+## Questions before cleanup
+
+```text
+Q1. Should historical canary workflows stay until after ordinary default-on weekly observation?
+Q2. Should old canary docs later move under an archive index?
+Q3. Should the Lean formal layer remain active after release?
+Q4. Should live previews use a generated latest-comparison pointer?
+Q5. Should run records be treated as stable after merge?
+Q6. Should scripts stay flat until after release?
+Q7. Should fixture ownership be documented if fixtures grow?
+```
+
+## Recommended order
+
+```text
+1. Define legacy fallback removal gate.
+2. Observe ordinary default-on weekly run.
+3. Add script dependency map if script cleanup is desired.
+4. Add workflow retirement plan if old canary workflows are retired.
+5. Add archive indexes for historical docs or rules if desired.
+6. Change only items whose gate is satisfied.
+```
+
+## Current answer
+
+The repository should not receive broad cleanup yet.
+
+It should receive staged cleanup after the release gates are explicit.


### PR DESCRIPTION
## Summary
- Add `docs/root-folder-audit.md` to classify root-level folders before cleanup.
- Record that bulk cleanup is not recommended yet; cleanup should be staged by gates.
- Add maintainer questions for historical workflows, docs, formal layer, live previews, run records, scripts, and fixtures.
- Link the audit from `docs/README.md`.

## Scope
- `docs/root-folder-audit.md`
- `docs/README.md`

## Current finding
No top-level folder is obviously misplaced for the current static GitHub Pages experiment. The repository is evidence-heavy, not automatically messy. Cleanup should follow explicit gates rather than broad deletion.

## Non-goals
- No deletion.
- No workflow change.
- No runner code change.
- No lab implementation change.
- No generated evidence change.
- No legacy fallback removal.