### PR TITLE
Show baseline-only weeks in history

### DIFF
--- a/.github/workflows/safety-check.yml
+++ b/.github/workflows/safety-check.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     branches: ["main"]
     paths:
-      - "lab/**"
+      - "lab/index.html"
+      - "lab/style.css"
+      - "lab/app.js"
 
 permissions:
   contents: read

--- a/lab/history/index.html
+++ b/lab/history/index.html
@@ -28,6 +28,25 @@
     </section>
     <section class="week-grid" aria-label="Weekly experiment history">
 
+      <article class="week-card" aria-labelledby="week-2026-W21">
+        <div class="week-card-head">
+          <p class="week-kicker">Week</p>
+          <h2 id="week-2026-W21">2026-W21</h2>
+        </div>
+        <dl class="facts">
+          <div><dt>Candidates</dt><dd>0</dd></div>
+          <div><dt>Clear</dt><dd>0</dd></div>
+          <div><dt>Runtime scans</dt><dd>0</dd></div>
+          <div><dt>Blocked</dt><dd>0</dd></div>
+          <div><dt>Review</dt><dd>0</dd></div>
+          <div><dt>Implemented</dt><dd>0</dd></div>
+          <div><dt>Not selected</dt><dd>0</dd></div>
+          <div><dt>Open</dt><dd>0</dd></div>
+          <div><dt>Adopted</dt><dd>no change</dd></div>
+        </dl>
+        <p class="week-link"><a href="../../runs/week-2026-W21-vote-summary.md">Open run record</a></p>
+      </article>
+
       <article class="week-card" aria-labelledby="week-2026-W20">
         <div class="week-card-head">
           <p class="week-kicker">Week</p>

--- a/scripts/build_history_page.py
+++ b/scripts/build_history_page.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 import argparse
 import html
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 SAFE_CSP = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'none'; frame-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none';"
+RUN_RECORD_RE = re.compile(r"^week-(?P<week_id>\d{4}-W\d{2})-vote-summary\.md$")
 
 
 @dataclass(frozen=True)
@@ -23,7 +25,8 @@ class WeekSummary:
     not_selected_count: int
     open_count: int
     adopted_rank: str
-    comparison_href: str
+    link_href: str
+    link_text: str
 
 
 def _labels(item: dict[str, Any]) -> set[str]:
@@ -32,6 +35,17 @@ def _labels(item: dict[str, Any]) -> set[str]:
 
 def _week_labels(issue: dict[str, Any]) -> set[str]:
     return {label.split(":", 1)[1] for label in _labels(issue) if label.startswith("week:")}
+
+
+def _run_record_weeks(runs_dir: Path) -> set[str]:
+    if not runs_dir.exists():
+        return set()
+    weeks: set[str] = set()
+    for path in runs_dir.glob("week-*-vote-summary.md"):
+        match = RUN_RECORD_RE.match(path.name)
+        if match:
+            weeks.add(match.group("week_id"))
+    return weeks
 
 
 def _rank_from_text_blob(text: str) -> int | None:
@@ -82,10 +96,12 @@ def _merged_pr_rank_by_issue(public_results: dict[str, Any]) -> dict[int, int]:
     return ranks
 
 
-def build_week_summaries(public_results: dict[str, Any]) -> list[WeekSummary]:
+def build_week_summaries(public_results: dict[str, Any], runs_dir: Path = Path("runs")) -> list[WeekSummary]:
     issues = list(public_results.get("issues", []))
     pr_rank_by_issue = _merged_pr_rank_by_issue(public_results)
-    week_ids = sorted({week for issue in issues for week in _week_labels(issue)}, reverse=True)
+    issue_week_ids = {week for issue in issues for week in _week_labels(issue)}
+    run_record_week_ids = _run_record_weeks(runs_dir)
+    week_ids = sorted(issue_week_ids | run_record_week_ids, reverse=True)
     summaries: list[WeekSummary] = []
 
     for week_id in week_ids:
@@ -121,7 +137,11 @@ def build_week_summaries(public_results: dict[str, Any]) -> list[WeekSummary]:
             if str(issue.get("state", "")).upper() == "OPEN":
                 open_count += 1
 
-        adopted_rank = f"rank {min(adopted_ranks)}" if adopted_ranks else "not decided"
+        has_run_record = week_id in run_record_week_ids
+        is_run_record_only = has_run_record and not week_issues
+        adopted_rank = "no change" if is_run_record_only else f"rank {min(adopted_ranks)}" if adopted_ranks else "not decided"
+        link_href = f"../../runs/week-{week_id}-vote-summary.md" if is_run_record_only else f"../comparisons/{week_id}/"
+        link_text = "Open run record" if is_run_record_only else "Open weekly comparison"
         summaries.append(
             WeekSummary(
                 week_id=week_id,
@@ -134,14 +154,15 @@ def build_week_summaries(public_results: dict[str, Any]) -> list[WeekSummary]:
                 not_selected_count=not_selected_count,
                 open_count=open_count,
                 adopted_rank=adopted_rank,
-                comparison_href=f"../comparisons/{week_id}/",
+                link_href=link_href,
+                link_text=link_text,
             )
         )
     return summaries
 
 
