### PR TITLE
Gate legacy weekly runner explicitly

### DIFF
--- a/.github/workflows/weekly-auto-run.yml
+++ b/.github/workflows/weekly-auto-run.yml
@@ -34,21 +34,34 @@ jobs:
         run: |
           set -euo pipefail
           use_canonical="${PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER:-$DEFAULT_USE_CANONICAL_SELECTED_PROMPT_RUNNER}"
+          allow_legacy="${PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN:-false}"
           case "$use_canonical" in
             true|false) ;;
             *) echo "PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER must be true or false"; exit 1 ;;
           esac
+          case "$allow_legacy" in
+            true|false) ;;
+            *) echo "PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN must be true or false"; exit 1 ;;
+          esac
+          if [ "$use_canonical" = "false" ] && [ "$allow_legacy" != "true" ]; then
+            echo "Legacy weekly runner requested, but PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN is not true."
+            echo "Set PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN=true only for an explicit rollback or diagnostic run."
+            exit 1
+          fi
           {
             echo "RUN_WEEK=week-$(date -u +%G-W%V)"
             echo "NO_CHANGE_BASELINE=${PROMPT_VOTE_LAB_NO_CHANGE_BASELINE:-$DEFAULT_NO_CHANGE_BASELINE}"
             echo "SUPPORT_USD=${PROMPT_VOTE_LAB_SUPPORT_USD:-$DEFAULT_SUPPORT_USD}"
             echo "USE_CANONICAL_SELECTED_PROMPT_RUNNER=$use_canonical"
+            echo "ALLOW_LEGACY_OPENAI_LAB_RUN=$allow_legacy"
           } >> "$GITHUB_ENV"
           echo "use_canonical=$use_canonical" >> "$GITHUB_OUTPUT"
+          echo "allow_legacy=$allow_legacy" >> "$GITHUB_OUTPUT"
         env:
           PROMPT_VOTE_LAB_NO_CHANGE_BASELINE: ${{ vars.PROMPT_VOTE_LAB_NO_CHANGE_BASELINE }}
           PROMPT_VOTE_LAB_SUPPORT_USD: ${{ vars.PROMPT_VOTE_LAB_SUPPORT_USD }}
           PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER: ${{ vars.PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER }}
+          PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN: ${{ vars.PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN }}
 
       - name: Resolve automated support unlocks
         run: |
@@ -103,6 +116,10 @@ jobs:
             echo "## Canonical selected-prompt runner"
             echo ""
             echo "${USE_CANONICAL_SELECTED_PROMPT_RUNNER}"
+            echo ""
+            echo "## Legacy OpenAI lab-run fallback"
+            echo ""
+            echo "${ALLOW_LEGACY_OPENAI_LAB_RUN}"
             echo ""
             echo "## Eligible implementation ranks"
             echo ""
@@ -175,7 +192,7 @@ jobs:
             --api-call-limit-per-candidate 1
 
       - name: Install Python dependency
-        if: ${{ steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical != 'true' }}
+        if: ${{ steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical != 'true' && steps.weekly-vars.outputs.allow_legacy == 'true' }}
         run: |
           python -m pip install --upgrade pip
           python -m pip install openai
@@ -202,6 +219,7 @@ jobs:
           week = os.environ['RUN_WEEK']
           run_number = "${{ github.run_number }}"
           use_canonical = os.environ.get('USE_CANONICAL_SELECTED_PROMPT_RUNNER') == 'true'
+          allow_legacy = os.environ.get('ALLOW_LEGACY_OPENAI_LAB_RUN') == 'true'
           candidates = json.loads(Path('.tmp/eligible-candidates.json').read_text())
           if not candidates:
               print('No eligible candidates to implement')
@@ -290,6 +308,8 @@ jobs:
                   build_public_bundle(rank, issue)
                   copy_rank_diagnostics(rank)
               else:
+                  if not allow_legacy:
+                      raise SystemExit('Legacy OpenAI lab-run fallback is disabled. Set PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN=true for explicit rollback or diagnostic use.')
                   sh([
                       'python', 'scripts/openai_lab_run.py',
                       '--week', week,

--- a/scripts/test_weekly_auto_run_workflow_contract.py
+++ b/scripts/test_weekly_auto_run_workflow_contract.py
@@ -10,6 +10,10 @@ CANONICAL_RUNNER_CALL = "display=f'bash scripts/run_codex_selected_prompt.sh --p
 PUBLIC_BUNDLE_BUILD_CALL = "                  build_public_bundle(rank, issue)"
 DIAGNOSTICS_COPY_CALL = "                  copy_rank_diagnostics(rank)"
 ALWAYS_CANONICAL_ARTIFACT_CONDITION = "always() && steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical == 'true'"
+LEGACY_GATE_VAR = "PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN"
+LEGACY_GATE_FAILURE = "Legacy weekly runner requested, but PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN is not true."
+LEGACY_PIP_GATE = "steps.eligibility.outputs.has_eligible == 'true' && steps.weekly-vars.outputs.use_canonical != 'true' && steps.weekly-vars.outputs.allow_legacy == 'true'"
+LEGACY_RUNTIME_GATE = "if not allow_legacy:"
 
 REQUIRED_TEXT = [
     "name: Weekly Auto Run",
@@ -20,15 +24,24 @@ REQUIRED_TEXT = [
     "issues: read",
     "DEFAULT_USE_CANONICAL_SELECTED_PROMPT_RUNNER: \"true\"",
     "PROMPT_VOTE_LAB_USE_CANONICAL_SELECTED_PROMPT_RUNNER",
+    LEGACY_GATE_VAR,
+    "allow_legacy=\"${PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN:-false}\"",
+    "PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN must be true or false",
+    LEGACY_GATE_FAILURE,
+    "ALLOW_LEGACY_OPENAI_LAB_RUN=$allow_legacy",
+    "allow_legacy=$allow_legacy",
     "USE_CANONICAL_SELECTED_PROMPT_RUNNER=$use_canonical",
     "use_canonical=$use_canonical",
     "Canonical selected-prompt runner",
-    "steps.weekly-vars.outputs.use_canonical != 'true'",
+    "Legacy OpenAI lab-run fallback",
+    LEGACY_PIP_GATE,
     "scripts/openai_lab_run.py",
     "steps.weekly-vars.outputs.use_canonical == 'true'",
     ALWAYS_CANONICAL_ARTIFACT_CONDITION,
     "if use_canonical:",
     "else:",
+    LEGACY_RUNTIME_GATE,
+    "Legacy OpenAI lab-run fallback is disabled.",
     "scripts/run_codex_selected_prompt.sh",
     "--prompt-file",
     CANONICAL_RUNNER_CALL,
@@ -54,6 +67,7 @@ REQUIRED_TEXT = [
 
 FORBIDDEN_TEXT = [
     "DEFAULT_USE_CANONICAL_SELECTED_PROMPT_RUNNER: \"false\"",
+    "steps.weekly-vars.outputs.use_canonical != 'true' }}\n        run: |\n          python -m pip install openai",
     "gh pr merge",
     "auto-merge",
     "--prompt-body",  # weekly canonical path should avoid command-argument prompt bodies
@@ -102,9 +116,21 @@ def main() -> int:
     )
     require_block_order(
         text,
-        "steps.weekly-vars.outputs.use_canonical != 'true'",
+        "allow_legacy=\"${PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN:-false}\"",
+        LEGACY_GATE_FAILURE,
+        "legacy fallback gate should be resolved before failure check",
+    )
+    require_block_order(
+        text,
+        LEGACY_GATE_FAILURE,
+        "Resolve automated support unlocks",
+        "legacy fallback gate should run before weekly work begins",
+    )
+    require_block_order(
+        text,
+        LEGACY_PIP_GATE,
         "python -m pip install openai",
-        "legacy OpenAI dependency install should be gated before the install command",
+        "legacy OpenAI dependency install should be explicitly gated before the install command",
     )
     require_block_order(
         text,
@@ -115,8 +141,14 @@ def main() -> int:
     require_block_order(
         text,
         "else:",
+        LEGACY_RUNTIME_GATE,
+        "legacy runtime gate should be inside the non-canonical branch",
+    )
+    require_block_order(
+        text,
+        LEGACY_RUNTIME_GATE,
         "scripts/openai_lab_run.py",
-        "legacy runner invocation should be inside the non-canonical branch",
+        "legacy runner invocation should remain behind the explicit legacy gate",
     )
     require_block_order(
         text,


### PR DESCRIPTION
## Summary
- Require `PROMPT_VOTE_LAB_ALLOW_LEGACY_OPENAI_LAB_RUN=true` before the weekly workflow can use the legacy OpenAI lab-run fallback.
- Record the legacy fallback gate value in the weekly vote summary.
- Update the weekly workflow contract test so `USE_CANONICAL=false` alone is not enough to reach the legacy runner.

## Why
Docs already state that the legacy fallback requires an explicit downstream gate. The workflow implementation still allowed the legacy path when the canonical runner flag was set to false. This PR aligns the active workflow with the documented safety contract.

## Scope
- `.github/workflows/weekly-auto-run.yml`
- `scripts/test_weekly_auto_run_workflow_contract.py`

## Non-goals
- No lab implementation change.
- No generated evidence update.
- No runner rewrite.
- No release tag.