### PR TITLE
Add local release verification checklist

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -41,6 +41,7 @@ on:
       - "docs/repository-cleanup-inventory.md"
       - "docs/workflow-family-map.md"
       - "docs/canary-archive-inventory.md"
+      - "docs/local-release-verification.md"
       - "docs/operator-runbook.md"
       - "docs/weekly-automation.md"
       - "docs/for-participants.md"
@@ -169,6 +170,9 @@ jobs:
 
       - name: Run canary archive inventory test
         run: python scripts/test_canary_archive_inventory.py
+
+      - name: Run local release verification test
+        run: python scripts/test_local_release_verification.py
 
       - name: Run OpenAI lab runner legacy contract test
         run: python scripts/test_openai_lab_run_legacy_contract.py

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,30 +16,31 @@ Prompt Vote Lab is a prompt game and experiment. Players compete by writing prom
 4. [Canonical runner evidence guide](./canonical-runner-evidence-guide.md) — how to verify Docker/Codex selected-prompt evidence.
 5. [Canonical status drift check](./canonical-status-drift-check.md) — canonical, legacy script, fixed weekly runner, auto-merge, and release-gate status contract.
 6. [Release readiness review](./release-readiness-review.md) — security posture, participant journey, live preview, and release decision review.
-7. [Root folder audit](./root-folder-audit.md) — top-level folder roles, cleanup posture, and maintainer questions before cleanup.
-8. [Repository 5S and language policy](./repository-5s-and-language-policy.md) — cleanup, English-only, and sustain rules.
-9. [Repository cleanup inventory](./repository-cleanup-inventory.md) — protected evidence, canonical surfaces, legacy script status, generated snapshots, retired scaffolding, and cleanup candidates.
-10. [Workflow family map](./workflow-family-map.md) — canonical, weekly, generated, safety, canary, retired legacy, legacy script, and test workflow classification.
-11. [Canary archive inventory](./canary-archive-inventory.md) — historical canary workflow/doc classification before further cleanup.
-12. [Usable experiment operations](./usable-experiment-ops.md) — current manual canary and comparison-run operations.
-13. [Operator runbook](./operator-runbook.md) — maintainer checklist for weekly operation, failures, merge decisions, tokens, and cleanup boundaries.
-14. [Public results export](./public-results-export.md) — raw public data snapshots for participant analysis.
-15. [Public agent run bundle](./public-agent-run-bundle.md) — redacted raw agent-run evidence; summaries are not primary evidence.
-16. [Issue lifecycle](./issue-lifecycle.md) — weekly close policy; Issues are closed, not deleted.
-17. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
-18. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
-19. [Weekly automation](./weekly-automation.md) — weekly schedule, support unlock prerequisite, fixed canonical runner, and E2E status.
-20. [Automation map](./automation-map.md) — workflow boundaries.
-21. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
-22. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
-23. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and cleanup checks.
-24. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
-25. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
-26. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
-27. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
-28. [Report policy](./report-policy.md) — weekly report draft policy.
-29. [Pre-API freeze checklist](./pre-api-freeze.md) — historical guardrail record for the earlier API/SDK path.
-30. [Release week numbering](./release-week-numbering.md) — public Release Week 1/2/3 labels versus internal ISO week evidence IDs.
+7. [Local release verification](./local-release-verification.md) — local clone, contract checks, GitHub Actions, GitHub Pages, and soft-release gate.
+8. [Root folder audit](./root-folder-audit.md) — top-level folder roles, cleanup posture, and maintainer questions before cleanup.
+9. [Repository 5S and language policy](./repository-5s-and-language-policy.md) — cleanup, English-only, and sustain rules.
+10. [Repository cleanup inventory](./repository-cleanup-inventory.md) — protected evidence, canonical surfaces, legacy script status, generated snapshots, retired scaffolding, and cleanup candidates.
+11. [Workflow family map](./workflow-family-map.md) — canonical, weekly, generated, safety, canary, retired legacy, legacy script, and test workflow classification.
+12. [Canary archive inventory](./canary-archive-inventory.md) — historical canary workflow/doc classification before further cleanup.
+13. [Usable experiment operations](./usable-experiment-ops.md) — current manual canary and comparison-run operations.
+14. [Operator runbook](./operator-runbook.md) — maintainer checklist for weekly operation, failures, merge decisions, tokens, and cleanup boundaries.
+15. [Public results export](./public-results-export.md) — raw public data snapshots for participant analysis.
+16. [Public agent run bundle](./public-agent-run-bundle.md) — redacted raw agent-run evidence; summaries are not primary evidence.
+17. [Issue lifecycle](./issue-lifecycle.md) — weekly close policy; Issues are closed, not deleted.
+18. [Persona routes](./persona-routes.md) — role-specific paths for writers, voters, spectators, supporters, and reviewers.
+19. [No-change baseline](./no-change-baseline.md) — the 20-vote baseline.
+20. [Weekly automation](./weekly-automation.md) — weekly schedule, support unlock prerequisite, fixed canonical runner, and E2E status.
+21. [Automation map](./automation-map.md) — workflow boundaries.
+22. [Weekly operations doctrine](./weekly-ops-doctrine.md) — weekly evidence-to-action loop.
+23. [Evidence artifact review](./evidence-artifact-review.md) — dry-run artifact checks.
+24. [Repository cleanup checklist](./repository-cleanup.md) — stale branch and cleanup checks.
+25. [Codex path comparison](./codex-path-005-vs-007.md) — prompt selection layer versus 005/007/008/009 execution paths.
+26. [Canary 008 task packet design](./canary-008-selected-prompt-task-packet.md) — selected prompt packet, `/task:ro`, and credential hygiene design.
+27. [Canary 009 selected Issue instruction design](./canary-009-selected-issue-instructions.md) — fixed GitHub Issue ingestion into a bounded instruction packet.
+28. [Support policy](./support-policy.md) — support boundaries and comparison-run thresholds.
+29. [Report policy](./report-policy.md) — weekly report draft policy.
+30. [Pre-API freeze checklist](./pre-api-freeze.md) — historical guardrail record for the earlier API/SDK path.
+31. [Release week numbering](./release-week-numbering.md) — public Release Week 1/2/3 labels versus internal ISO week evidence IDs.
 
 ## Current reputation status
 
