### PR TITLE
Filter comparison dashboard candidates

### DIFF
--- a/scripts/build_comparison_dashboard.py
+++ b/scripts/build_comparison_dashboard.py
@@ -9,10 +9,15 @@ from typing import Any
 
 SAFE_CSP = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'none'; frame-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none';"
 ROOT_LAB_FILES = {"lab/index.html", "lab/style.css", "lab/app.js"}
+REQUIRED_CANDIDATE_LABELS = {"prompt-proposal", "normal-candidate"}
 
 
 def labels(item: dict[str, Any]) -> set[str]:
     return {str(x) for x in item.get('labels', [])}
+
+
+def is_comparison_candidate(issue_labels: set[str], week_id: str) -> bool:
+    return f'week:{week_id}' in issue_labels and REQUIRED_CANDIDATE_LABELS.issubset(issue_labels)
 
 
 def rank_from_issue(issue: dict[str, Any]) -> int | None:
@@ -156,7 +161,8 @@ def rows(data: dict[str, Any], week_id: str) -> list[dict[str, Any]]:
     prs = list(data.get('pull_requests', []))
     best_by_rank: dict[int, dict[str, Any]] = {}
     for issue in data.get('issues', []):
-        if f'week:{week_id}' not in labels(issue):
+        issue_labels = labels(issue)
+        if not is_comparison_candidate(issue_labels, week_id):
             continue
         rank = rank_from_issue(issue)
         issue_no = int(issue.get('number'))
@@ -168,7 +174,6 @@ def rows(data: dict[str, Any], week_id: str) -> list[dict[str, Any]]:
         if rank is None:
             continue
         pr = best_pr_for_issue(prs, issue_no, week_id, rank)
-        issue_labels = labels(issue)
         row = {
             'rank': rank,
             'issue_no': issue_no,

--- a/scripts/test_build_comparison_dashboard.py
+++ b/scripts/test_build_comparison_dashboard.py
@@ -17,10 +17,10 @@ def test_dashboard_builder() -> None:
         "issues": [
             {
                 "number": 183,
-                "title": "Old Rank 1 candidate",
+                "title": "Old Rank 1 non-prompt candidate",
                 "url": "https://example.test/issues/183",
                 "state": "CLOSED",
-                "labels": ["week:2026-W20", "prompt-proposal", "normal-candidate", "issue-safety:clear"],
+                "labels": ["week:2026-W20", "normal-candidate", "issue-safety:clear"],
                 "reaction_plus_one_count": 0,
                 "safety": {"clear": True, "blocked": False, "review": False, "runtime_detected": True},
                 "body": "## Comparison metadata\n\n- Intended comparison rank: 1",
@@ -177,7 +177,7 @@ def test_dashboard_builder() -> None:
 
     forbidden = [
         "<h3>Changed files</h3>",
-        "Old Rank 1 candidate",
+        "Old Rank 1 non-prompt candidate",
         "Issue #183",
         "PR #184",
         "old.html",


### PR DESCRIPTION
## Summary
- Restrict generated comparison dashboard rows to Issues that carry both `prompt-proposal` and `normal-candidate` labels for the requested week.
- Keep older non-prompt implemented Issues out of the weekly comparison dashboard.
- Update the comparison dashboard test so a week-labeled non-prompt Issue does not displace the intended prompt comparison set.

## Why
After PR #344 fixed public-results pagination, older `week:2026-W20` Issues re-entered `data/public-results.json`. That exposed a second bug: the dashboard generator treated every week-labeled implemented Issue as a comparison candidate.

For W20, Issue #183 is week-labeled and implemented but is not a prompt proposal. It should not replace the intended W20 comparison set:

```text
Rank 1: Issue #191 / PR #192
Rank 2: Issue #195 / PR #214
Rank 3: Issue #196 / PR #224
```

## Scope
- `scripts/build_comparison_dashboard.py`
- `scripts/test_build_comparison_dashboard.py`

## Follow-up
After this is merged, allow `Public Results Export` to regenerate generated evidence and verify `lab/comparisons/2026-W20/` shows Rank 1/2/3 correctly.

## Non-goals
- No generated evidence update in this PR.
- No root lab change.
- No workflow change.
- No runner change.
- No historical evidence rename.
- No release tag.