### PR TITLE
Restore root lab minimal state

### DIFF
--- a/lab/index.html
+++ b/lab/index.html
@@ -9,144 +9,34 @@
 </head>
 <body>
   <main class="lab-root" aria-labelledby="lab-title">
-    <p class="status">
-      <span class="pill">Static lab</span>
-      <span>public evidence is the source of truth</span>
+    <p class="status" aria-live="polite">
+      <span class="pill" aria-hidden="true">Static lab</span>
+      <span id="status-text">Minimal implementation target</span>
     </p>
 
     <h1 id="lab-title">Prompt Vote Lab</h1>
     <p class="note">
-      A constrained implementation target where prompt proposals become small static UI changes. Accepted experiment runs may change this page, while Issues, PRs, run records, and public results stay visible for review.
-    </p>
-    <p class="note secondary-note">
-      Start by voting with GitHub 👍 reactions, then submit prompts once you understand what good prompts look like.
+      This area is the constrained implementation target. It starts intentionally small and may be changed only by accepted experiment runs.
     </p>
 
-    <nav class="evidence-nav" aria-label="Primary participant navigation">
-      <a class="primary-link" href="https://github.com/Unjuno/prompt-vote-lab/issues?q=is%3Aissue+label%3Aprompt-proposal">Vote on prompt Issues</a>
-      <a href="#live-previews">Live previews</a>
-      <a href="https://github.com/Unjuno/prompt-vote-lab/issues/new?template=prompt.yml">Submit prompt</a>
-      <a href="https://github.com/Unjuno/prompt-vote-lab/blob/main/docs/for-participants.md">Participant guide</a>
-      <a href="./comparisons/2026-W20/">Latest comparison</a>
-      <a href="./history/">History</a>
-      <a href="../data/public-results.md">Public results</a>
-      <a href="https://github.com/Unjuno/prompt-vote-lab/actions/workflows/weekly-auto-run.yml">Weekly runs</a>
-    </nav>
-
-    <section class="summary-card action-card" aria-labelledby="start-title">
-      <p class="eyebrow">Start here</p>
-      <h2 id="start-title">Vote first. Submit second. Watch the run trail.</h2>
-      <div class="action-grid" aria-label="Participant actions">
-        <a class="action-link" href="https://github.com/Unjuno/prompt-vote-lab/issues?q=is%3Aissue+label%3Aprompt-proposal">
-          <span>1</span>
-          <strong>Vote with 👍</strong>
-          <em>Support only prompts specific enough to deserve one bounded implementation-agent attempt.</em>
-        </a>
-        <a class="action-link" href="https://github.com/Unjuno/prompt-vote-lab/issues/new?template=prompt.yml">
-          <span>2</span>
-          <strong>Submit a small prompt</strong>
-          <em>Ask for a visible static-lab change and say what would count as a bad implementation.</em>
-        </a>
-        <a class="action-link" href="https://github.com/Unjuno/prompt-vote-lab/actions/workflows/weekly-auto-run.yml">
-          <span>3</span>
-          <strong>Watch weekly runs</strong>
-          <em>See the workflow that turns votes into a vote summary or an implementation PR.</em>
-        </a>
-      </div>
-    </section>
-
-    <section class="summary-card" aria-labelledby="baseline-rule-title">
-      <p class="eyebrow">Selection rule</p>
-      <h2 id="baseline-rule-title">Support unlocks comparison runs only after the baseline loses.</h2>
-      <p>
-        Every week includes a virtual no-change baseline with 20 votes. If that baseline ranks first, no implementation candidate runs, even when support exists.
-      </p>
-      <ol class="review-order">
-        <li>If a real prompt ranks first, Rank 1 is eligible for the normal weekly attempt.</li>
-        <li>After that baseline pass, 5 USD weekly support can unlock Rank 2 as a comparison run.</li>
-        <li>After that baseline pass, 10 USD weekly support can unlock Rank 2 and Rank 3 as comparison runs.</li>
-        <li>Rank 2 and Rank 3 do not independently need 20+ votes after Rank 1 beats the baseline.</li>
-      </ol>
-    </section>
-
-    <section class="summary-card preview-card" id="live-previews" aria-labelledby="live-preview-title">
-      <p class="eyebrow">Live previews</p>
-      <h2 id="live-preview-title">Open rendered pages, not source files.</h2>
-      <p>
-        Current lab, rank outputs, comparison dashboards, and history are all public static pages. Rank outputs show candidate implementations; dashboards and history show the evidence index around them.
-      </p>
-      <div class="preview-grid" aria-label="Live preview links">
-        <a class="preview-link preview-link--current" href="./">
-          <strong>Current accepted lab</strong>
-          <span>The live state inherited by future accepted implementation runs.</span>
-        </a>
-        <a class="preview-link" href="./comparisons/2026-W20/rank-1/">
-          <strong>2026-W20 Rank 1 output</strong>
-          <span>Issue #191 · PR #192 · accepted candidate snapshot.</span>
-        </a>
-        <a class="preview-link" href="./comparisons/2026-W20/rank-2/">
-          <strong>2026-W20 Rank 2 output</strong>
-          <span>Issue #195 · PR #214 · comparison candidate snapshot.</span>
-        </a>
-        <a class="preview-link" href="./comparisons/2026-W20/rank-3/">
-          <strong>2026-W20 Rank 3 output</strong>
-          <span>Issue #196 · PR #224 · comparison candidate snapshot.</span>
-        </a>
-        <a class="preview-link" href="./comparisons/2026-W20/">
-          <strong>2026-W20 comparison dashboard</strong>
-          <span>Rank cards, Issues, PRs, run records, and output roots.</span>
-        </a>
-        <a class="preview-link" href="./history/">
-          <strong>History</strong>
-          <span>Weekly progression generated from public results.</span>
-        </a>
-      </div>
-    </section>
-
-    <section class="summary-card" aria-labelledby="live-run-title">
-      <p class="eyebrow">Live run trail</p>
-      <h2 id="live-run-title">The latest verified path is visible.</h2>
-      <p>
-        The no-eligible live path has been verified: support export produced a public unlock file, weekly automation read it, and the no-change baseline won without creating an implementation PR.
-      </p>
-      <div class="run-links" aria-label="Live run evidence links">
-        <a href="https://github.com/Unjuno/prompt-vote-lab/actions/workflows/support-unlock-export.yml">Support Unlock Export workflow</a>
-        <a href="../data/support-unlocks/2026-W19.json">2026-W19 support unlock JSON</a>
-        <a href="https://github.com/Unjuno/prompt-vote-lab/actions/workflows/weekly-auto-run.yml">Weekly Auto Run workflow</a>
-        <a href="https://github.com/Unjuno/prompt-vote-lab/blob/main/runs/week-2026-W19-vote-summary.md">2026-W19 vote summary</a>
-        <a href="https://github.com/Unjuno/prompt-vote-lab/pull/243">Vote summary PR #243</a>
-      </div>
-    </section>
-
-    <section class="summary-card" aria-labelledby="current-status-title">
-      <p class="eyebrow">Current public state</p>
-      <h2 id="current-status-title">2026-W20 comparison is complete.</h2>
-      <p>
-        Rank 1, Rank 2, and Rank 3 comparison outputs are recorded. Each candidate links back to its Issue, implementation PR, run record, and output root.
-      </p>
-      <ul class="status-list">
-        <li><span>Rank 1</span><strong>Issue #191 · PR #192 · implemented</strong></li>
-        <li><span>Rank 2</span><strong>Issue #195 · PR #214 · implemented</strong></li>
-        <li><span>Rank 3</span><strong>Issue #196 · PR #224 · implemented</strong></li>
-      </ul>
-    </section>
-
-    <section class="summary-card" aria-labelledby="participant-action-title">
-      <p class="eyebrow">Prompt quality</p>
-      <h2 id="participant-action-title">A good prompt is small, specific, and reviewable.</h2>
-      <ol class="review-order">
-        <li>Explain the visible change you want.</li>
-        <li>Keep the request inside the static lab scope.</li>
-        <li>Say what should not change.</li>
-        <li>Do not ask for login, payment, external APIs, trackers, or broad redesigns.</li>
-      </ol>
-    </section>
-
-    <section class="summary-card" aria-labelledby="scope-title">
-      <p class="eyebrow">Execution boundary</p>
-      <h2 id="scope-title">The lab remains static and local.</h2>
-      <p>
-        The accepted implementation target is limited to <code>lab/index.html</code>, <code>lab/style.css</code>, and <code>lab/app.js</code>. This page works without network access, does not call external APIs, does not use cookies, and does not collect analytics.
+    <section class="experiment-card" role="note" aria-label="Experiment status">
+      <h2>Experiment status</h2>
+      <dl class="meta-list">
+        <div>
+          <dt>Current state</dt>
+          <dd>Minimal static lab</dd>
+        </div>
+        <div>
+          <dt>Allowed mutation</dt>
+          <dd>Small local changes to this page, its stylesheet, and its script</dd>
+        </div>
+        <div>
+          <dt>Runtime boundary</dt>
+          <dd id="runtime-boundary">No network access, no cookies, no external scripts</dd>
+        </div>
+      </dl>
+      <p class="small-note">
+        Explanations, policies, history, comparisons, and public evidence live outside this root lab page. This page stays small so future accepted runs have a clear implementation target.
       </p>
     </section>
 

