### PR TITLE
Add canary archive inventory

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -40,6 +40,7 @@ on:
       - "docs/repository-5s-and-language-policy.md"
       - "docs/repository-cleanup-inventory.md"
       - "docs/workflow-family-map.md"
+      - "docs/canary-archive-inventory.md"
       - "docs/operator-runbook.md"
       - "docs/weekly-automation.md"
       - "docs/for-participants.md"
@@ -165,6 +166,9 @@ jobs:
 
       - name: Run workflow family map test
         run: python scripts/test_workflow_family_map.py
+
+      - name: Run canary archive inventory test
+        run: python scripts/test_canary_archive_inventory.py
 
       - name: Run OpenAI lab runner legacy contract test
         run: python scripts/test_openai_lab_run_legacy_contract.py

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,25 +20,26 @@ Prompt Vote Lab is a prompt game and experiment. Players compete by writing prom
 8. [Repository 5S and language policy](./repository-5s-and-language-policy.md) — cleanup, English-only, and sustain rules.
 9. [Repository cleanup inventory](./repository-cleanup-inventory.md) — protected evidence, canonical surfaces, legacy script status, generated snapshots, retired scaffolding, and cleanup candidates.
 10. [Workflow family map](./workflow-family-map.md) — canonical, weekly, generated, safety, canary, retired legacy, legacy script, and test workflow classification.
-11. [Usable experiment operations](./usable-experiment-ops.md) — current manual canary and comparison-run operations.
-12. [Operator runbook](./operator-runbook.md) — maintainer checklist for weekly operation, failures, merge decisions, tokens, and cleanup boundaries.
-13. [Public results export](./public-results-export.md) — raw public data snapshots for participant analysis.
-14. [Public agent run bundle](./public-agent-run-bundle.md) — redacted raw agent-run evidence; summaries are not primary evidence.
-15. [Issue lifecycle](./issue-lifecycle.md) — weekly close policy; Issues are closed, not deleted.
-16. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
-17. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
-18. [Weekly automation](./weekly-automation.md) — weekly schedule, support unlock prerequisite, fixed canonical runner, and E2E status.
-19. [Automation map](./automation-map.md) — workflow boundaries.
-20. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
-21. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
-22. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and cleanup checks.
-23. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
-24. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
-25. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
-26. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
-27. [Report policy](./report-policy.md) — weekly report draft policy.
-28. [Pre-API freeze checklist](./pre-api-freeze.md) — historical guardrail record for the earlier API/SDK path.
-29. [Release week numbering](./release-week-numbering.md) — public Release Week 1/2/3 labels versus internal ISO week evidence IDs.
+11. [Canary archive inventory](./canary-archive-inventory.md) — historical canary workflow/doc classification before further cleanup.
+12. [Usable experiment operations](./usable-experiment-ops.md) — current manual canary and comparison-run operations.
+13. [Operator runbook](./operator-runbook.md) — maintainer checklist for weekly operation, failures, merge decisions, tokens, and cleanup boundaries.
+14. [Public results export](./public-results-export.md) — raw public data snapshots for participant analysis.
+15. [Public agent run bundle](./public-agent-run-bundle.md) — redacted raw agent-run evidence; summaries are not primary evidence.
+16. [Issue lifecycle](./issue-lifecycle.md) — weekly close policy; Issues are closed, not deleted.
+17. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
+18. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
+19. [Weekly automation](./weekly-automation.md) — weekly schedule, support unlock prerequisite, fixed canonical runner, and E2E status.
+20. [Automation map](./automation-map.md) — workflow boundaries.
+21. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
+22. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
+23. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and cleanup checks.
+24. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
+25. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
+26. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
+27. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
+28. [Report policy](./report-policy.md) — weekly report draft policy.
+29. [Pre-API freeze checklist](./pre-api-freeze.md) — historical guardrail record for the earlier API/SDK path.
+30. [Release week numbering](./release-week-numbering.md) — public Release Week 1/2/3 labels versus internal ISO week evidence IDs.
 
 ## Current reputation status
 
