### PR TITLE
Link cleanup documentation

### DIFF
--- a/docs/root-folder-audit.md
+++ b/docs/root-folder-audit.md
@@ -12,6 +12,18 @@ bulk cleanup: not recommended yet
 ordinary default-on weekly observation: pending
 ```
 
+## Related cleanup documents
+
+Use these documents together:
+
+```text
+root-folder-audit.md -> top-level surfaces and cleanup questions
+script-dependency-map.md -> script families and retirement prerequisites
+workflow-family-map.md -> workflow families and retirement gates
+document-format-policy.md -> .md versus .mdx decision
+repository-cleanup-inventory.md -> protected evidence and cleanup candidates
+```
+
 ## Top-level surfaces
 
 | Surface | Role | Status | Action |

--- a/docs/script-dependency-map.md
+++ b/docs/script-dependency-map.md
@@ -17,6 +17,17 @@ contract tests: keep
 ordinary default-on weekly observation: pending
 ```
 
+## Related cleanup documents
+
+Use these documents together:
+
+```text
+root-folder-audit.md -> top-level surfaces and cleanup questions
+workflow-family-map.md -> workflow families and retirement gates
+document-format-policy.md -> documentation format and .md versus .mdx decision
+repository-cleanup-inventory.md -> protected evidence and cleanup candidates
+```
+
 ## Script families
 
 | Family | Examples | Current role | Cleanup posture |


### PR DESCRIPTION
## Summary
- Add related-document links to `docs/root-folder-audit.md`.
- Add related-document links to `docs/script-dependency-map.md`.
- Improve cleanup-doc reachability without updating the large docs index.

## Why
`docs/README.md` full updates have been brittle in this environment. This small PR improves discoverability of the new cleanup and document-format docs by linking the cleanup documents to each other.

## Scope
- `docs/root-folder-audit.md`
- `docs/script-dependency-map.md`

## Non-goals
- No README rewrite.
- No docs format conversion.
- No workflow change.
- No runner code change.
- No lab implementation change.
- No generated evidence change.