--- a/lab/style.css
+++ b/lab/style.css
@@ -2,10 +2,9 @@
   color-scheme: light;
   --bg: #f7f7f4;
   --fg: #191919;
-  --muted: #62615c;
+  --muted: #6a6a6a;
   --line: #deded8;
   --card: rgba(255, 255, 255, 0.68);
-  --card-strong: rgba(255, 255, 255, 0.88);
 }
 
 * {
@@ -15,15 +14,19 @@
 body {
   min-height: 100vh;
   margin: 0;
+  display: grid;
+  place-items: center;
   background: var(--bg);
   color: var(--fg);
   font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 .lab-root {
-  width: min(920px, calc(100% - 32px));
-  margin: 0 auto;
-  padding: 48px 0;
+  width: min(640px, calc(100% - 32px));
+  padding: 48px;
+  border: 1px dashed var(--line);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.55);
 }
 
 .status {
@@ -34,7 +37,7 @@ body {
   margin: 0 0 16px;
   color: var(--muted);
   font-size: 0.82rem;
-  font-weight: 800;
+  font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -51,237 +54,73 @@ body {
 }
 
 h1 {
-  max-width: 720px;
   margin: 0 0 16px;
-  font-size: clamp(2.6rem, 8vw, 5.8rem);
+  font-size: clamp(2rem, 8vw, 4.5rem);
   line-height: 0.95;
-  letter-spacing: -0.075em;
+  letter-spacing: -0.07em;
 }
 
 .note,
 noscript,
-.summary-card p {
+.small-note,
+.meta-list dd {
   color: var(--muted);
   line-height: 1.7;
 }
 
-.note {
-  max-width: 760px;
+.note,
+noscript,
+.small-note {
   margin: 0;
-  font-size: 1.05rem;
 }
 
-.evidence-nav {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin: 24px 0 0;
-}
-
-.evidence-nav a,
-.run-links a {
-  display: inline-flex;
-  align-items: center;
-  min-height: 40px;
-  padding: 0 13px;
-  border: 1px solid rgba(25, 25, 25, 0.14);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.72);
-  color: var(--fg);
-  font-size: 0.88rem;
-  font-weight: 850;
-  line-height: 1.2;
-  text-decoration: none;
-}
-
-.evidence-nav a:hover,
-.action-link:hover,
-.run-links a:hover,
-.preview-link:hover {
-  border-color: rgba(25, 25, 25, 0.38);
-}
-
-.evidence-nav .primary-link {
-  border-color: rgba(25, 25, 25, 0.5);
-  background: var(--fg);
-  color: var(--bg);
-}
-
-.summary-card {
+.experiment-card {
   margin: 18px 0 0;
-  padding: 18px;
+  padding: 16px;
+  border-radius: 18px;
   border: 1px solid rgba(25, 25, 25, 0.14);
-  border-radius: 22px;
   background: var(--card);
 }
 
-.action-card,
-.preview-card {
-  background: var(--card-strong);
+.experiment-card h2 {
+  margin: 0 0 12px;
+  font-size: 1.05rem;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
 }
 
-.eyebrow {
-  margin: 0 0 8px;
-  color: var(--muted);
-  font-size: 0.78rem;
-  font-weight: 900;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-
-.summary-card h2 {
-  margin: 0 0 10px;
-  font-size: clamp(1.3rem, 3vw, 2rem);
-  line-height: 1.12;
-  letter-spacing: -0.04em;
-}
-
-.summary-card p {
+.meta-list {
+  display: grid;
+  gap: 10px;
   margin: 0;
 }
 
-.action-grid,
-.preview-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 10px;
-  margin-top: 16px;
-}
-
-.action-link,
-.preview-link {
-  display: grid;
-  gap: 10px;
-  min-height: 100%;
-  padding: 16px;
-  border: 1px solid rgba(25, 25, 25, 0.14);
-  border-radius: 18px;
-  background: rgba(247, 247, 244, 0.62);
-  color: var(--fg);
-  text-decoration: none;
-}
-
-.action-link span {
-  display: inline-grid;
-  width: 30px;
-  height: 30px;
-  place-items: center;
-  border-radius: 999px;
-  background: var(--fg);
-  color: var(--bg);
-  font-size: 0.84rem;
-  font-weight: 900;
-}
-
-.action-link strong,
-.preview-link strong {
-  font-size: 1.05rem;
-  line-height: 1.15;
-}
-
-.action-link em,
-.preview-link span {
-  color: var(--muted);
-  font-size: 0.9rem;
-  font-style: normal;
-  font-weight: 650;
-  line-height: 1.5;
-}
-
-.preview-link--current {
-  border-color: rgba(25, 25, 25, 0.34);
-  background: rgba(255, 255, 255, 0.82);
-}
-
-.run-links {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 14px;
-}
-
-.status-list,
-.review-order {
-  margin: 14px 0 0;
-  padding: 0;
-  list-style: none;
-}
-
-.status-list {
-  display: grid;
-  gap: 10px;
-}
-
-.status-list li {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  gap: 8px 16px;
+.meta-list div {
   padding-top: 10px;
   border-top: 1px solid var(--line);
 }
 
-.status-list span,
-.review-order li::before {
-  color: var(--muted);
+.meta-list dt {
   font-weight: 900;
 }
 
-.status-list strong {
-  font-weight: 850;
+.meta-list dd {
+  margin: 3px 0 0;
 }
 
-.review-order {
-  counter-reset: step;
-}
-
-.review-order li {
-  position: relative;
-  margin: 10px 0 0;
-  padding-left: 34px;
-  line-height: 1.55;
-  font-weight: 700;
-}
-
-.review-order li::before {
-  counter-increment: step;
-  content: counter(step) ".";
-  position: absolute;
-  left: 0;
-}
-
-code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 0.92em;
+.small-note {
+  margin-top: 14px;
+  font-size: 0.86rem;
 }
 
 noscript {
   display: block;
-  margin-top: 18px;
-}
-
-@media (max-width: 720px) {
-  .action-grid,
-  .preview-grid {
-    grid-template-columns: 1fr;
-  }
+  margin-top: 16px;
 }
 
 @media (max-width: 560px) {
   .lab-root {
-    width: min(100% - 22px, 920px);
-    padding: 30px 0;
-  }
-
-  .evidence-nav a,
-  .run-links a {
-    width: 100%;
-    justify-content: center;
-    text-align: center;
-  }
-
-  .summary-card {
-    padding: 16px;
-    border-radius: 20px;
+    width: min(100% - 22px, 640px);
+    padding: 30px;
   }
 }


### PR DESCRIPTION
## Summary
- Restore root `/lab/` to a small constrained implementation target.
- Remove participant-docs/LP-style navigation, baseline/support explanation, live preview grids, and run-trail sections from the mutable root lab page.
- Keep a minimal static experiment card with current state, allowed mutation, and runtime boundary.

## Why
The root lab had drifted into a documentation/landing-page surface. That made it feel like a docs page rather than the mutable experiment target. Explanations, policies, comparisons, history, and public evidence should live outside root `/lab/`.

This PR restores the original design direction: `/lab/` is the current implementation target; comparison/history/evidence pages remain separate surfaces.

## Scope
- `lab/index.html`
- `lab/style.css`

## Non-goals
- No scripts change.
- No workflow change.
- No runner code change.
- No generated comparison/history update.
- No participant policy change.
- No legacy fallback removal.