### PR TITLE
[codex] Track docs README in Script Check

### DIFF
--- a/.github/workflows/script-check.yml
+++ b/.github/workflows/script-check.yml
@@ -42,6 +42,7 @@ on:
       - "docs/workflow-family-map.md"
       - "docs/canary-archive-inventory.md"
       - "docs/local-release-verification.md"
+      - "docs/README.md"
       - "docs/operator-runbook.md"
       - "docs/weekly-automation.md"
       - "docs/for-participants.md"

--- a/scripts/test_script_check_workflow_contract.py
+++ b/scripts/test_script_check_workflow_contract.py
@@ -23,6 +23,7 @@ REQUIRED_TEXT = [
     "docs/workflow-family-map.md",
     "docs/canary-archive-inventory.md",
     "docs/local-release-verification.md",
+    "docs/README.md",
     "docs/operator-runbook.md",
     "docs/weekly-automation.md",
     "docs/for-participants.md",
@@ -170,6 +171,9 @@ def main() -> int:
 
     if text.index("docs/canary-archive-inventory.md") > text.index("docs/local-release-verification.md"):
         raise SystemExit("local release verification should be tracked after the canary archive inventory")
+
+    if text.index("docs/local-release-verification.md") > text.index("docs/README.md"):
+        raise SystemExit("docs README should be tracked after local release verification")
 
     if text.index("docs/local-release-verification.md") > text.index("docs/operator-runbook.md"):
         raise SystemExit("operator runbook should be tracked after local release verification")


### PR DESCRIPTION
## Summary

- Add `docs/README.md` to `Script Check` pull_request paths.
- Add `docs/README.md` to the Script Check workflow contract test.
- Preserve the release verification guard so docs README-only PRs cannot bypass the relevant contract checks.

## Checks

```text
python scripts/test_script_check_workflow_contract.py
python scripts/test_local_release_verification.py
```

## Protected evidence check

```text
Protected evidence check: PASS — no runs/, data/, lab/comparisons/, lab/history/, public bundles, or generated snapshots touched.
Canonical/legacy check: PASS — no canonical runner or legacy script behavior changed.
Generated snapshot check: PASS — generated snapshots untouched.
Removal gate: N/A — no removal.
Rollback path: revert this workflow/test wiring change.
```

## Non-goals

- No lab implementation change.
- No generated evidence update.
- No release tag.
- No auto-merge.
