### PR TITLE
Regenerate W20 comparison dashboard PR links

### DIFF
--- a/lab/comparisons/2026-W20/index.html
+++ b/lab/comparisons/2026-W20/index.html
@@ -27,15 +27,53 @@
           <div><dt>Votes</dt><dd>0</dd></div>
           <div><dt>Safety</dt><dd>clear</dd></div>
           <div><dt>Runtime scan</dt><dd>detected</dd></div>
-          <div><dt>Implementation PR</dt><dd><a href="https://github.com/Unjuno/prompt-vote-lab/pull/256">PR #256</a> · MERGED</dd></div>
+          <div><dt>Implementation PR</dt><dd><a href="https://github.com/Unjuno/prompt-vote-lab/pull/192">PR #192</a> · MERGED</dd></div>
           <div><dt>Live output</dt><dd><a href="./rank-1/">Open rank 1 output</a> · <code>lab/comparisons/2026-W20/rank-1/</code></dd></div>
           <div><dt>Run record</dt><dd><a href="https://github.com/Unjuno/prompt-vote-lab/blob/main/runs/2026-W20-rank-1-issue-191.md"><code>runs/2026-W20-rank-1-issue-191.md</code></a></dd></div>
           <div><dt>Decision</dt><dd>implemented</dd></div>
         </dl>
         <h3>Implementation PR changed files</h3>
-        <ul class="changed-files"><li><code>scripts/build_history_page.py</code></li><li><code>scripts/test_build_history_page.py</code></li></ul>
+        <ul class="changed-files"><li><code>lab/app.js</code></li><li><code>lab/index.html</code></li><li><code>lab/style.css</code></li></ul>
         <h3>Live output snapshot files</h3>
         <ul class="changed-files"><li><code>lab/comparisons/2026-W20/rank-1/index.html</code></li><li><code>lab/comparisons/2026-W20/rank-1/style.css</code></li><li><code>lab/comparisons/2026-W20/rank-1/app.js</code></li></ul>
+      </article>
+
+      <article class="rank-card" aria-labelledby="rank-2-title">
+        <p class="rank-eyebrow">Rank 2</p>
+        <h2 id="rank-2-title">[Prompt][Rank 2]: Add an evidence map for reviewing weekly runs</h2>
+        <dl class="facts">
+          <div><dt>Issue</dt><dd><a href="https://github.com/Unjuno/prompt-vote-lab/issues/195">Issue #195</a> · CLOSED</dd></div>
+          <div><dt>Votes</dt><dd>0</dd></div>
+          <div><dt>Safety</dt><dd>clear</dd></div>
+          <div><dt>Runtime scan</dt><dd>detected</dd></div>
+          <div><dt>Implementation PR</dt><dd><a href="https://github.com/Unjuno/prompt-vote-lab/pull/214">PR #214</a> · MERGED</dd></div>
+          <div><dt>Live output</dt><dd><a href="./rank-2/">Open rank 2 output</a> · <code>lab/comparisons/2026-W20/rank-2/</code></dd></div>
+          <div><dt>Run record</dt><dd><a href="https://github.com/Unjuno/prompt-vote-lab/blob/main/runs/2026-W20-rank-2-issue-195.md"><code>runs/2026-W20-rank-2-issue-195.md</code></a></dd></div>
+          <div><dt>Decision</dt><dd>implemented</dd></div>
+        </dl>
+        <h3>Implementation PR changed files</h3>
+        <ul class="changed-files"><li><code>lab/comparisons/2026-W20/rank-2/app.js</code></li><li><code>lab/comparisons/2026-W20/rank-2/index.html</code></li><li><code>lab/comparisons/2026-W20/rank-2/style.css</code></li></ul>
+        <h3>Live output snapshot files</h3>
+        <ul class="changed-files"><li><code>lab/comparisons/2026-W20/rank-2/index.html</code></li><li><code>lab/comparisons/2026-W20/rank-2/style.css</code></li><li><code>lab/comparisons/2026-W20/rank-2/app.js</code></li></ul>
+      </article>
+
+      <article class="rank-card" aria-labelledby="rank-3-title">
+        <p class="rank-eyebrow">Rank 3</p>
+        <h2 id="rank-3-title">[Prompt][Rank 3]: Add a participant decision card for weekly run review</h2>
+        <dl class="facts">
+          <div><dt>Issue</dt><dd><a href="https://github.com/Unjuno/prompt-vote-lab/issues/196">Issue #196</a> · CLOSED</dd></div>
+          <div><dt>Votes</dt><dd>0</dd></div>
+          <div><dt>Safety</dt><dd>clear</dd></div>
+          <div><dt>Runtime scan</dt><dd>detected</dd></div>
+          <div><dt>Implementation PR</dt><dd><a href="https://github.com/Unjuno/prompt-vote-lab/pull/224">PR #224</a> · MERGED</dd></div>
+          <div><dt>Live output</dt><dd><a href="./rank-3/">Open rank 3 output</a> · <code>lab/comparisons/2026-W20/rank-3/</code></dd></div>
+          <div><dt>Run record</dt><dd><a href="https://github.com/Unjuno/prompt-vote-lab/blob/main/runs/2026-W20-rank-3-issue-196.md"><code>runs/2026-W20-rank-3-issue-196.md</code></a></dd></div>
+          <div><dt>Decision</dt><dd>implemented</dd></div>
+        </dl>
+        <h3>Implementation PR changed files</h3>
+        <ul class="changed-files"><li><code>lab/comparisons/2026-W20/rank-3/app.js</code></li><li><code>lab/comparisons/2026-W20/rank-3/index.html</code></li><li><code>lab/comparisons/2026-W20/rank-3/style.css</code></li></ul>
+        <h3>Live output snapshot files</h3>
+        <ul class="changed-files"><li><code>lab/comparisons/2026-W20/rank-3/index.html</code></li><li><code>lab/comparisons/2026-W20/rank-3/style.css</code></li><li><code>lab/comparisons/2026-W20/rank-3/app.js</code></li></ul>
       </article>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- Regenerate `lab/comparisons/2026-W20/index.html` after the comparison dashboard generator fixes.
- Restore all three W20 rank cards in the generated dashboard.
- Update the Implementation PR links so they point to the actual implementation PRs:
  - Rank 1: PR #192
  - Rank 2: PR #214
  - Rank 3: PR #224
- Keep the split between `Implementation PR changed files` and `Live output snapshot files`.

## Why
The previous generated dashboard could confuse later same-Issue maintenance PRs with the implementation PR. After PR #338 fixed the generator selection logic, the W20 generated dashboard should reflect the corrected implementation PR links.

## Scope
- `lab/comparisons/2026-W20/index.html`

## Non-goals
- No scripts change.
- No root lab implementation change.
- No workflow change.
- No runner code change.
- No generated rank output snapshot change.
- No history page change.
- No legacy fallback removal.