-def render_history(public_results: dict[str, Any]) -> str:
-    summaries = build_week_summaries(public_results)
+def render_history(public_results: dict[str, Any], runs_dir: Path = Path("runs")) -> str:
+    summaries = build_week_summaries(public_results, runs_dir)
     generated_at = html.escape(str(public_results.get("generated_at", "unknown")))
     cards: list[str] = []
     for summary in summaries:
@@ -163,7 +184,7 @@ def render_history(public_results: dict[str, Any]) -> str:
           <div><dt>Open</dt><dd>{summary.open_count}</dd></div>
           <div><dt>Adopted</dt><dd>{html.escape(summary.adopted_rank)}</dd></div>
         </dl>
-        <p class="week-link"><a href="{html.escape(summary.comparison_href, quote=True)}">Open weekly comparison</a></p>
+        <p class="week-link"><a href="{html.escape(summary.link_href, quote=True)}">{html.escape(summary.link_text)}</a></p>
       </article>"""
         )
     cards_html = "\n".join(cards) if cards else "<p>No week records found yet.</p>"
@@ -279,13 +300,14 @@ code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; fo
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--public-results", default="data/public-results.json")
+    parser.add_argument("--runs-dir", default="runs")
     parser.add_argument("--out-dir", required=True)
     args = parser.parse_args()
 
     public_results = json.loads(Path(args.public_results).read_text(encoding="utf-8"))
     out_dir = Path(args.out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    (out_dir / "index.html").write_text(render_history(public_results), encoding="utf-8")
+    (out_dir / "index.html").write_text(render_history(public_results, Path(args.runs_dir)), encoding="utf-8")
     (out_dir / "style.css").write_text(render_css(), encoding="utf-8")
     return 0
 

--- a/scripts/test_build_history_page.py
+++ b/scripts/test_build_history_page.py
@@ -61,10 +61,25 @@ def test_history_builder() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         source = tmp_path / "public-results.json"
+        runs_dir = tmp_path / "runs"
         out_dir = tmp_path / "history"
         source.write_text(json.dumps(data), encoding="utf-8")
+        runs_dir.mkdir()
+        (runs_dir / "week-2026-W21-vote-summary.md").write_text(
+            "# Weekly vote summary: week-2026-W21\n\nbaseline_won: true\neligible_count: 0\n",
+            encoding="utf-8",
+        )
         subprocess.run(
-            [sys.executable, str(SCRIPT), "--public-results", str(source), "--out-dir", str(out_dir)],
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--public-results",
+                str(source),
+                "--runs-dir",
+                str(runs_dir),
+                "--out-dir",
+                str(out_dir),
+            ],
             check=True,
             cwd=ROOT,
         )
@@ -73,6 +88,7 @@ def test_history_builder() -> None:
 
     required = [
         "Prompt Vote Lab history",
+        "2026-W21",
         "2026-W20",
         "2026-W19",
         "Candidate state flow",
@@ -81,8 +97,11 @@ def test_history_builder() -> None:
         "finalizer close",
         "live rank output pages remain the source of truth",
         "Open weekly comparison",
+        "Open run record",
+        "../../runs/week-2026-W21-vote-summary.md",
         "../comparisons/2026-W20/",
         "../comparisons/2026-W19/",
+        "<dt>Adopted</dt><dd>no change</dd>",
         "<dt>Adopted</dt><dd>rank 1</dd>",
         "Generated from <code>data/public-results.json</code>",
         "connect-src 'none'",


### PR DESCRIPTION
## Summary

- Include baseline-only weeks from `runs/week-*-vote-summary.md` in generated history.
- Render run-record-only weeks as no-change history cards.
- Add regression coverage for a `2026-W21` baseline-only run record.
- Regenerate `lab/history/index.html` so W21 appears in the public history page.

## Why

`runs/week-2026-W21-vote-summary.md` was merged, but `lab/history/index.html` did not show W21 because the history generator only discovered weeks from `week:*` issue labels.

Baseline-only weeks are still public outcomes and should appear in history.

## CI scope note

Safety Check is intended for mutable root lab implementation files, not generated history pages with generator/test changes.

This PR narrows the Safety Check path trigger from `lab/**` to:

- `lab/index.html`
- `lab/style.css`
- `lab/app.js`

The safety script itself is unchanged.

## Checks

```text
python scripts/test_build_history_page.py
python scripts/test_repository_language_policy.py
python scripts/test_local_release_verification.py
python scripts/test_script_check_workflow_contract.py
```

## Protected evidence check

```text
Protected evidence check: PASS — existing run records were not rewritten.
Generated history update: PASS — `lab/history/index.html` was regenerated from the updated generator.
Canonical/legacy check: PASS — no runner behavior changed.
Lab implementation check: PASS — root lab implementation files were not changed.
Language policy check: PASS — maintainer-authored copy remains English-only.
Removal gate: N/A — no removal.
Rollback path: revert this generator/test/generated-history PR.
```

## Non-goals

* No weekly runner behavior change.
* No comparison page creation for baseline-only weeks.
* No `/lab/` implementation change.
* No workflow check logic change.
* No public-results schema change.
* No release tag.
* No auto-merge.