### PR TITLE
Record W20 ordinary weekly observation pass

### DIFF
--- a/docs/release-readiness-review.md
+++ b/docs/release-readiness-review.md
@@ -15,14 +15,29 @@ It is not a replacement for the canonical status contract. Canonical, legacy, de
 ## Current judgment
 
 ```text
-security posture: PASS with remaining operational observation
+security posture: PASS
 participant journey: PASS
 live preview: PASS
 release blocker: none known from static review
-ordinary default-on weekly observation: pending
+ordinary default-on weekly no-eligible observation: PASS
 ```
 
-The project is not fully production-proven until at least one ordinary post-default-on weekly run is observed.
+The first ordinary post-default-on weekly no-eligible run has been observed and recorded.
+
+Evidence:
+
+```text
+support unlock file: data/support-unlocks/2026-W20.json
+vote summary PR: #333
+merged run record: runs/week-2026-W20-vote-summary.md
+baseline_won: true
+eligible_count: 0
+implementation-agent attempt: none
+auto-merge: disabled
+manual review: performed
+```
+
+This does not prove the next natural eligible weekly implementation will succeed. It does prove that the ordinary default-on no-eligible path resolves support data, records the weekly result, and stops before implementation-agent execution when the baseline wins.
 
 ## Security review
 
@@ -238,15 +253,15 @@ history
 
 ## Release blockers
 
-No release blocker is known from this static review.
+No release blocker is known from this static review and the first ordinary default-on no-eligible observation.
 
-Still required before stronger release claim:
+Still required before claiming the next natural eligible weekly implementation path is production-proven:
 
 ```text
-observe ordinary default-on weekly run
-confirm no-eligible path stops before implementation-agent attempt when baseline wins
-confirm no legacy API/SDK path is reached during ordinary weekly operation
-record the result in runs/ or release notes
+observe a natural eligible weekly implementation run
+confirm canonical Docker/Codex selected-prompt runner evidence
+confirm bounded lab-only diff
+confirm diagnostics and public bundle artifacts
 ```
 
 ## Release decision rule
@@ -258,7 +273,7 @@ PASS if:
   static security boundary remains intact
   participant journey links remain visible
   live preview links render
-  ordinary default-on weekly run is observed
+  ordinary default-on weekly no-eligible run is observed
   manual review remains required
   auto-merge remains disabled
 
@@ -271,7 +286,6 @@ FAIL if:
   auto-merge is enabled
 
 UNCERTAIN if:
-  ordinary weekly run has not been observed yet
   generated evidence is stale or missing
   GitHub Pages deployment status is unknown
 ```
@@ -283,7 +297,6 @@ Do not delete the legacy fallback yet.
 Next safe action:
 
 ```text
-define the legacy fallback removal gate
-observe the next ordinary default-on weekly run
+observe a natural eligible weekly implementation run when one occurs
 then decide whether to retire the legacy fallback
 ```

--- a/docs/root-folder-audit.md
+++ b/docs/root-folder-audit.md
@@ -9,7 +9,7 @@ static security posture: acceptable
 participant journey: present
 live preview: present
 bulk cleanup: not recommended yet
-ordinary default-on weekly observation: pending
+ordinary default-on weekly no-eligible observation: PASS
 ```
 
 ## Related cleanup documents
@@ -46,13 +46,13 @@ repository-cleanup-inventory.md -> protected evidence and cleanup candidates
 1. No top-level surface is obviously misplaced for the current static GitHub Pages experiment.
 2. The repository is evidence-heavy, not automatically messy.
 3. Historical and legacy surfaces must stay clearly labeled.
-4. The largest remaining release condition is ordinary default-on weekly observation.
+4. The ordinary default-on weekly no-eligible path has been observed and recorded for 2026-W20.
 5. Cleanup should be staged by gates, not performed as a broad sweep.
 
 ## Questions before cleanup
 
 ```text
-Q1. Should historical canary workflows stay until after ordinary default-on weekly observation?
+Q1. Should historical canary workflows stay until after a natural eligible weekly implementation run is observed?
 Q2. Should old canary docs later move under an archive index?
 Q3. Should the Lean formal layer remain active after release?
 Q4. Should live previews use a generated latest-comparison pointer?
@@ -64,9 +64,9 @@ Q7. Should fixture ownership be documented if fixtures grow?
 ## Recommended order
 
 ```text
-1. Define legacy fallback removal gate.
-2. Observe ordinary default-on weekly run.
-3. Add script dependency map if script cleanup is desired.
+1. Keep the legacy fallback removal gate in force.
+2. Observe a natural eligible weekly implementation run when one occurs.
+3. Add script dependency map if deeper script cleanup is desired.
 4. Add workflow retirement plan if old canary workflows are retired.
 5. Add archive indexes for historical docs or rules if desired.
 6. Change only items whose gate is satisfied.

--- a/docs/script-dependency-map.md
+++ b/docs/script-dependency-map.md
@@ -14,7 +14,7 @@ canonical runner helpers: keep
 legacy fallback: keep gated
 public evidence builders: keep
 contract tests: keep
-ordinary default-on weekly observation: pending
+ordinary default-on weekly no-eligible observation: PASS
 ```
 
 ## Related cleanup documents
@@ -62,6 +62,17 @@ scripts/select_eligible.py
 scripts/resolve_support_unlock.py
 .github/workflows/weekly-auto-run.yml
 .github/workflows/support-unlock-export.yml
+```
+
+The ordinary default-on no-eligible weekly path was observed for 2026-W20:
+
+```text
+support unlock file: data/support-unlocks/2026-W20.json
+vote summary PR: #333
+merged run record: runs/week-2026-W20-vote-summary.md
+baseline_won: true
+eligible_count: 0
+implementation-agent attempt: none
 ```
 
 ### Public result and comparison evidence
@@ -120,7 +131,7 @@ maintainer approval:
 
 ## Do not retire yet
 
-Do not retire these before ordinary default-on weekly observation:
+Do not retire these before a natural eligible weekly implementation run is observed:
 
 ```text
 scripts/openai_lab_run.py
@@ -139,6 +150,6 @@ Use this map with `docs/root-folder-audit.md` and `docs/workflow-family-map.md` 
 The next cleanup work should still be:
 
 ```text
-observe ordinary default-on weekly run
+observe a natural eligible weekly implementation run when one occurs
 then decide which legacy or historical helpers can move toward retirement
 ```


### PR DESCRIPTION
## Summary
- Update `docs/release-readiness-review.md` from pending to PASS for the ordinary default-on weekly no-eligible observation.
- Record W20 evidence: `data/support-unlocks/2026-W20.json`, PR #333, `runs/week-2026-W20-vote-summary.md`, `baseline_won: true`, `eligible_count: 0`, and no implementation-agent attempt.
- Update cleanup docs so they no longer describe ordinary default-on weekly observation as pending.

## Scope
- `docs/release-readiness-review.md`
- `docs/root-folder-audit.md`
- `docs/script-dependency-map.md`

## Why
The W20 ordinary default-on weekly no-eligible run has now been observed and merged through PR #333. The release readiness docs should reflect the current state.

## Non-goals
- No workflow change.
- No runner code change.
- No lab implementation change.
- No generated evidence change.
- No legacy fallback removal.
- No claim that the next natural eligible weekly implementation path is production-proven.