@@ -90,6 +91,8 @@ The [Root folder audit](./root-folder-audit.md) records top-level folder roles, 
 The [Repository cleanup inventory](./repository-cleanup-inventory.md) classifies protected evidence, canonical active surfaces, legacy script surfaces, retired launch scaffolding, generated snapshots, cleanup candidates, and not-yet-removable items before any deletion work.
 
 The [Workflow family map](./workflow-family-map.md) classifies workflows before consolidation or deletion work so historical scaffolding is not mistaken for active canonical evidence.
+
+The [Canary archive inventory](./canary-archive-inventory.md) classifies historical canary workflows and canary-era docs before further cleanup.
 
 The [Canonical status drift check](./canonical-status-drift-check.md) keeps canonical runner, legacy script, fixed weekly runner, auto-merge, and release-gate wording aligned across maintainer-authored docs.
 

--- a/docs/canary-archive-inventory.md
+++ b/docs/canary-archive-inventory.md
@@ -1,0 +1,125 @@
+# Canary archive inventory
+
+## Purpose
+
+This inventory classifies historical canary workflows and canary-era docs before any further cleanup.
+
+It is a deletion-prevention map. It does not approve removing any workflow, doc, run record, artifact, or generated evidence by itself.
+
+## Current rule
+
+```text
+Do not delete historical canary evidence merely because the canonical selected-prompt runner is fixed-on.
+Do not treat a historical canary workflow as current canonical evidence unless the evidence contains the canonical marker.
+Do not remove a canary workflow without a replacement evidence path, affected-doc list, affected-test list, and rollback path.
+```
+
+Canonical evidence marker:
+
+```text
+Runner: codex-cli-selected-prompt-packet-container
+Canonical selected-prompt runner: true
+```
+
+## Inventory states
+
+| State | Meaning | Default action |
+|---|---|---|
+| Canonical active | Current selected-prompt implementation or verification path | Keep and harden |
+| Historical gated evidence | Old weaker canary retained for audit, gated against accidental rerun | Keep; do not run unless intentionally enabled |
+| Historical evidence | Old canary retained for comparison and design history | Keep; label historical |
+| Boundary evidence | Canary that proves a specific sandbox, task-packet, or Issue-safety boundary | Keep until replacement evidence is stronger and linked |
+| Non-canonical compatibility evidence | Evidence for a path that can work but is not current canonical production evidence | Keep; never cite as current canonical |
+| Cleanup candidate | Candidate for later consolidation or retirement | Do not delete until removal gate passes |
+
+## Workflow inventory
+
+| Workflow | State | Keep reason | Removal gate |
+|---|---|---|---|
+| `.github/workflows/codex-selected-prompt-run.yml` | Canonical active | Manual canonical selected-prompt smoke path | Not a cleanup candidate |
+| `.github/workflows/weekly-auto-run.yml` | Canonical active / weekly active | Fixed-on canonical weekly selected-prompt path for eligible candidates | Not a cleanup candidate |
+| `.github/workflows/codex-first-canary-run.yml` | Historical gated evidence | Records early workspace-write canary behavior | Replacement evidence map plus explicit retirement PR |
+| `.github/workflows/codex-isolated-3file-canary-run.yml` | Historical gated evidence | Records isolated three-file execution attempt | Replacement evidence map plus explicit retirement PR |
+| `.github/workflows/codex-isolated-3file-relaxed-canary-run.yml` | Historical gated evidence | Records relaxed sandbox canary behavior | Replacement evidence map plus explicit retirement PR |
+| `.github/workflows/codex-agent-observed-canary-run.yml` | Historical gated evidence | Records agent-observed direct edit path | Replacement evidence map plus explicit retirement PR |
+| `.github/workflows/codex-writeback-canary-run.yml` | Historical evidence | Records unified diff writeback attempt | Replacement evidence map plus explicit retirement PR |
+| `.github/workflows/codex-offline-json-canary-run.yml` | Non-canonical compatibility evidence | Records offline JSON full-file replacement path | Legacy script policy finalized plus explicit retirement PR |
+| `.github/workflows/canary-007-policy-feasibility.yml` | Boundary evidence | Records feasibility of policy-enforced container execution | Replacement evidence proves same or stronger boundary |
+| `.github/workflows/codex-policy-agent-canary-run.yml` | Boundary evidence | Records policy-agent diagnostics and public bundle evidence | Replacement evidence proves same or stronger boundary |
+| `.github/workflows/codex-task-packet-canary-run.yml` | Boundary evidence | Records read-only task-packet boundary evidence | Replacement evidence proves same or stronger boundary |
+| `.github/workflows/codex-fixed-issue-instruction-canary-run.yml` | Boundary evidence | Records fixed-Issue instruction packet and safety-gate evidence | Replacement evidence proves same or stronger boundary |
+
+## Doc inventory
+
+| Doc | State | Keep reason | Cleanup rule |
+|---|---|---|---|
+| `docs/codex-path-005-vs-007.md` | Historical evidence | Explains path comparison and migration reasoning | Keep unless superseded by a linked archive summary |
+| `docs/canary-007-policy-enforced-agent.md` | Boundary evidence | Explains policy-enforced agent canary | Keep until boundary evidence is summarized elsewhere |
+| `docs/canary-008-selected-prompt-task-packet.md` | Boundary evidence | Explains selected-prompt task packet design | Keep; still relevant to canonical task-packet boundary |
+| `docs/canary-009-selected-issue-instructions.md` | Boundary evidence | Explains fixed-Issue instruction packet design | Keep; still relevant to Issue-derived prompts |
+| `docs/canary-policy.md` | Historical / compatibility evidence | Documents legacy API canary policy | Keep as historical unless legacy script is removed |
+| `docs/first-canary-readiness.md` | Cleanup candidate | Pre-launch readiness record for old path | Summarize before removal |
+| `docs/first-canary-prompt.md` | Cleanup candidate | Old canary prompt record | Preserve only if referenced by run records or archive summary |
+| `docs/first-canary-report-template.md` | Cleanup candidate | Old report template | Replace with current evidence/report templates before removal |
+| `docs/stop-rules.md` | Historical operating rule | May still encode useful stop policy | Review separately before removal |
+| `docs/pre-api-freeze.md` | Historical guardrail record | Captures earlier API/SDK freeze assumptions | Keep while `scripts/openai_lab_run.py` remains present |
+
+## Gated weak canary rule
+
+These workflows must remain gated:
+
+```text
+.github/workflows/codex-first-canary-run.yml
+.github/workflows/codex-isolated-3file-canary-run.yml
+.github/workflows/codex-isolated-3file-relaxed-canary-run.yml
+.github/workflows/codex-agent-observed-canary-run.yml
+```
+
+Required gate:
+
+```text
+ALLOW_HISTORICAL_WEAK_CANARY_WORKFLOWS=true
+```
+
+If a future PR removes the gate, it must explain why the old weak path is safe to run by default. That should normally be rejected.
+
+## Removal gate for historical canary workflows
+
+A future removal PR must include:
+
+```text
+Workflow removed:
+Historical evidence role:
+Current active role, if any:
+Replacement evidence path:
+Affected docs:
+Affected tests:
+Protected evidence check:
+Generated snapshot check:
+Run record check:
+Rollback path:
+Maintainer approval:
+```
+
+Minimum conditions:
+
+```text
+replacement evidence is documented
+public docs no longer cite the workflow as required active evidence
+contract tests are updated
+run records remain inspectable
+public generated snapshots remain untouched
+rollback path is explicit
+```
+
+## Safe next actions
+
+Current safe next actions are:
+
+```text
+1. Keep all listed canary workflows for now.
+2. Keep gated weak canaries gated.
+3. Audit cleanup-candidate docs one by one.
+4. Summarize removable first-canary docs before deleting any of them.
+5. Do not delete run records, public bundles, support unlock records, comparison dashboards, or history pages.
+```