@@ -71,6 +72,8 @@ participant journey: PASS
 live preview: PASS
 ordinary default-on weekly no-eligible observation: PASS
 ```
+
+[Local release verification](./local-release-verification.md) defines the local clone, contract checks, GitHub Actions, GitHub Pages, and soft-release gate that must be checked before announcing the project.
 
 ## Release week status
 

--- a/docs/local-release-verification.md
+++ b/docs/local-release-verification.md
@@ -1,0 +1,283 @@
+# Local release verification
+
+## Purpose
+
+This checklist defines how to verify Prompt Vote Lab locally before a soft release or public release.
+
+Local verification is not a replacement for GitHub Actions, GitHub Pages smoke checks, weekly workflow evidence, or manual review. It is a pre-release operator check that reduces avoidable mistakes before announcing the project.
+
+## Release rule
+
+```text
+Local pass is necessary but not sufficient.
+GitHub Actions pass is required.
+GitHub Pages public rendering must be checked.
+Manual review remains required.
+Auto-merge remains disabled.
+```
+
+## Scope
+
+This checklist covers:
+
+```text
+clone and clean working tree
+local syntax checks
+contract tests for canonical/cleanup/release docs
+static page preview
+participant route check
+operator route check
+release-blocking failure conditions
+```
+
+It does not cover:
+
+```text
+running the paid implementation agent locally
+calling external model APIs
+publishing externally
+turning on auto-merge
+rewriting run records
+regenerating public result snapshots
+```
+
+## Clone or refresh
+
+Fresh clone:
+
+```bash
+git clone https://github.com/Unjuno/prompt-vote-lab.git
+cd prompt-vote-lab
+git switch main
+git pull --ff-only origin main
+```
+
+Existing clone:
+
+```bash
+cd prompt-vote-lab
+git fetch origin --prune
+git switch main
+git pull --ff-only origin main
+git status
+```
+
+Required clean state:
+
+```text
+On branch main
+Your branch is up to date with 'origin/main'.
+nothing to commit, working tree clean
+```
+
+If the working tree is not clean, stop and decide whether the local changes should be committed, stashed, or discarded. Do not release from an ambiguous local tree.
+
+## Runtime prerequisites
+
+Minimum local tools:
+
+```text
+git
+python 3
+node 20 or compatible local Node for syntax checks
+bash for shell syntax checks, or Git Bash on Windows
+```
+
+Windows PowerShell users can run Python and Node checks directly, but shell script syntax checks need Bash-compatible tooling.
+
+## Local syntax checks
+
+Python syntax check:
+
+```powershell
+Get-ChildItem scripts -Recurse -Filter *.py | ForEach-Object {
+  python -m py_compile $_.FullName
+}
+```
+
+Node syntax check:
+
+```powershell
+Get-ChildItem scripts -Recurse -Filter *.mjs | ForEach-Object {
+  node --check $_.FullName
+}
+```
+
+Bash syntax check:
+
+```bash
+find scripts -name '*.sh' -print0 | xargs -0 -I{} bash -n {}
+```
+
+## Required local contract checks
+
+Run these before release review:
+
+```bash
+python scripts/test_canonical_status_drift.py
+python scripts/test_current_codex_path_doc.py
+python scripts/test_canonical_runner_evidence_guide.py
+python scripts/test_repository_cleanup_inventory.py
+python scripts/test_workflow_family_map.py
+python scripts/test_canary_archive_inventory.py
+python scripts/test_weekly_operator_docs.py
+python scripts/test_local_release_verification.py
+python scripts/test_script_check_workflow_contract.py
+```
+
+These checks cover the current release-critical documentation contract:
+
+```text
+canonical selected-prompt runner status
+fixed-on weekly runner status
+legacy script non-canonical status
+cleanup and protected-evidence boundaries
+canary archive classification
+operator release procedure
+local release verification procedure
+Script Check wiring
+```
+
+## Static page preview
+
+Start a local static server:
+
+```bash
+python -m http.server 8000
+```
+
+Open:
+
+```text
+http://localhost:8000/
+http://localhost:8000/lab/
+```
+
+Minimum checks:
+
+```text
+root page loads
+lab page loads
+root page explains prompt proposals and voting
+root page mentions the 20-vote baseline
+lab page remains static and does not require a backend
+external scripts are not required for the static preview
+```
+
+## Participant route check
+
+Before release, an unfamiliar participant should be able to answer:
+
+```text
+Where do I submit a prompt?
+Where do I vote?
+What does 👍 mean?
+What is the no-change baseline?
+What files can the implementation agent change?
+Where can I inspect results and evidence?
+```
+
+If these answers are not obvious from the landing page, docs, and Issue template, do not public-release yet.
+
+## Operator route check
+
+Before release, the maintainer should be able to answer:
+
+```text
+Where is the canonical status contract?
+Where is the weekly automation runbook?
+Where is the selected-prompt evidence guide?
+Where is the cleanup inventory?
+Where is the canary archive inventory?
+How do I stop after an unsafe or unclear run?
+How do I verify that auto-merge remains disabled?
+```
+
+## GitHub Actions requirement
+
+Local checks do not replace CI.
+
+Required GitHub Actions status before release:
+
+```text
+Pre-API Freeze Audit: success
+Static Site Check: success
+Lab PR Scope Check: success
+Script Check: success
+```
+
+If CI fails, local success does not matter. Fix CI first.
+
+## GitHub Pages requirement
+
+Before public release, open the deployed site and verify:
+
+```text
+https://unjuno.github.io/prompt-vote-lab/
+https://unjuno.github.io/prompt-vote-lab/lab/
+```
+
+Minimum public checks:
+
+```text
+root page renders as HTML
+lab page renders as HTML
+links to GitHub-rendered docs work
+Issue proposal route works
+no raw Markdown page is presented as the main reader path
+```
+
+## Soft release versus public release
+
+Soft release is acceptable when:
+
+```text
+local checks pass
+CI passes
+GitHub Pages renders correctly
+manual review remains required
+auto-merge remains disabled
+participant route is understandable for a small trusted group
+```
+
+Public release should wait until:
+
+```text
+soft release path has been exercised
+first ordinary release-week evidence is understandable
+weekly no-eligible or eligible behavior can be explained publicly
+Release Week numbering is not confused with internal ISO week IDs
+maintainer can explain the canonical evidence chain without guessing
+```
+
+## Release blockers
+
+Do not release if any of these are true:
+
+```text
+working tree is dirty
+local syntax checks fail
+release-critical contract tests fail
+GitHub Actions fail
+GitHub Pages root or lab page fails to render
+participant cannot find prompt submission or voting route
+auto-merge appears enabled
+manual review requirement is unclear
+legacy script is described as canonical
+protected evidence, run records, generated snapshots, or history pages were deleted without a gate
+```
+
+## Current recommendation
+
+For the current state of Prompt Vote Lab, the recommended path is:
+
+```text
+1. local verification
+2. GitHub Actions verification
+3. GitHub Pages verification
+4. soft release to a small trusted group
+5. observe Release Week 1 behavior
+6. decide whether to broaden public release
+```
+
+Do not skip soft release. The first public impression will be shaped more by participant route clarity than by the internal runner architecture.

--- a/scripts/test_local_release_verification.py
+++ b/scripts/test_local_release_verification.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "local-release-verification.md"
+README = ROOT / "docs" / "README.md"
+
+REQUIRED_DOC_TEXT = [
+    "# Local release verification",
+    "Local verification is not a replacement for GitHub Actions, GitHub Pages smoke checks, weekly workflow evidence, or manual review.",
+    "Local pass is necessary but not sufficient.",
+    "GitHub Actions pass is required.",
+    "GitHub Pages public rendering must be checked.",
+    "Manual review remains required.",
+    "Auto-merge remains disabled.",
+    "git clone https://github.com/Unjuno/prompt-vote-lab.git",
+    "git pull --ff-only origin main",
+    "nothing to commit, working tree clean",
+    "python -m py_compile",
+    "node --check",
+    "bash -n",
+    "python scripts/test_canonical_status_drift.py",
+    "python scripts/test_current_codex_path_doc.py",
+    "python scripts/test_canonical_runner_evidence_guide.py",
+    "python scripts/test_repository_cleanup_inventory.py",
+    "python scripts/test_workflow_family_map.py",
+    "python scripts/test_canary_archive_inventory.py",
+    "python scripts/test_weekly_operator_docs.py",
+    "python scripts/test_local_release_verification.py",
+    "python scripts/test_script_check_workflow_contract.py",
+    "python -m http.server 8000",
+    "http://localhost:8000/",
+    "http://localhost:8000/lab/",
+    "Where do I submit a prompt?",
+    "Where do I vote?",
+    "What does 👍 mean?",
+    "What is the no-change baseline?",
+    "Where is the canonical status contract?",
+    "Where is the weekly automation runbook?",
+    "Where is the selected-prompt evidence guide?",
+    "Pre-API Freeze Audit: success",
+    "Static Site Check: success",
+    "Lab PR Scope Check: success",
+    "Script Check: success",
+    "https://unjuno.github.io/prompt-vote-lab/",
+    "https://unjuno.github.io/prompt-vote-lab/lab/",
+    "Soft release is acceptable when:",
+    "Public release should wait until:",
+    "Do not release if any of these are true:",
+    "working tree is dirty",
+    "GitHub Actions fail",
+    "legacy script is described as canonical",
+    "protected evidence, run records, generated snapshots, or history pages were deleted without a gate",
+]
+
+REQUIRED_README_TEXT = [
+    "[Local release verification](./local-release-verification.md)",
+    "local clone, contract checks, GitHub Actions, GitHub Pages, and soft-release gate",
+]
+
+FORBIDDEN_DOC_TEXT = [
+    "local pass is sufficient",
+    "skip GitHub Actions",
+    "skip GitHub Pages",
+    "enable auto-merge",
+    "auto-merge may be enabled",
+    "release from a dirty working tree",
+    "legacy script is canonical",
+    "delete run records before release",
+]
+
+
+def require_all(text: str, required: list[str], label: str) -> None:
+    missing = [item for item in required if item not in text]
+    if missing:
+        raise SystemExit(f"Missing {label} text: {missing}")
+
+
+def reject_all(text: str, forbidden: list[str], label: str) -> None:
+    found = [item for item in forbidden if item.lower() in text.lower()]
+    if found:
+        raise SystemExit(f"Forbidden {label} text found: {found}")
+
+
+def main() -> int:
+    doc = DOC.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+
+    require_all(doc, REQUIRED_DOC_TEXT, "local release verification doc")
+    require_all(readme, REQUIRED_README_TEXT, "docs README")
+    reject_all(doc, FORBIDDEN_DOC_TEXT, "local release verification doc")
+
+    if doc.index("## Clone or refresh") > doc.index("## Runtime prerequisites"):
+        raise SystemExit("runtime prerequisites should follow clone or refresh")
+    if doc.index("## Runtime prerequisites") > doc.index("## Local syntax checks"):
+        raise SystemExit("local syntax checks should follow runtime prerequisites")
+    if doc.index("## Local syntax checks") > doc.index("## Required local contract checks"):
+        raise SystemExit("contract checks should follow syntax checks")
+    if doc.index("## Required local contract checks") > doc.index("## Static page preview"):
+        raise SystemExit("static page preview should follow contract checks")
+    if doc.index("## Static page preview") > doc.index("## Participant route check"):
+        raise SystemExit("participant route check should follow static page preview")
+    if doc.index("## Participant route check") > doc.index("## Operator route check"):
+        raise SystemExit("operator route check should follow participant route check")
+    if doc.index("## Operator route check") > doc.index("## GitHub Actions requirement"):
+        raise SystemExit("GitHub Actions requirement should follow operator route check")
+    if doc.index("## GitHub Actions requirement") > doc.index("## GitHub Pages requirement"):
+        raise SystemExit("GitHub Pages requirement should follow GitHub Actions requirement")
+    if doc.index("## GitHub Pages requirement") > doc.index("## Soft release versus public release"):
+        raise SystemExit("soft/public release rule should follow GitHub Pages requirement")
+    if doc.index("## Soft release versus public release") > doc.index("## Release blockers"):
+        raise SystemExit("release blockers should follow soft/public release rule")
+
+    print("local release verification test passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_script_check_workflow_contract.py
+++ b/scripts/test_script_check_workflow_contract.py
@@ -22,6 +22,7 @@ REQUIRED_TEXT = [
     "docs/repository-cleanup-inventory.md",
     "docs/workflow-family-map.md",
     "docs/canary-archive-inventory.md",
+    "docs/local-release-verification.md",
     "docs/operator-runbook.md",
     "docs/weekly-automation.md",
     "docs/for-participants.md",
@@ -46,6 +47,8 @@ REQUIRED_TEXT = [
     "python scripts/test_workflow_family_map.py",
     "Run canary archive inventory test",
     "python scripts/test_canary_archive_inventory.py",
+    "Run local release verification test",
+    "python scripts/test_local_release_verification.py",
     "Run OpenAI lab runner legacy contract test",
     "python scripts/test_openai_lab_run_legacy_contract.py",
     "Run weekly operator docs test",
@@ -165,8 +168,11 @@ def main() -> int:
     if text.index("docs/workflow-family-map.md") > text.index("docs/canary-archive-inventory.md"):
         raise SystemExit("canary archive inventory should be tracked after the workflow family map")
 
-    if text.index("docs/canary-archive-inventory.md") > text.index("docs/operator-runbook.md"):
-        raise SystemExit("operator runbook should be tracked after the canary archive inventory")
+    if text.index("docs/canary-archive-inventory.md") > text.index("docs/local-release-verification.md"):
+        raise SystemExit("local release verification should be tracked after the canary archive inventory")
+
+    if text.index("docs/local-release-verification.md") > text.index("docs/operator-runbook.md"):
+        raise SystemExit("operator runbook should be tracked after local release verification")
 
     if text.index("docs/operator-runbook.md") > text.index("docs/weekly-automation.md"):
         raise SystemExit("weekly automation doc should be tracked after the operator runbook")
@@ -198,8 +204,11 @@ def main() -> int:
     if text.index("Run workflow family map test") > text.index("Run canary archive inventory test"):
         raise SystemExit("Canary archive inventory test should run after the workflow family map test")
 
-    if text.index("Run canary archive inventory test") > text.index("Run OpenAI lab runner legacy contract test"):
-        raise SystemExit("OpenAI lab runner legacy contract test should run after the canary archive inventory test")
+    if text.index("Run canary archive inventory test") > text.index("Run local release verification test"):
+        raise SystemExit("Local release verification test should run after the canary archive inventory test")
+
+    if text.index("Run local release verification test") > text.index("Run OpenAI lab runner legacy contract test"):
+        raise SystemExit("OpenAI lab runner legacy contract test should run after the local release verification test")
 
     if text.index("Run OpenAI lab runner legacy contract test") > text.index("Run weekly operator docs test"):
         raise SystemExit("Weekly operator docs test should run after the OpenAI lab runner legacy contract test")


### PR DESCRIPTION
## Summary

- Add `docs/local-release-verification.md` for clone/pull, local syntax checks, contract checks, static preview, participant route check, operator route check, GitHub Actions, GitHub Pages, and soft-release/public-release gates.
- Link the new release verification doc from `docs/README.md`.
- Add `scripts/test_local_release_verification.py` to protect the release checklist contract.
- Wire the new doc/test into `Script Check` and its workflow contract.

## Release stance

Local verification is useful but not sufficient. The checklist requires:

```text
local checks pass
GitHub Actions pass
GitHub Pages renders correctly
manual review remains required
auto-merge remains disabled
soft release before broader public release
```

## Protected evidence check

```text
Protected evidence check: PASS — no `runs/`, `data/`, `lab/comparisons/`, `lab/history/`, public bundle output, or generated snapshots touched.
Canonical/legacy check: PASS — no active canonical workflow removed; no legacy script removed.
Generated snapshot check: PASS — generated snapshots intentionally untouched.
Removal gate: N/A — this PR adds release verification docs/tests only and removes nothing.
Rollback path: remove the new release verification doc, test, README link, and Script Check wiring.
```

## Non-goals

- No `lab/` change.
- No workflow deletion.
- No generated output update.
- No run-record rewrite.
- No release tag creation.
- No external publishing.
- No removal of `scripts/openai_lab_run.py`.

## Expected checks

```text
python scripts/test_local_release_verification.py
python scripts/test_script_check_workflow_contract.py
```

CI should be the source of truth for the full Script Check suite.