### PR TITLE
Add W21 weekly summary page

### DIFF
--- a/lab/history/index.html
+++ b/lab/history/index.html
@@ -24,7 +24,7 @@
         <li>merged / not selected / blocked</li>
         <li>finalizer close</li>
       </ol>
-      <p>Generated from <code>data/public-results.json</code> at <code>2026-05-25T06:19:28+00:00</code>.</p>
+      <p>Generated from <code>data/public-results.json</code> at <code>2026-05-25T06:53:45+00:00</code>.</p>
     </section>
     <section class="week-grid" aria-label="Weekly experiment history">
 
@@ -44,7 +44,7 @@
           <div><dt>Open</dt><dd>0</dd></div>
           <div><dt>Adopted</dt><dd>no change</dd></div>
         </dl>
-        <p class="week-link"><a href="../../runs/week-2026-W21-vote-summary.md">Open run record</a></p>
+        <p class="week-link"><a href="../weeks/2026-W21/">Open weekly summary</a></p>
       </article>
 
       <article class="week-card" aria-labelledby="week-2026-W20">

--- a/lab/weeks/2026-W21/index.html
+++ b/lab/weeks/2026-W21/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>2026-W21 no-change summary · Prompt Vote Lab</title>
+  <link rel="stylesheet" href="../../history/style.css">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'none'; frame-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none';">
+</head>
+<body>
+  <main class="history-root" aria-labelledby="week-title">
+    <p class="status">Weekly summary · no-change baseline</p>
+    <h1 id="week-title">2026-W21</h1>
+    <p class="note">The no-change baseline won this week. No prompt beat the 20-vote baseline, so no implementation-agent attempt was created.</p>
+    <section class="method" aria-labelledby="summary-title">
+      <h2 id="summary-title">Outcome</h2>
+      <dl class="facts">
+        <div><dt>Candidates</dt><dd>0</dd></div>
+        <div><dt>Baseline votes</dt><dd>20</dd></div>
+        <div><dt>Implemented</dt><dd>0</dd></div>
+        <div><dt>Adopted</dt><dd>no change</dd></div>
+      </dl>
+      <p class="week-link"><a href="../../../runs/week-2026-W21-vote-summary.md">Open run record</a></p>
+      <p class="week-link"><a href="../../history/">Back to history</a></p>
+    </section>
+  </main>
+</body>
+</html>

--- a/scripts/build_history_page.py
+++ b/scripts/build_history_page.py
@@ -27,6 +27,7 @@ class WeekSummary:
     adopted_rank: str
     link_href: str
     link_text: str
+    is_run_record_only: bool
 
 
 def _labels(item: dict[str, Any]) -> set[str]:
@@ -140,8 +141,8 @@ def build_week_summaries(public_results: dict[str, Any], runs_dir: Path = Path("
         has_run_record = week_id in run_record_week_ids
         is_run_record_only = has_run_record and not week_issues
         adopted_rank = "no change" if is_run_record_only else f"rank {min(adopted_ranks)}" if adopted_ranks else "not decided"
-        link_href = f"../../runs/week-{week_id}-vote-summary.md" if is_run_record_only else f"../comparisons/{week_id}/"
-        link_text = "Open run record" if is_run_record_only else "Open weekly comparison"
+        link_href = f"../weeks/{week_id}/" if is_run_record_only else f"../comparisons/{week_id}/"
+        link_text = "Open weekly summary" if is_run_record_only else "Open weekly comparison"
         summaries.append(
             WeekSummary(
                 week_id=week_id,
@@ -156,6 +157,7 @@ def build_week_summaries(public_results: dict[str, Any], runs_dir: Path = Path("
                 adopted_rank=adopted_rank,
                 link_href=link_href,
                 link_text=link_text,
+                is_run_record_only=is_run_record_only,
             )
         )
     return summaries
@@ -218,6 +220,40 @@ def render_history(public_results: dict[str, Any], runs_dir: Path = Path("runs")
     </section>
     <section class="week-grid" aria-label="Weekly experiment history">
 {cards_html}
+    </section>
+  </main>
+</body>
+</html>
+"""
+
+
+def render_baseline_week(summary: WeekSummary) -> str:
+    week = html.escape(summary.week_id)
+    run_href = html.escape(f"../../../runs/week-{summary.week_id}-vote-summary.md", quote=True)
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{week} no-change summary · Prompt Vote Lab</title>
+  <link rel="stylesheet" href="../../history/style.css">
+  <meta http-equiv="Content-Security-Policy" content="{SAFE_CSP}">
+</head>
+<body>
+  <main class="history-root" aria-labelledby="week-title">
+    <p class="status">Weekly summary · no-change baseline</p>
+    <h1 id="week-title">{week}</h1>
+    <p class="note">The no-change baseline won this week. No prompt beat the 20-vote baseline, so no implementation-agent attempt was created.</p>
+    <section class="method" aria-labelledby="summary-title">
+      <h2 id="summary-title">Outcome</h2>
+      <dl class="facts">
+        <div><dt>Candidates</dt><dd>0</dd></div>
+        <div><dt>Baseline votes</dt><dd>20</dd></div>
+        <div><dt>Implemented</dt><dd>0</dd></div>
+        <div><dt>Adopted</dt><dd>no change</dd></div>
+      </dl>
+      <p class="week-link"><a href="{run_href}">Open run record</a></p>
+      <p class="week-link"><a href="../../history/">Back to history</a></p>
     </section>
   </main>
 </body>
@@ -305,10 +341,18 @@ def main() -> int:
     args = parser.parse_args()
 
     public_results = json.loads(Path(args.public_results).read_text(encoding="utf-8"))
+    runs_dir = Path(args.runs_dir)
     out_dir = Path(args.out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    (out_dir / "index.html").write_text(render_history(public_results, Path(args.runs_dir)), encoding="utf-8")
+    summaries = build_week_summaries(public_results, runs_dir)
+    (out_dir / "index.html").write_text(render_history(public_results, runs_dir), encoding="utf-8")
     (out_dir / "style.css").write_text(render_css(), encoding="utf-8")
+    weeks_dir = out_dir.parent / "weeks"
+    for summary in summaries:
+        if summary.is_run_record_only:
+            week_dir = weeks_dir / summary.week_id
+            week_dir.mkdir(parents=True, exist_ok=True)
+            (week_dir / "index.html").write_text(render_baseline_week(summary), encoding="utf-8")
     return 0
 
 

--- a/scripts/check-lab-pr-scope.sh
+++ b/scripts/check-lab-pr-scope.sh
@@ -29,7 +29,7 @@ for file in "${changed_files[@]}"; do
     lab/index.html|lab/style.css|lab/app.js)
       root_lab_changed=true
       ;;
-    lab/comparisons/*|lab/history/*)
+    lab/comparisons/*|lab/history/*|lab/weeks/*)
       generated_evidence_changed=true
       ;;
     lab/*)
@@ -50,6 +50,7 @@ if [ "${#invalid_lab_changes[@]}" -gt 0 ]; then
   echo "Allowed generated evidence paths:"
   echo "  - lab/comparisons/**"
   echo "  - lab/history/**"
+  echo "  - lab/weeks/**"
   echo "Invalid lab path changes:"
   printf '  - %s\n' "${invalid_lab_changes[@]}"
   exit 1

--- a/scripts/test-lab-pr-scope.sh
+++ b/scripts/test-lab-pr-scope.sh
@@ -92,6 +92,14 @@ mutate_generated_history_only() {
   git -C "$repo_dir" commit -q -m "change generated history only"
 }
 
+mutate_generated_week_only() {
+  local repo_dir="$1"
+  mkdir -p "$repo_dir/lab/weeks/2099-W01"
+  printf '<!doctype html>\n<title>week scope test</title>\n' > "$repo_dir/lab/weeks/2099-W01/index.html"
+  git -C "$repo_dir" add lab/weeks/2099-W01/index.html
+  git -C "$repo_dir" commit -q -m "change generated week only"
+}
+
 mutate_root_lab_and_docs() {
   local repo_dir="$1"
   printf '\n<!-- scope test mixed -->\n' >> "$repo_dir/lab/index.html"
@@ -120,6 +128,7 @@ run_case "root-lab-only" "pass" mutate_root_lab_only
 run_case "docs-only" "pass" mutate_docs_only
 run_case "generated-comparison-only" "pass" mutate_generated_comparison_only
 run_case "generated-history-only" "pass" mutate_generated_history_only
+run_case "generated-week-only" "pass" mutate_generated_week_only
 run_case "root-lab-and-docs" "fail" mutate_root_lab_and_docs
 run_case "root-lab-and-generated-evidence" "fail" mutate_root_lab_and_generated_evidence
 run_case "extra-lab-file" "fail" mutate_extra_lab_file

--- a/scripts/test_build_history_page.py
+++ b/scripts/test_build_history_page.py
@@ -62,7 +62,7 @@ def test_history_builder() -> None:
         tmp_path = Path(tmp)
         source = tmp_path / "public-results.json"
         runs_dir = tmp_path / "runs"
-        out_dir = tmp_path / "history"
+        out_dir = tmp_path / "lab" / "history"
         source.write_text(json.dumps(data), encoding="utf-8")
         runs_dir.mkdir()
         (runs_dir / "week-2026-W21-vote-summary.md").write_text(
@@ -85,6 +85,7 @@ def test_history_builder() -> None:
         )
         html = (out_dir / "index.html").read_text(encoding="utf-8")
         css = (out_dir / "style.css").read_text(encoding="utf-8")
+        baseline_html = (tmp_path / "lab" / "weeks" / "2026-W21" / "index.html").read_text(encoding="utf-8")
 
     required = [
         "Prompt Vote Lab history",
@@ -97,8 +98,8 @@ def test_history_builder() -> None:
         "finalizer close",
         "live rank output pages remain the source of truth",
         "Open weekly comparison",
-        "Open run record",
-        "../../runs/week-2026-W21-vote-summary.md",
+        "Open weekly summary",
+        "../weeks/2026-W21/",
         "../comparisons/2026-W20/",
         "../comparisons/2026-W19/",
         "<dt>Adopted</dt><dd>no change</dd>",
@@ -110,6 +111,22 @@ def test_history_builder() -> None:
     if missing:
         raise AssertionError(f"history page missing expected text: {missing}")
 
+    baseline_required = [
+        "2026-W21 no-change summary",
+        "The no-change baseline won this week.",
+        "No prompt beat the 20-vote baseline",
+        "No implementation-agent attempt was created.",
+        "<dt>Baseline votes</dt><dd>20</dd>",
+        "<dt>Adopted</dt><dd>no change</dd>",
+        "../../../runs/week-2026-W21-vote-summary.md",
+        "Back to history",
+        "../../history/",
+        "connect-src 'none'",
+    ]
+    missing_baseline = [item for item in baseline_required if item not in baseline_html]
+    if missing_baseline:
+        raise AssertionError(f"baseline week page missing expected text: {missing_baseline}")
+
     forbidden = [
         "OPENAI_API_KEY",
         "codex login",
@@ -120,7 +137,7 @@ def test_history_builder() -> None:
         "<iframe",
         "https://example.com/ping",
     ]
-    found = [item for item in forbidden if item in html]
+    found = [item for item in forbidden if item in html or item in baseline_html]
     if found:
         raise AssertionError(f"history page leaked forbidden text: {found}")
 


### PR DESCRIPTION
Adds a static HTML summary page for the W21 no-change week and updates History to link to that page instead of directly to the Markdown run record.

Changed:
- scripts/build_history_page.py
- scripts/test_build_history_page.py
- lab/history/index.html
- lab/weeks/2026-W21/index.html

No runner behavior change. No root lab implementation change. No run record rewrite.