--- a/scripts/test_canary_archive_inventory.py
+++ b/scripts/test_canary_archive_inventory.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "canary-archive-inventory.md"
+README = ROOT / "docs" / "README.md"
+WORKFLOW_MAP = ROOT / "docs" / "workflow-family-map.md"
+
+REQUIRED_DOC_TEXT = [
+    "# Canary archive inventory",
+    "This inventory classifies historical canary workflows and canary-era docs before any further cleanup.",
+    "It is a deletion-prevention map.",
+    "Do not delete historical canary evidence merely because the canonical selected-prompt runner is fixed-on.",
+    "Runner: codex-cli-selected-prompt-packet-container",
+    "Canonical selected-prompt runner: true",
+    "## Inventory states",
+    "Canonical active",
+    "Historical gated evidence",
+    "Historical evidence",
+    "Boundary evidence",
+    "Non-canonical compatibility evidence",
+    "Cleanup candidate",
+    ".github/workflows/codex-selected-prompt-run.yml",
+    ".github/workflows/weekly-auto-run.yml",
+    ".github/workflows/codex-first-canary-run.yml",
+    ".github/workflows/codex-isolated-3file-canary-run.yml",
+    ".github/workflows/codex-isolated-3file-relaxed-canary-run.yml",
+    ".github/workflows/codex-agent-observed-canary-run.yml",
+    ".github/workflows/codex-writeback-canary-run.yml",
+    ".github/workflows/codex-offline-json-canary-run.yml",
+    ".github/workflows/canary-007-policy-feasibility.yml",
+    ".github/workflows/codex-policy-agent-canary-run.yml",
+    ".github/workflows/codex-task-packet-canary-run.yml",
+    ".github/workflows/codex-fixed-issue-instruction-canary-run.yml",
+    "docs/codex-path-005-vs-007.md",
+    "docs/canary-007-policy-enforced-agent.md",
+    "docs/canary-008-selected-prompt-task-packet.md",
+    "docs/canary-009-selected-issue-instructions.md",
+    "docs/canary-policy.md",
+    "docs/first-canary-readiness.md",
+    "docs/first-canary-prompt.md",
+    "docs/first-canary-report-template.md",
+    "docs/stop-rules.md",
+    "docs/pre-api-freeze.md",
+    "ALLOW_HISTORICAL_WEAK_CANARY_WORKFLOWS=true",
+    "## Removal gate for historical canary workflows",
+    "Protected evidence check:",
+    "Generated snapshot check:",
+    "Run record check:",
+    "Maintainer approval:",
+    "Do not delete run records, public bundles, support unlock records, comparison dashboards, or history pages.",
+]
+
+REQUIRED_README_TEXT = [
+    "[Canary archive inventory](./canary-archive-inventory.md)",
+    "historical canary workflows and canary-era docs before further cleanup",
+]
+
+REQUIRED_WORKFLOW_MAP_TEXT = [
+    "Canary evidence workflows",
+    "Historical weak canary gate",
+    "Cleanup candidates",
+]
+
+FORBIDDEN_DOC_TEXT = [
+    "delete all canary workflows",
+    "safe to delete historical canary evidence",
+    "remove run records",
+    "remove public bundles",
+    "remove generated snapshots",
+    "auto-delete",
+]
+
+
+def require_all(text: str, required: list[str], label: str) -> None:
+    missing = [item for item in required if item not in text]
+    if missing:
+        raise SystemExit(f"Missing {label} text: {missing}")
+
+
+def reject_all(text: str, forbidden: list[str], label: str) -> None:
+    found = [item for item in forbidden if item.lower() in text.lower()]
+    if found:
+        raise SystemExit(f"Forbidden {label} text found: {found}")
+
+
+def main() -> int:
+    doc = DOC.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    workflow_map = WORKFLOW_MAP.read_text(encoding="utf-8")
+
+    require_all(doc, REQUIRED_DOC_TEXT, "canary archive inventory")
+    require_all(readme, REQUIRED_README_TEXT, "docs README")
+    require_all(workflow_map, REQUIRED_WORKFLOW_MAP_TEXT, "workflow family map")
+    reject_all(doc, FORBIDDEN_DOC_TEXT, "canary archive inventory")
+
+    if doc.index("## Current rule") > doc.index("## Inventory states"):
+        raise SystemExit("current rule should appear before inventory states")
+    if doc.index("## Inventory states") > doc.index("## Workflow inventory"):
+        raise SystemExit("workflow inventory should follow inventory states")
+    if doc.index("## Workflow inventory") > doc.index("## Doc inventory"):
+        raise SystemExit("doc inventory should follow workflow inventory")
+    if doc.index("## Gated weak canary rule") > doc.index("## Removal gate for historical canary workflows"):
+        raise SystemExit("removal gate should follow gated weak canary rule")
+    if doc.index("## Removal gate for historical canary workflows") > doc.index("## Safe next actions"):
+        raise SystemExit("safe next actions should follow removal gate")
+
+    print("canary archive inventory test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_script_check_workflow_contract.py
+++ b/scripts/test_script_check_workflow_contract.py
@@ -21,6 +21,7 @@ REQUIRED_TEXT = [
     "docs/repository-5s-and-language-policy.md",
     "docs/repository-cleanup-inventory.md",
     "docs/workflow-family-map.md",
+    "docs/canary-archive-inventory.md",
     "docs/operator-runbook.md",
     "docs/weekly-automation.md",
     "docs/for-participants.md",
@@ -43,6 +44,8 @@ REQUIRED_TEXT = [
     "python scripts/test_repository_cleanup_inventory.py",
     "Run workflow family map test",
     "python scripts/test_workflow_family_map.py",
+    "Run canary archive inventory test",
+    "python scripts/test_canary_archive_inventory.py",
     "Run OpenAI lab runner legacy contract test",
     "python scripts/test_openai_lab_run_legacy_contract.py",
     "Run weekly operator docs test",
@@ -159,8 +162,11 @@ def main() -> int:
     if text.index("docs/repository-cleanup-inventory.md") > text.index("docs/workflow-family-map.md"):
         raise SystemExit("workflow family map should be tracked after the repository cleanup inventory")
 
-    if text.index("docs/workflow-family-map.md") > text.index("docs/operator-runbook.md"):
-        raise SystemExit("operator runbook should be tracked after the workflow family map")
+    if text.index("docs/workflow-family-map.md") > text.index("docs/canary-archive-inventory.md"):
+        raise SystemExit("canary archive inventory should be tracked after the workflow family map")
+
+    if text.index("docs/canary-archive-inventory.md") > text.index("docs/operator-runbook.md"):
+        raise SystemExit("operator runbook should be tracked after the canary archive inventory")
 
     if text.index("docs/operator-runbook.md") > text.index("docs/weekly-automation.md"):
         raise SystemExit("weekly automation doc should be tracked after the operator runbook")
@@ -189,8 +195,11 @@ def main() -> int:
     if text.index("Run repository cleanup inventory test") > text.index("Run workflow family map test"):
         raise SystemExit("Workflow family map test should run after the repository cleanup inventory test")
 
-    if text.index("Run workflow family map test") > text.index("Run OpenAI lab runner legacy contract test"):
-        raise SystemExit("OpenAI lab runner legacy contract test should run after the workflow family map test")
+    if text.index("Run workflow family map test") > text.index("Run canary archive inventory test"):
+        raise SystemExit("Canary archive inventory test should run after the workflow family map test")
+
+    if text.index("Run canary archive inventory test") > text.index("Run OpenAI lab runner legacy contract test"):
+        raise SystemExit("OpenAI lab runner legacy contract test should run after the canary archive inventory test")
 
     if text.index("Run OpenAI lab runner legacy contract test") > text.index("Run weekly operator docs test"):
         raise SystemExit("Weekly operator docs test should run after the OpenAI lab runner legacy contract test")


### PR DESCRIPTION
## Summary

- Add `docs/canary-archive-inventory.md` to classify historical canary workflows and canary-era docs before further cleanup.
- Link the new inventory from `docs/README.md`.
- Add `scripts/test_canary_archive_inventory.py` and wire it into `Script Check`.
- Update the `script-check` workflow contract so the new inventory remains monitored.

## Cleanup stance

This PR does **not** delete any historical canary workflow, canary doc, generated snapshot, run record, public bundle, or lab file.

It creates a deletion-prevention map so later cleanup can distinguish:

```text
canonical active
historical gated evidence
historical evidence
boundary evidence
non-canonical compatibility evidence
cleanup candidate
```

## Protected evidence check

```text
Protected evidence check: PASS — no `runs/`, `data/`, `lab/comparisons/`, `lab/history/`, or public bundle output touched.
Canonical/legacy check: PASS — no active canonical workflow removed; no legacy script removed.
Generated snapshot check: PASS — generated snapshots intentionally untouched.
Removal gate: N/A — this PR classifies only and removes nothing.
Rollback path: remove the new inventory doc, test, README link, and Script Check wiring.
```

## Non-goals

- No workflow deletion.
- No generated output update.
- No `lab/` change.
- No run-record rewrite.
- No removal of `scripts/openai_lab_run.py`.

## Expected checks

```text
python scripts/test_canary_archive_inventory.py
python scripts/test_script_check_workflow_contract.py
```

CI should be the source of truth for the full Script Check suite.