### PR TITLE
Make comparison rank extraction explicit

### DIFF
--- a/scripts/build_comparison_dashboard.py
+++ b/scripts/build_comparison_dashboard.py
@@ -4,12 +4,19 @@ from __future__ import annotations
 import argparse
 import html
 import json
+import re
 from pathlib import Path
 from typing import Any
 
 SAFE_CSP = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'none'; frame-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none';"
 ROOT_LAB_FILES = {"lab/index.html", "lab/style.css", "lab/app.js"}
 REQUIRED_CANDIDATE_LABELS = {"prompt-proposal", "normal-candidate"}
+ISSUE_RANK_PATTERNS = [
+    re.compile(r"intended comparison rank\s*:\s*([1-3])", re.IGNORECASE),
+    re.compile(r"\[rank\s*([1-3])\]", re.IGNORECASE),
+    re.compile(r"^\s*-\s*rank\s*:\s*([1-3])\s*$", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^\s*candidate_rank\s*:\s*([1-3])\s*$", re.IGNORECASE | re.MULTILINE),
+]
 
 
 def labels(item: dict[str, Any]) -> set[str]:
@@ -20,12 +27,18 @@ def is_comparison_candidate(issue_labels: set[str], week_id: str) -> bool:
     return f'week:{week_id}' in issue_labels and REQUIRED_CANDIDATE_LABELS.issubset(issue_labels)
 
 
-def rank_from_issue(issue: dict[str, Any]) -> int | None:
-    text = f"{issue.get('title', '')}\n{issue.get('body', '')}".lower()
-    for n in (1, 2, 3):
-        if f'rank {n}' in text or f'rank-{n}' in text or f'rank:{n}' in text:
-            return n
+def explicit_rank(text: str) -> int | None:
+    for pattern in ISSUE_RANK_PATTERNS:
+        match = pattern.search(text)
+        if match:
+            return int(match.group(1))
     return None
+
+
+def rank_from_issue(issue: dict[str, Any]) -> int | None:
+    title = str(issue.get('title', ''))
+    body = str(issue.get('body', ''))
+    return explicit_rank(body) or explicit_rank(title)
 
 
 def pr_rank(pr: dict[str, Any]) -> int | None:

--- a/scripts/test_build_comparison_dashboard.py
+++ b/scripts/test_build_comparison_dashboard.py
@@ -43,7 +43,14 @@ def test_dashboard_builder() -> None:
                 "labels": ["week:2026-W20", "prompt-proposal", "normal-candidate", "issue-safety:clear", "issue-safety:submission-detected"],
                 "reaction_plus_one_count": 4,
                 "safety": {"clear": True, "blocked": False, "review": False, "runtime_detected": True},
-                "body": "## Comparison metadata\n\n- Intended comparison rank: 2",
+                "body": (
+                    "## Comparison metadata\n\n"
+                    "- Intended comparison rank: 2\n\n"
+                    "## Optional context\n\n"
+                    "This is a rank-2 comparison candidate. It should be run with the same "
+                    "model policy, retry policy, fallback policy, and file-scope constraints "
+                    "as rank 1 and rank 3."
+                ),
             },
             {
                 "number": 196,
@@ -53,7 +60,14 @@ def test_dashboard_builder() -> None:
                 "labels": ["week:2026-W20", "prompt-proposal", "normal-candidate", "issue-safety:clear", "issue-safety:submission-detected"],
                 "reaction_plus_one_count": 2,
                 "safety": {"clear": True, "blocked": False, "review": False, "runtime_detected": False},
-                "body": "## Comparison metadata\n\n- Intended comparison rank: 3",
+                "body": (
+                    "## Comparison metadata\n\n"
+                    "- Intended comparison rank: 3\n\n"
+                    "## Optional context\n\n"
+                    "This is a rank-3 comparison candidate. It should be run with the same "
+                    "model policy, retry policy, fallback policy, and file-scope constraints "
+                    "as rank 1 and rank 2."
+                ),
             },
         ],
         "pull_requests": [
@@ -191,8 +205,10 @@ def test_dashboard_builder() -> None:
     if found:
         raise AssertionError(f"dashboard leaked forbidden text: {found}")
 
-    if html.count('<p class="rank-eyebrow">Rank 1</p>') != 1:
-        raise AssertionError("dashboard should render exactly one Rank 1 card")
+    for rank in (1, 2, 3):
+        marker = f'<p class="rank-eyebrow">Rank {rank}</p>'
+        if html.count(marker) != 1:
+            raise AssertionError(f"dashboard should render exactly one Rank {rank} card")
 
     if html.count("Implementation PR changed files") != 3:
         raise AssertionError("dashboard should label PR changed files on each rank card")


### PR DESCRIPTION
## Summary
- Parse Issue comparison rank from explicit comparison metadata or title rank tags.
- Avoid using incidental prose in Issue bodies as rank metadata.
- Add a regression fixture based on the W20 Rank 2 and Rank 3 body shape.

## Why
The W20 comparison dashboard can lose Rank 2 and Rank 3 because the previous parser searched the whole Issue body for rank words in order. Optional context can mention other ranks and cause misclassification.

## Scope
- `scripts/build_comparison_dashboard.py`
- `scripts/test_build_comparison_dashboard.py`

## Follow-up
After merge, let Public Results Export regenerate the generated dashboard and verify W20 shows Rank 1, Rank 2, and Rank 3.

## Non-goals
- No generated evidence update in this PR.
- No root lab change.
- No workflow change.
- No runner change.
- No release tag.