### PR TITLE
Update docs README release readiness status

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -66,10 +66,10 @@ live preview
 It currently records:
 
 ```text
-security posture: PASS with remaining operational observation
+security posture: PASS
 participant journey: PASS
 live preview: PASS
-ordinary default-on weekly observation: pending
+ordinary default-on weekly no-eligible observation: PASS
 ```
 
 ## Repository cleanup status


### PR DESCRIPTION
## Summary
- Update `docs/README.md` so its release-readiness status matches `docs/release-readiness-review.md`.
- Replace the stale `ordinary default-on weekly observation: pending` wording with `ordinary default-on weekly no-eligible observation: PASS`.

## Scope
- `docs/README.md`

## Why
PR #335 recorded the W20 ordinary default-on weekly no-eligible observation as PASS. The docs index still had the old pending status, which could mislead readers.

## Non-goals
- No workflow change.
- No runner code change.
- No lab implementation change.
- No generated evidence change.
- No legacy fallback removal.